### PR TITLE
update jdbc version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.0.0</version>
+            <version>3.6.6</version>
         </dependency>
 
 


### PR DESCRIPTION
When writing kafka connector, it need the latest jdbc driver to build connection using key pair.