### PR TITLE
Move gpg.keyname to settings.xml because of maven 3.5 cli parse bug

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,9 +5,6 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 if [ -z "$GPG_KEY_ID" ]; then
   echo "[ERROR] Key Id not specified!"
   exit 1
-else
-# name can include spaces
-  MVN_GPG_OPTIONS+=("\"-Dgpg.keyname=$GPG_KEY_ID\"")
 fi
 
 if [ -z "$GPG_KEY_PASSPHRASE" ]; then
@@ -43,6 +40,16 @@ cat > $OSSRH_DEPLOY_SETTINGS_XML << SETTINGS.XML
       <password>$SONATYPE_PWD</password>
     </server>
   </servers>
+  <profiles>
+    <profile>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <gpg.keyname>$GPG_KEY_ID</gpg.keyname>
+      </properties>
+    </profile>
+  <profiles>
 </settings>
 SETTINGS.XML
 


### PR DESCRIPTION
This is an attempt to fix an issue identified when attempting to update Maven. It looks like Maven 3.5 may have an issue parsing complex command line options, see https://issues.apache.org/jira/browse/MNG-6385. gpg.keyname appears to be the only option that requires extra quoting so I've moved that into the settings.xml file.