### PR TITLE
fix travis build issue and upgrade jackson-databind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: java
 matrix:
   include:
     - jdk: oraclejdk8
- 
+
+dist: trusty
+
 env:
   - JACOCO_COVERAGE=true
 

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9</version>
+            <version>2.9.9.2</version>
         </dependency>
 
 


### PR DESCRIPTION
- Fix travis build issue (oracle jdk 8)
- upgrade jackson-databind to 2.9.9.2 for security improvement