### PR TITLE
Do not log JWT

### DIFF
--- a/src/main/java/net/snowflake/ingest/connection/SecurityManager.java
+++ b/src/main/java/net/snowflake/ingest/connection/SecurityManager.java
@@ -171,7 +171,7 @@ final class SecurityManager
     }
 
     //atomically update the string
-    LOGGER.info("Created new JWT  - {}", newToken);
+    LOGGER.info("Created new JWT");
     token.set(newToken);
   }
 


### PR DESCRIPTION
Logging JWTs is considered a security risk and common practice is to protect tokens like any other credential. 