### PR TITLE
Implementing auto-closeable for SimpleIngestManager and SecurityManager

### DIFF
--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
  *
  * @author obabarinsa
  */
-public class SimpleIngestManager
+public class SimpleIngestManager implements AutoCloseable
 {
 
   /**
@@ -591,4 +591,15 @@ public class SimpleIngestManager
     return ServiceResponseHandler.unmarshallHistoryRangeResponse(response);
   }
 
+  /**
+   * Closes the resources associated with this object. Resources cannot be
+   * reopened, initialize new instance of this class
+   * {@link SimpleIngestManager} to reopen and start ingesting/monitoring new
+   * data.
+   */
+  @Override
+  public void close()
+  {
+    builder.closeResources();
+  }
 }

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -535,4 +535,16 @@ public final class RequestBuilder
 
     return get;
   }
+
+  /**
+   * Closes the resources being used by RequestBuilder object.
+   * {@link SecurityManager} is one such resource which uses a threadpool
+   * which needs to be shutdown once SimpleIngestManager is done interacting
+   * with Snowpipe Service (Rest APIs)
+   * @throws Exception
+   */
+  public void closeResources()
+  {
+    securityManager.close();
+  }
 }

--- a/src/main/java/net/snowflake/ingest/connection/SecurityManager.java
+++ b/src/main/java/net/snowflake/ingest/connection/SecurityManager.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author obabarinsa
  * @since 1.8
  */
-final class SecurityManager
+final class SecurityManager implements AutoCloseable
 {
   //the logger for SecurityManager
   private static final Logger LOGGER =
@@ -220,4 +220,12 @@ final class SecurityManager
     return publicKeyFingerPrint;
   }
 
+  /**
+   * Currently, it only shuts down the instance of ExecutorService.
+   */
+  @Override
+  public void close()
+  {
+    keyRenewer.shutdown();
+  }
 }


### PR DESCRIPTION
SNOW-163783

- ScheduledThreadExecutor is not shutdown, causing more threads to being spun up when kafka connector is restarted for rebalancing. 
- Consumers can use try-with-resources or can explicitly call `close()` method during shutdown. 
- Fixes #20 