### PR TITLE
Bump up version to 0.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- Arifact name and version information -->
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-ingest-sdk</artifactId>
-    <version>0.9.8</version>
+    <version>0.9.9</version>
     <packaging>jar</packaging>
     <name>Snowflake Ingest SDK</name>
     <description>Snowflake Ingest SDK</description>


### PR DESCRIPTION
Bumping up version for ingest-java sdk to solve thread leak issue inside Kafka Connector

- Introducing `close()` API for `SimpleIngestManager` which can be used as is or object can be instantiated inside a try-with-resource block since it implements `AutoCloseable`