### PR TITLE
Add retry logic for NoHTTPResponseException and improve logging

### DIFF
--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -481,7 +481,7 @@ public class SimpleIngestManager implements AutoCloseable
     UUID request = requestId == null ? UUID.randomUUID() : requestId;
 
     //We're about to send this request number
-    LOGGER.info("Sending Request UUID - ", request.toString());
+    LOGGER.info("Sending Request UUID - {}", request.toString());
 
     //send the request and get a response....
     HttpResponse response = httpClient.execute(

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -118,16 +118,17 @@ public class HttpUtil
         int statusCode = response.getStatusLine().getStatusCode();
         LOGGER.info("In retryRequest for service unavailability with statusCode:{} and uri:{}",
                     statusCode, getRequestUriFromContext(context));
-        boolean needNextRetry = (statusCode == REQUEST_TIMEOUT || statusCode >= 500)
-                && executionCount < MAX_RETRIES + 1;
         if (executionCount == MAX_RETRIES + 1)
         {
-          LOGGER.info("Reach the max retry time.");
+          LOGGER.info("Reached the max retry time, not retrying anymore");
+          return false;
         }
-        if (needNextRetry && executionCount < MAX_RETRIES + 1)
+        boolean needNextRetry = (statusCode == REQUEST_TIMEOUT || statusCode >= 500)
+                && executionCount < MAX_RETRIES + 1;
+        if (needNextRetry)
         {
           long interval = (1 << executionCount) * 1000;
-          LOGGER.info("Sleep time in millisecond: {}", interval);
+          LOGGER.info("Sleep time in millisecond: {}, retryCount: {}", interval, executionCount);
         }
         return needNextRetry;
       }


### PR DESCRIPTION
SNOW-195017

This PR:
- Improves logging, where requestId was not getting printed. 
- Add retry logic for `NoHttpResponseException`. 
- Decouples the retry logic and serviceUnavailableRetry logic from the client creation. 
