### PR TITLE
Bump up jackson core and databind libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,14 +210,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.9</version>
+            <version>2.11.0</version>
         </dependency>
 
         <!-- Jackson Databind api -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0.pr1</version>
+            <version>2.11.0</version>
         </dependency>
 
 


### PR DESCRIPTION
SNOW-202934

Getting ClassNotFoundException: net.snowflake.ingest.internal.fasterxml.jackson.core.exc.InputCoercionException
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:355)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	... 17 more

There was an automatic bump up by dependabot. https://github.com/FasterXML/jackson-databind/issues/2511

We need to release this version as well. Will follow up after this change. 

Test: https://travis-ci.org/github/snowflakedb/snowflake-ingest-java/builds/733753169