### PR TITLE
Disable SL4j shading to enable custom properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,10 +315,6 @@
                                     <pattern>org.apache</pattern>
                                     <shadedPattern>${shadeBase}.apache</shadedPattern>
                                 </relocation>
-                                <relocation>
-                                    <pattern>org.slf4j</pattern>
-                                    <shadedPattern>${shadeBase}.slf4j</shadedPattern>
-                                </relocation>
                             </relocations>
                             <filters>
                                 <filter>


### PR DESCRIPTION
This will not bring the slf4j package into internal package. Shading is not needed for slf4j, it stops clients using the SDK not use their default/custom properties. 
https://maven.apache.org/plugins/maven-shade-plugin/

Test:
Generate a jar and use it on my own sample app. 

`log4j.logger.net.snowflake.ingest.connection=ERROR, <Any Appender>
log4j.additivity.net.snowflake.ingest.connection=false`