### PR TITLE
Fix mvn install by fixing shaded jar script check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- Arifact name and version information -->
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-ingest-sdk</artifactId>
-    <version>0.9.11</version>
+    <version>0.9.12</version>
     <packaging>jar</packaging>
     <name>Snowflake Ingest SDK</name>
     <description>Snowflake Ingest SDK</description>

--- a/scripts/check_content.sh
+++ b/scripts/check_content.sh
@@ -5,8 +5,7 @@
 set -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-
-if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v mime.types | grep -v project.properties | grep -v -E "javax"; then
+if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v mime.types | grep -v project.properties | grep -v -E "javax" | grep -v -E "^org/"; then
   echo "[ERROR] Ingest SDK jar includes class not under the snowflake namespace"
   exit 1
 fi


### PR DESCRIPTION
remove org/slf4j/ directory because slf4j was removed from previous script.  

Fixed build travis CI: https://travis-ci.org/github/snowflakedb/snowflake-ingest-java/builds/742042037

-- Also bumping up the version. 