### PR TITLE
Add http proxy username and password support in httpclient for Kafka Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,12 @@
             <version>2.3.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>29.0-jre</version>
+        </dependency>
+
 
         <!-- JUnit so that we can make some basic unit tests -->
         <dependency>


### PR DESCRIPTION
SNOW-260640

Background
- Kafka connector added configuration which allows to setup proxy host. 
- This proxy host can have authentication based on username and password. 
- The proxy host is able to call snowpipe api when there are not user/pwd, but fails to do it if proxy enforces one. 

This change allows snowpipe KC to call snowpipe API from KC cluster with proxy on. 

This is a naive implementation of proxy user/password at the moment since KC implements it at JVM level instead of KC level. 
Because this version is already released in KC, we would tackle this naive implementation first and then set proxy parameter which are unique per kafka connector. 

Future update:
- Instead of fetching it from JVM env, we would like to take it in a request. (SimpleIngestManager ctor)