### PR TITLE
Bump up minor version for ingest sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- Arifact name and version information -->
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-ingest-sdk</artifactId>
-    <version>0.9.12</version>
+    <version>0.10.0</version>
     <packaging>jar</packaging>
     <name>Snowflake Ingest SDK</name>
     <description>Snowflake Ingest SDK</description>

--- a/scripts/check_content.sh
+++ b/scripts/check_content.sh
@@ -5,7 +5,7 @@
 set -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v mime.types | grep -v project.properties | grep -v -E "javax" | grep -v -E "^org/"; then
+if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v mime.types | grep -v project.properties | grep -v -E "javax" | grep -v -E "^org/" | grep -v -E "^com/google"; then
   echo "[ERROR] Ingest SDK jar includes class not under the snowflake namespace"
   exit 1
 fi


### PR DESCRIPTION
Based on: https://semver.org/spec/v2.0.0-rc.1.html
Previous [change](https://github.com/snowflakedb/snowflake-ingest-java/commit/c06b01374dc8f3044e602aa67a71a950e4efc237) does include minor changes in the way http clients are made and is backward compatible hence minor version bump

Release Notes:
- Support for pattern pipes. (Ingest response)
- HttpClient now supports rest proxy with username and password (Required for Kafka connector)


Release Urgency
- High - Blocks https://snowflakecomputing.atlassian.net/browse/SNOW-242554