### PR TITLE
Fix slf4j shading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- Arifact name and version information -->
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-ingest-sdk</artifactId>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
     <packaging>jar</packaging>
     <name>Snowflake Ingest SDK</name>
     <description>Snowflake Ingest SDK</description>
@@ -242,6 +242,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.21</version>
+            <scope>provided</scope>
         </dependency>
 
 
@@ -341,6 +342,12 @@
                                     <artifact>commons-logging:commons-logging</artifact>
                                     <excludes>
                                         <exclude>org/apache/commons/logging/impl/AvalonLogger.class</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.slf4j:slf4j-simple</artifact>
+                                    <excludes>
+                                        <exclude>org/slf4j/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
Another one of Shading issue. 
Although I removed shaded jar from relocated (internal) package, slf4j was still part of shaded jar. 
![Screen Shot 2021-01-20 at 8 33 29 PM](https://user-images.githubusercontent.com/57274584/105324099-cfc99180-5b7f-11eb-8d94-91050e8a8c5d.png)
![Screen Shot 2021-01-20 at 8 33 49 PM](https://user-images.githubusercontent.com/57274584/105324102-d0622800-5b7f-11eb-8f63-bd1641adb894.png)


This change, reduces scope of base slf4j to provided and removing implementation (slf4j-simple) from shaded plugin. 

This is what it looks like now:
![Screen Shot 2021-01-21 at 12 31 48 AM](https://user-images.githubusercontent.com/57274584/105324283-13bc9680-5b80-11eb-8a19-97738c1e0003.png)

## Root cause:
- KC was not able to use custom log4j properties which used to generate file before 0.9.12 (snowpipe sdk where we release unshaded slf4j jar)
- Priority:
- - Urgent


## Testing
- Tested local jar in KC and tests are passing. sf.log file is also getting created. 