### PR TITLE
Bump up Java ingest sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- Arifact name and version information -->
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-ingest-sdk</artifactId>
-    <version>0.10.1</version>
+    <version>0.10.2</version>
     <packaging>jar</packaging>
     <name>Snowflake Ingest SDK</name>
     <description>Snowflake Ingest SDK</description>


### PR DESCRIPTION
Release notes:
- Fixes issue where JWT token invalid was returned from Snowflake servers when accountNames had `.` in them. 
  - We will trim account name's suffix after `.`
- Made it functionally similar to python connector. 