### PR TITLE
Change slf4j-simple to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.21</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException -->


### PR DESCRIPTION
`slf4j-simple` should not be a runtime dependency. Log provider should be specified by the user of the library.