### PR TITLE
Update README to include instructions on running the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ mvn package
 However, for general usage, pulling a pre-built jar from maven is
 recommended.
 
+If you would like to run SnowflakeIngestBasicExample.java in the example folder, 
+you would need to remove the following scope limits in pom.xml
+
+<pre>
+&lt;!-- Remove test scope from snowflake-jdbc --&gt;
+&lt;dependency&gt;
+    &lt;groupId&gt;net.snowflake&lt;groupId&gt;
+    &lt;artifactId&gt;snowflake-jdbc&lt;/artifactId&gt;
+    <s>&lt;scope&gt;test&lt;/scope&gt;</s>
+&lt;/dependency&gt;
+</pre>
+
+<pre>
+&lt;!-- Remove provided scope from slf4j-api --&gt;
+&lt;dependency&gt;
+    &lt;groupId&gt;org.slf4j&lt;/groupId&gt;
+    &lt;artifactId&gt;slf4j-api&lt;/artifactId&gt;
+    <s>&lt;scope&gt;provided&lt;/scope&gt;</s>
+&lt;/dependency&gt;
+</pre>
+
 # Testing (SimpleIngestIT Test)
 
 -   Modify `TestUtils.java` file and replace *PROFILE_PATH* with `profile.json.example` for testing.


### PR DESCRIPTION
Run into this issue during my setup, so updating the README to make sure others know what to do if they need to run examples in the example folder

The change looks nasty, but the result looks good since I really want to have overline text but it doesn't work with ```
![image](https://user-images.githubusercontent.com/65984323/113066227-04a12880-916f-11eb-9648-cec170325ed2.png)

