### PR TITLE
SNOW-225155 add custom user agent in snowpipe requests

### DIFF
--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -4,7 +4,7 @@
 
 package net.snowflake.ingest;
 
-import static net.snowflake.ingest.connection.RequestBuilder.DEFAULT_HOST;
+import static net.snowflake.ingest.connection.RequestBuilder.DEFAULT_HOST_SUFFIX;
 
 import com.google.common.base.Strings;
 import java.io.IOException;
@@ -71,6 +71,8 @@ public class SimpleIngestManager implements AutoCloseable {
 
     // Hostname to connect to, default will be RequestBuilder#DEFAULT_HOST
     private String hostName;
+
+    private PrivateKey privateKey;
 
     /**
      * getAccount - returns the name of the account this builder will inject into the IngestManager
@@ -184,7 +186,8 @@ public class SimpleIngestManager implements AutoCloseable {
      */
     public SimpleIngestManager build() {
       if (Strings.isNullOrEmpty(hostName)) {
-        return new SimpleIngestManager(account, user, pipe, DEFAULT_HOST, keypair, userAgentSuffix);
+        return new SimpleIngestManager(
+            account, user, pipe, DEFAULT_HOST_SUFFIX, keypair, userAgentSuffix);
       }
       return new SimpleIngestManager(account, user, pipe, hostName, keypair, userAgentSuffix);
     }
@@ -305,12 +308,16 @@ public class SimpleIngestManager implements AutoCloseable {
    * Using this constructor for Builder pattern. KeyPair can be passed in now since we have
    * made @see {@link SimpleIngestManager#createKeyPairFromPrivateKey(PrivateKey)} public
    *
-   * @param account
-   * @param user
-   * @param pipe
-   * @param hostName
-   * @param keyPair
-   * @param userAgentSuffix
+   * @param account The account into which we're loading Note: account should not include region or
+   *     cloud provider info. e.g. if host is testaccount.us-east-1.azure .snowflakecomputing.com,
+   *     account should be testaccount. If this is the case, you should use the constructor that
+   *     accepts hostname as argument
+   * @param user the user performing this load
+   * @param pipe the fully qualified name of the pipe
+   * @param hostName the hostname
+   * @param keyPair keyPair associated with the private key used for authentication. See @see {@link
+   *     SimpleIngestManager#createKeyPairFromPrivateKey} to generate KP from p8Key
+   * @param userAgentSuffix user agent suffix we want to add.
    */
   public SimpleIngestManager(
       String account,

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -62,7 +62,7 @@ public final class RequestBuilder {
   /* Static constants Begin */
 
   // the default host is snowflakecomputing.com
-  public static final String DEFAULT_HOST = "snowflakecomputing.com";
+  public static final String DEFAULT_HOST_SUFFIX = "snowflakecomputing.com";
 
   // the default connection scheme is HTTPS
   private static final String DEFAULT_SCHEME = "https";
@@ -126,7 +126,7 @@ public final class RequestBuilder {
    * @param keyPair - the Public/Private key pair we'll use to authenticate
    */
   public RequestBuilder(String accountName, String userName, KeyPair keyPair) {
-    this(accountName, userName, keyPair, DEFAULT_SCHEME, DEFAULT_HOST, DEFAULT_PORT, null);
+    this(accountName, userName, keyPair, DEFAULT_SCHEME, DEFAULT_HOST_SUFFIX, DEFAULT_PORT, null);
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -140,8 +140,11 @@ public final class RequestBuilder {
 
   /**
    * Creates a string for user agent which should always be present in all requests to Snowflake
-   * (Snowpipe APIs) Here is the format we will use SnowpipeJavaSDK/version (platform details)
-   * JAVA/<java-version>
+   * (Snowpipe APIs)
+   *
+   * <p>Here is the format we will use:
+   *
+   * <p>SnowpipeJavaSDK/version (platform details) JAVA/<java-version>
    *
    * @return the default agent string
    */
@@ -169,7 +172,7 @@ public final class RequestBuilder {
   }
 
   private static String buildCustomUserAgent(String additionalUserAgentInfo) {
-    return getDefaultUserAgent().trim() + " " + additionalUserAgentInfo;
+    return USER_AGENT.trim() + " " + additionalUserAgentInfo;
   }
   /**
    * A simple POJO for generating our POST body to the insert endpoint

--- a/src/test/java/net/snowflake/ingest/TestUtils.java
+++ b/src/test/java/net/snowflake/ingest/TestUtils.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyFactory;
+import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.sql.Connection;
@@ -26,6 +27,8 @@ public class TestUtils {
   private static String user = "";
 
   private static PrivateKey privateKey = null;
+
+  private static KeyPair keyPair = null;
 
   private static String account = "";
 
@@ -75,6 +78,7 @@ public class TestUtils {
 
     PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
     privateKey = kf.generatePrivate(keySpec);
+    keyPair = SimpleIngestManager.createKeyPairFromPrivateKey(privateKey);
   }
 
   /**
@@ -134,5 +138,44 @@ public class TestUtils {
     if (profile == null) init();
     return new SimpleIngestManager(
         account, user, database + "." + schema + "." + pipe, privateKey, scheme, host, port);
+  }
+
+  /**
+   * Use this constructor to test the new userAgentSuffix code path
+   *
+   * @param pipe pipe name
+   * @param userAgentSuffix suffix we want to add in all request header of user-agent to the
+   *     snowpipe API.
+   * @return ingest manager object
+   * @throws Exception
+   */
+  public static SimpleIngestManager getManager(String pipe, final String userAgentSuffix)
+      throws Exception {
+    if (profile == null) init();
+    return new SimpleIngestManager(
+        account,
+        user,
+        database + "." + schema + "." + pipe,
+        privateKey,
+        scheme,
+        host,
+        port,
+        userAgentSuffix);
+  }
+
+  /**
+   * Test for using builder pattern of SimpleIngestManager. In most of the cases we will not require
+   * to pass in scheme and port since they are supposed to be kept https and 443 respectively
+   */
+  public static SimpleIngestManager getManagerUsingBuilderPattern(
+      String pipe, final String userAgentSuffix) throws Exception {
+    if (profile == null) init();
+    return new SimpleIngestManager.Builder()
+        .setAccount(account)
+        .setUser(user)
+        .setPipe(database + "." + schema + "." + pipe)
+        .setKeypair(keyPair)
+        .setUserAgentSuffix(userAgentSuffix)
+        .build();
   }
 }


### PR DESCRIPTION
**Background:** 
- This is required for Kafka connector. 
- KC will use additionInformation which is passed in by the configuration parameter, we will use this information to differentiate whether a KC is self hosted, confluent hosted or potentially by AWS as MSK. 

**More Info:**
- Modify existing user agent string since that is not matching with current standards.
- We cannot have validation on SDK side since there is no validation for snowpipe dispatcher as of yet (Server side)
- Added test
- Technically you would require the user agent information from only single Snowpipe API (ideally `insertFiles`) since the subsequent calls should all happen from same environment, it can be debatable to just add this into `/insertFiles` endpoint but there is no harm in adding to all requests to be consistent. 