### PR TITLE
SNOW-241535 SNOW-336964 Remove vulnerable dependency/bump up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>7.9</version>
+            <version>9.9.3</version>
          </dependency>
 
 
@@ -233,6 +233,18 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
+            <exclusions>
+                <exclusion>  <!-- declare the exclusion here -->
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
         </dependency>
 
 


### PR DESCRIPTION
https://snowflakecomputing.atlassian.net/browse/SNOW-241535
https://snowflakecomputing.atlassian.net/browse/SNOW-336964

nimbus-jose-jwt -> json-smart
Removed codecs from http client since they havent bumped up yet and added an explicit version for that. 

`mvn dependency:tree`