### PR TITLE
New version of ingest java sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- Arifact name and version information -->
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-ingest-sdk</artifactId>
-    <version>0.10.2</version>
+    <version>0.10.3</version>
     <packaging>jar</packaging>
     <name>Snowflake Ingest SDK</name>
     <description>Snowflake Ingest SDK</description>

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -112,7 +112,7 @@ public final class RequestBuilder {
   // Don't change!
   public static final String CLIENT_NAME = "SnowpipeJavaSDK";
 
-  public static final String DEFAULT_VERSION = "0.10.2";
+  public static final String DEFAULT_VERSION = "0.10.3";
 
   public static final String JAVA_USER_AGENT = "JAVA";
 


### PR DESCRIPTION
- Supporting suffix in user agent for snowpipe APIs. (Will be utilized by Snowflake Kafka connector)
  - Can use new SimpleIngestManager constructor. 
- Using new version of nimbus-jose-jwt since older version was vulnerable for security.  