### PR TITLE
Rename file after we used gh actions to pass deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -87,5 +87,5 @@ mvn ${MVN_OPTIONS[@]} \
 rm $OSSRH_DEPLOY_SETTINGS_XML
 
 #white source
-chmod 755 ./scripts/run_whitesource.sh
-scripts/run_whitesource.sh
+chmod 755 ./scripts/run_whitesource_gh.sh
+scripts/run_whitesource_gh.sh


### PR DESCRIPTION
- Jenkins job for releasing this SDK was failing in last step for whitesource check. (It can still release but says file not found since I changed the file name few months back)