### PR TITLE
Shade Guava and exclude guava compile-only dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- Arifact name and version information -->
+    <!-- Artifact name and version information -->
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-ingest-sdk</artifactId>
     <version>0.10.3</version>
@@ -341,6 +341,10 @@
                                 <relocation>
                                     <pattern>org.apache</pattern>
                                     <shadedPattern>${shadeBase}.apache</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern> com.google.guava</pattern>
+                                    <shadedPattern>${shadeBase}.google.guava</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>

--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,24 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>29.0-jre</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
 
@@ -343,7 +361,7 @@
                                     <shadedPattern>${shadeBase}.apache</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern> com.google.guava</pattern>
+                                    <pattern>com.google.guava</pattern>
                                     <shadedPattern>${shadeBase}.google.guava</shadedPattern>
                                 </relocation>
                             </relocations>


### PR DESCRIPTION
Guava was left unshaded, which was causing dependency conflicts for downstream projects that include a different version of Guava.