### PR TITLE
PRODSEC-1059 integrate whitesource for github

### DIFF
--- a/.github/workflows/whitesource-issue.yml
+++ b/.github/workflows/whitesource-issue.yml
@@ -1,0 +1,26 @@
+
+name: whitesource-issue
+
+on:
+  issues:
+    types: [opened, reopened]
+
+concurrency: whitesource-issue
+
+jobs:
+  whitesource:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.user.login == 'whitesource-for-github-com[bot]' }}
+    steps:
+    - name: checkout action
+      uses: actions/checkout@v2
+      with:
+        repository: snowflakedb/whitesource-actions
+        token: ${{ secrets.WHITESOURCE_ACTION_TOKEN }}
+        path: whitesource-actions
+
+    - name: Jira Creation
+      uses: ./whitesource-actions/whitesource-issue
+      with:
+        jira_token: ${{ secrets.JIRA_TOKEN }}
+        gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/whitesource.yml
+++ b/.github/workflows/whitesource.yml
@@ -1,0 +1,29 @@
+name: whitesource
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  whitesource:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'whitesource-for-github-com[bot]' }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        fetch-depth: 0
+
+    - name: checkout action
+      uses: actions/checkout@v2
+      with:
+        repository: snowflakedb/whitesource-actions
+        token: ${{ secrets.WHITESOURCE_ACTION_TOKEN }}
+        path: whitesource-actions
+
+    - name: PR
+      uses: ./whitesource-actions/whitesource-pr
+      with:
+        jira_token: ${{ secrets.JIRA_TOKEN }}
+        gh_token: ${{ secrets.GITHUB_TOKEN }}
+        amend: false # true if you want the commit to be amended with the JIRA number

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,19 @@
+{
+  "scanSettings": {
+    "configMode": "AUTO",
+    "configExternalURL": "",
+    "projectToken": "",
+    "baseBranches": []
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure",
+    "displayMode": "diff"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW"
+  },
+  "remediateSettings": {
+    "enableRenovate": false,
+    "commitMessagePrefix": "SNOW-470176"
+  }
+}


### PR DESCRIPTION
The purpose of the PR is to enable whitesource for github integration to enable new features like alerts in `issues` tab, PR check, auto-fix PR for security vulnerabilities.