### PR TITLE
SNOW-488437 Add connection timeout

### DIFF
--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -7,6 +7,7 @@ package net.snowflake.ingest.utils;
 import static net.snowflake.ingest.utils.StringsUtils.isNullOrEmpty;
 
 import java.security.Security;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -43,7 +44,8 @@ public class HttpUtil {
 
   private static final String PROXY_SCHEME = "http";
   private static final int MAX_RETRIES = 3;
-  private static final int TIMEOUT = 300; // 5 minutes
+  static final int DEFAULT_CONNECTION_TIMEOUT = 1; // minute
+  static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 5; // minutes
   private static HttpClient httpClient;
 
   public static HttpClient getHttpClient() {
@@ -71,9 +73,9 @@ public class HttpUtil {
     // Set socketTimeout which is the max time gap between two consecutive data packets
     RequestConfig requestConfig =
         RequestConfig.custom()
-            .setConnectTimeout(TIMEOUT * 1000)
-            .setConnectionRequestTimeout(TIMEOUT * 1000)
-            .setSocketTimeout(TIMEOUT * 1000)
+            .setConnectTimeout((int)TimeUnit.MILLISECONDS.convert(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MINUTES))
+            .setConnectionRequestTimeout((int)TimeUnit.MILLISECONDS.convert(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MINUTES))
+            .setSocketTimeout((int)TimeUnit.MILLISECONDS.convert(DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT, TimeUnit.MINUTES))
             .build();
     /**
      * Use a anonymous class to implement the interface ServiceUnavailableRetryStrategy() The max

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -73,9 +73,14 @@ public class HttpUtil {
     // Set socketTimeout which is the max time gap between two consecutive data packets
     RequestConfig requestConfig =
         RequestConfig.custom()
-            .setConnectTimeout((int)TimeUnit.MILLISECONDS.convert(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MINUTES))
-            .setConnectionRequestTimeout((int)TimeUnit.MILLISECONDS.convert(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MINUTES))
-            .setSocketTimeout((int)TimeUnit.MILLISECONDS.convert(DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT, TimeUnit.MINUTES))
+            .setConnectTimeout(
+                (int) TimeUnit.MILLISECONDS.convert(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MINUTES))
+            .setConnectionRequestTimeout(
+                (int) TimeUnit.MILLISECONDS.convert(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MINUTES))
+            .setSocketTimeout(
+                (int)
+                    TimeUnit.MILLISECONDS.convert(
+                        DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT, TimeUnit.MINUTES))
             .build();
     /**
      * Use a anonymous class to implement the interface ServiceUnavailableRetryStrategy() The max

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -73,7 +73,7 @@ public class HttpUtil {
         RequestConfig.custom()
             .setConnectTimeout(TIMEOUT * 1000)
             .setConnectionRequestTimeout(TIMEOUT * 1000)
-            .setSocketTimeout(TIMEOUT)
+            .setSocketTimeout(TIMEOUT * 1000)
             .build();
     /**
      * Use a anonymous class to implement the interface ServiceUnavailableRetryStrategy() The max


### PR DESCRIPTION
Resolves issues related to this [ticket](https://snowflakecomputing.atlassian.net/browse/SNOW-488437). 
Currently, the Java SDK does not timeout on HTTP connections, I added timeout in the RequestConfig. 