### PR TITLE
Use HTTPS for maven URLs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <licenses>
       <license>
         <name>The Apache Software License, Version 2.0</name>
-        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       </license>
     </licenses>
 
@@ -32,7 +32,7 @@
 
     <scm>
       <connection>scm:git:git://github.com/snowflakedb/snowflake-ingest-java</connection>
-      <url>http://github.com/snowflakedb/snowflake-ingest-java/tree/master</url>
+      <url>https://github.com/snowflakedb/snowflake-ingest-java/tree/master</url>
     </scm>
 
     <!-- Set our Language Level to Java 8 -->


### PR DESCRIPTION
The current configuration is causing our build system which relies on this field
to try and clone the repository over HTTP.  In order to meet internal compliance
commitments would you be willing to merge this update?

Thanks!

~~ Matt