### PR TITLE
SNOW-533760: include client name and key during upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.11</version>
+            <version>3.13.14</version>
         </dependency>
 
         <!-- String collation-->

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -162,7 +162,11 @@ class FlushService {
     try {
       this.targetStage =
           new StreamingIngestStage(
-              isTestMode, client.getRole(), client.getHttpClient(), client.getRequestBuilder());
+              isTestMode,
+              client.getRole(),
+              client.getHttpClient(),
+              client.getRequestBuilder(),
+              client.getName());
     } catch (SnowflakeSQLException | IOException err) {
       throw new SFException(err, ErrorCode.UNABLE_TO_CONNECT_TO_STAGE);
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestStage.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestStage.java
@@ -77,13 +77,19 @@ class StreamingIngestStage {
   private final HttpClient httpClient;
   private final RequestBuilder requestBuilder;
   private final String role;
+  private final String clientName;
 
   StreamingIngestStage(
-      boolean isTestMode, String role, HttpClient httpClient, RequestBuilder requestBuilder)
+      boolean isTestMode,
+      String role,
+      HttpClient httpClient,
+      RequestBuilder requestBuilder,
+      String clientName)
       throws SnowflakeSQLException, IOException {
     this.httpClient = httpClient;
     this.role = role;
     this.requestBuilder = requestBuilder;
+    this.clientName = clientName;
 
     if (!isTestMode) {
       refreshSnowflakeMetadata();
@@ -95,8 +101,9 @@ class StreamingIngestStage {
    *
    * @param isTestMode must be true
    * @param role Snowflake role used by the Client
-   * @param httpClient
-   * @param requestBuilder
+   * @param httpClient http client reference
+   * @param requestBuilder request builder to build the HTTP request
+   * @param clientName the client name
    * @param testMetadata SnowflakeFileTransferMetadataWithAge to test with
    */
   StreamingIngestStage(
@@ -104,6 +111,7 @@ class StreamingIngestStage {
       String role,
       HttpClient httpClient,
       RequestBuilder requestBuilder,
+      String clientName,
       SnowflakeFileTransferMetadataWithAge testMetadata) {
     if (!isTestMode) {
       throw new SFException(ErrorCode.INTERNAL_ERROR);
@@ -111,6 +119,7 @@ class StreamingIngestStage {
     this.httpClient = httpClient;
     this.role = role;
     this.requestBuilder = requestBuilder;
+    this.clientName = clientName;
     this.fileTransferMetadataWithAge = testMetadata;
   }
 
@@ -160,6 +169,8 @@ class StreamingIngestStage {
               .setUploadStream(inStream)
               .setRequireCompress(false)
               .setOcspMode(OCSPMode.FAIL_OPEN)
+              .setStreamingIngestClientKey(this.clientPrefix)
+              .setStreamingIngestClientName(this.clientName)
               .build());
     } catch (NullPointerException npe) {
       // TODO SNOW-350701 Update JDBC driver to throw a reliable token expired error

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
@@ -84,6 +84,7 @@ public class StreamingIngestStageTest {
             "role",
             null,
             null,
+            "clientName",
             new StreamingIngestStage.SnowflakeFileTransferMetadataWithAge(
                 originalMetadata, Optional.of(System.currentTimeMillis())));
     PowerMockito.mockStatic(SnowflakeFileTransferAgent.class);
@@ -125,6 +126,7 @@ public class StreamingIngestStageTest {
                 "role",
                 null,
                 null,
+                "clientName",
                 new StreamingIngestStage.SnowflakeFileTransferMetadataWithAge(
                     fullFilePath, Optional.of(System.currentTimeMillis()))));
     Mockito.doReturn(true).when(stage).isLocalFS();
@@ -151,6 +153,7 @@ public class StreamingIngestStageTest {
             "role",
             null,
             null,
+            "clientName",
             new StreamingIngestStage.SnowflakeFileTransferMetadataWithAge(
                 originalMetadata, Optional.of(System.currentTimeMillis())));
     PowerMockito.mockStatic(SnowflakeFileTransferAgent.class);
@@ -203,7 +206,8 @@ public class StreamingIngestStageTest {
     Mockito.when(mockResponse.getEntity()).thenReturn(entity);
     Mockito.when(mockClient.execute(Mockito.any())).thenReturn(mockResponse);
 
-    StreamingIngestStage stage = new StreamingIngestStage(true, "role", mockClient, mockBuilder);
+    StreamingIngestStage stage =
+        new StreamingIngestStage(true, "role", mockClient, mockBuilder, "clientName");
 
     StreamingIngestStage.SnowflakeFileTransferMetadataWithAge metadataWithAge =
         stage.refreshSnowflakeMetadata(true);
@@ -251,6 +255,7 @@ public class StreamingIngestStageTest {
             "role",
             mockClient,
             mockBuilder,
+            "clientName",
             new StreamingIngestStage.SnowflakeFileTransferMetadataWithAge(
                 originalMetadata, Optional.of(0L)));
 


### PR DESCRIPTION
include client name and key during file upload, which will be used for streaming ingest billing