### PR TITLE
NO-SNOW: simplify SnowflakeStreamingIngestClient interface 

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestClient.java
+++ b/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestClient.java
@@ -26,4 +26,7 @@ public interface SnowflakeStreamingIngestClient extends AutoCloseable {
    * @return the client name
    */
   String getName();
+
+  /** @return a boolean to indicate whether the client is closed */
+  boolean isClosed();
 }

--- a/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestClient.java
+++ b/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestClient.java
@@ -4,15 +4,13 @@
 
 package net.snowflake.ingest.streaming;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
  * A class that is the starting point for using the Streaming Ingest client APIs, a single client
  * maps to exactly one account in Snowflake; however, multiple clients can point to the same
  * account. Each client will contain information for Snowflake authentication and authorization, and
  * it will be used to create one or more {@link SnowflakeStreamingIngestChannel}
  */
-public interface SnowflakeStreamingIngestClient {
+public interface SnowflakeStreamingIngestClient extends AutoCloseable {
 
   /**
    * Open a channel against a Snowflake table using a {@link OpenChannelRequest}
@@ -23,20 +21,9 @@ public interface SnowflakeStreamingIngestClient {
   SnowflakeStreamingIngestChannel openChannel(OpenChannelRequest request);
 
   /**
-   * Close all the channels in the client, which will make sure all the data in all channels is
-   * committed before closing
-   *
-   * @return a completable future which will be completed when all the channels are closed
-   */
-  CompletableFuture<Void> close();
-
-  /**
    * Get the client name
    *
    * @return the client name
    */
   String getName();
-
-  /** @return a boolean to indicate whether the client is closed */
-  boolean isClosed();
 }

--- a/src/main/java/net/snowflake/ingest/streaming/example/SnowflakeStreamingIngestExample.java
+++ b/src/main/java/net/snowflake/ingest/streaming/example/SnowflakeStreamingIngestExample.java
@@ -34,8 +34,8 @@ public class SnowflakeStreamingIngestExample {
       // Create an open channel request on table T_STREAMINGINGEST
       OpenChannelRequest request1 =
           OpenChannelRequest.builder("CHANNEL")
-              .setDBName("DB_SSTREAMINGINGEST")
-              .setSchemaName("PUBLIC")
+              .setDBName("DB_STREAMINGINGEST")
+              .setSchemaName("SCHEMA_STREAMINGINGEST")
               .setTableName("T_STREAMINGINGEST")
               .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
               .build();

--- a/src/main/java/net/snowflake/ingest/streaming/example/SnowflakeStreamingIngestExample.java
+++ b/src/main/java/net/snowflake/ingest/streaming/example/SnowflakeStreamingIngestExample.java
@@ -6,13 +6,11 @@ package net.snowflake.ingest.streaming.example;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ExecutionException;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
@@ -25,22 +23,19 @@ public class SnowflakeStreamingIngestExample {
   private static String PROFILE_PATH = "profile.json";
   private static final ObjectMapper mapper = new ObjectMapper();
 
-  public static void main(String[] args)
-      throws ExecutionException, InterruptedException, IOException {
+  public static void main(String[] args) throws Exception {
     ObjectNode profile =
         (ObjectNode) mapper.readTree(new String(Files.readAllBytes(Paths.get(PROFILE_PATH))));
     Properties prop = Utils.getPropertiesFromJson(profile);
 
     // Create a streaming ingest client
-    SnowflakeStreamingIngestClient client =
-        SnowflakeStreamingIngestClientFactory.builder("CLIENT").setProperties(prop).build();
-
-    try {
+    try (SnowflakeStreamingIngestClient client =
+        SnowflakeStreamingIngestClientFactory.builder("CLIENT").setProperties(prop).build()) {
       // Create an open channel request on table T_STREAMINGINGEST
       OpenChannelRequest request1 =
           OpenChannelRequest.builder("CHANNEL")
-              .setDBName("DB_STREAMINGINGEST")
-              .setSchemaName("SCHEMA_STREAMINGINGEST")
+              .setDBName("DB_SSTREAMINGINGEST")
+              .setSchemaName("PUBLIC")
               .setTableName("T_STREAMINGINGEST")
               .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
               .build();
@@ -58,8 +53,6 @@ public class SnowflakeStreamingIngestExample {
           throw response.getInsertErrors().get(0).getException();
         }
       }
-    } finally {
-      client.close().get();
     }
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -251,7 +251,7 @@ class SnowflakeStreamingIngestChannelInternal implements SnowflakeStreamingInges
     this.isValid = false;
     this.arrowBuffer.close();
     logger.logWarn(
-        "Channel has been invalidated, name={}, channel sequencer={}",
+        "Channel is invalidated, name={}, channel sequencer={}",
         getFullyQualifiedName(),
         channelSequencer);
   }
@@ -266,7 +266,7 @@ class SnowflakeStreamingIngestChannelInternal implements SnowflakeStreamingInges
   void markClosed() {
     this.isClosed = true;
     logger.logDebug(
-        "Channel has been closed, name={}, channel sequencer={}",
+        "Channel is closed, name={}, channel sequencer={}",
         getFullyQualifiedName(),
         channelSequencer);
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -58,7 +58,7 @@ class SnowflakeStreamingIngestChannelInternal implements SnowflakeStreamingInges
   // Data encryption key
   private final String encryptionKey;
 
-  // Data encryption key Id
+  // Data encryption key id
   private final Long encryptionKeyId;
 
   // Indicates whether we're using it as of the any tests

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -214,6 +214,12 @@ public class SnowflakeStreamingIngestClientInternal implements SnowflakeStreamin
     return this.role;
   }
 
+  /** @return a boolean to indicate whether the client is closed or not */
+  @Override
+  public boolean isClosed() {
+    return isClosed;
+  }
+
   /**
    * Open a channel against a Snowflake table
    *

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -401,7 +401,7 @@ public class SnowflakeStreamingIngestClientInternal implements SnowflakeStreamin
                                     })));
   }
 
-  /** Close the client and release all the resources */
+  /** Close the client, which will flush first and then release all the resources */
   @Override
   public void close() throws Exception {
     if (isClosed) {

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -39,7 +39,7 @@ public class Constants {
   public static final int BLOB_FILE_SIZE_SIZE_IN_BYTES = 8;
   public static final int BLOB_CHECKSUM_SIZE_IN_BYTES = 8;
   public static final int BLOB_CHUNK_METADATA_LENGTH_SIZE_IN_BYTES = 4;
-  public static final long THREAD_SHUTDOWN_TIMEOUT_IN_SEC = 5L;
+  public static final long THREAD_SHUTDOWN_TIMEOUT_IN_SEC = 300L;
   public static final String BLOB_EXTENSION_TYPE = "bdec";
   public static final int MAX_THREAD_COUNT = Integer.MAX_VALUE;
   public static final int CPU_IO_TIME_RATIO = 1;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -613,7 +613,7 @@ public class SnowflakeStreamingIngestClientTest {
   }
 
   @Test
-  public void testClose() {
+  public void testClose() throws Exception {
     SnowflakeStreamingIngestClientInternal client =
         Mockito.spy(new SnowflakeStreamingIngestClientInternal("client"));
     ChannelsStatusResponse response = new ChannelsStatusResponse();
@@ -679,7 +679,7 @@ public class SnowflakeStreamingIngestClientTest {
   }
 
   @Test
-  public void testVerifyChannelsAreFullyCommittedSuccess() {
+  public void testVerifyChannelsAreFullyCommittedSuccess() throws Exception {
     SnowflakeStreamingIngestClientInternal client =
         Mockito.spy(new SnowflakeStreamingIngestClientInternal("client"));
     SnowflakeStreamingIngestChannelInternal channel =

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -657,7 +657,13 @@ public class SnowflakeStreamingIngestClientTest {
     future.completeExceptionally(new Exception("Simulating Error"));
     Mockito.when(client.flush(true)).thenReturn(future);
 
-    client.close();
+    try {
+      client.close();
+      Assert.fail("close should throw");
+    } catch (SFException e) {
+      Assert.assertEquals(ErrorCode.RESOURCE_CLEANUP_FAILURE.getMessageCode(), e.getVendorCode());
+    }
+
     // Calling close again on closed client shouldn't fail
     client.close();
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -6,7 +6,6 @@ import static net.snowflake.ingest.utils.Constants.JDBC_PRIVATE_KEY;
 import static net.snowflake.ingest.utils.Constants.PRIVATE_KEY;
 import static net.snowflake.ingest.utils.Constants.REGISTER_BLOB_ENDPOINT;
 import static net.snowflake.ingest.utils.Constants.ROLE;
-import static net.snowflake.ingest.utils.Constants.ROW_SEQUENCER_IS_COMMITTED;
 import static net.snowflake.ingest.utils.Constants.USER;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,14 +15,12 @@ import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.Security;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import net.snowflake.client.jdbc.internal.apache.commons.io.IOUtils;
 import net.snowflake.ingest.TestUtils;
 import net.snowflake.ingest.connection.RequestBuilder;
@@ -51,8 +48,6 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 public class SnowflakeStreamingIngestClientTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -138,7 +133,6 @@ public class SnowflakeStreamingIngestClientTest {
         SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
 
     Assert.assertEquals("client", client.getName());
-    Assert.assertFalse(client.isClosed());
   }
 
   @Test
@@ -610,7 +604,7 @@ public class SnowflakeStreamingIngestClientTest {
     client.flush(false).get();
 
     // Calling flush on closed client should fail
-    client.close().get();
+    client.close();
     try {
       client.flush(false).get();
     } catch (SFException e) {
@@ -619,7 +613,7 @@ public class SnowflakeStreamingIngestClientTest {
   }
 
   @Test
-  public void testClose() throws Exception {
+  public void testClose() {
     SnowflakeStreamingIngestClientInternal client =
         Mockito.spy(new SnowflakeStreamingIngestClientInternal("client"));
     ChannelsStatusResponse response = new ChannelsStatusResponse();
@@ -629,12 +623,9 @@ public class SnowflakeStreamingIngestClientTest {
 
     Mockito.doReturn(response).when(client).getChannelsStatus(Mockito.any());
 
-    Assert.assertFalse(client.isClosed());
-    client.close().get();
-    Assert.assertTrue(client.isClosed());
-
+    client.close();
     // Calling close again on closed client shouldn't fail
-    client.close().get();
+    client.close();
 
     // Calling open channel on closed client should fail
     try {
@@ -666,12 +657,9 @@ public class SnowflakeStreamingIngestClientTest {
     future.completeExceptionally(new Exception("Simulating Error"));
     Mockito.when(client.flush(true)).thenReturn(future);
 
-    Assert.assertFalse(client.isClosed());
-    client.close().get();
-    Assert.assertTrue(client.isClosed());
-
+    client.close();
     // Calling close again on closed client shouldn't fail
-    client.close().get();
+    client.close();
 
     // Calling open channel on closed client should fail
     try {
@@ -691,89 +679,7 @@ public class SnowflakeStreamingIngestClientTest {
   }
 
   @Test
-  public void testVerifyChannelsAreFullyCommittedFailure() throws InterruptedException {
-    SnowflakeStreamingIngestClientInternal client =
-        Mockito.spy(new SnowflakeStreamingIngestClientInternal("client"));
-    SnowflakeStreamingIngestChannelInternal channel1 =
-        new SnowflakeStreamingIngestChannelInternal(
-            "channel1",
-            "db",
-            "schema",
-            "table",
-            "0",
-            0L,
-            0L,
-            client,
-            "key",
-            1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
-    SnowflakeStreamingIngestChannelInternal channel2 =
-        new SnowflakeStreamingIngestChannelInternal(
-            "channel2",
-            "db",
-            "schema",
-            "table",
-            "0",
-            0L,
-            0L,
-            client,
-            "key",
-            1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
-    client.getChannelCache().addChannel(channel1);
-    client.getChannelCache().addChannel(channel2);
-
-    ChannelsStatusResponse response1 = new ChannelsStatusResponse();
-    response1.setStatusCode(0L);
-    response1.setMessage("Success");
-    ChannelsStatusResponse.ChannelStatusResponseDTO channelStatus1 =
-        new ChannelsStatusResponse.ChannelStatusResponseDTO();
-    channelStatus1.setStatusCode(27L);
-    channelStatus1.setPersistedOffsetToken("0");
-    channelStatus1.setPersistedRowSequencer(1L);
-    ChannelsStatusResponse.ChannelStatusResponseDTO channelStatus2 =
-        new ChannelsStatusResponse.ChannelStatusResponseDTO();
-    channelStatus2.setStatusCode((long) ROW_SEQUENCER_IS_COMMITTED);
-    channelStatus2.setPersistedOffsetToken("0");
-    channelStatus2.setPersistedRowSequencer(1L);
-    response1.setChannels(Arrays.asList(channelStatus1, channelStatus2));
-
-    ChannelsStatusResponse response2 = new ChannelsStatusResponse();
-    response2.setStatusCode(0L);
-    response2.setMessage("Success");
-    response2.setChannels(Collections.singletonList(channelStatus1));
-
-    Mockito.doAnswer(
-            new Answer<ChannelsStatusResponse>() {
-              @Override
-              public ChannelsStatusResponse answer(InvocationOnMock invocationOnMock)
-                  throws Throwable {
-                List<SnowflakeStreamingIngestChannelInternal> channels =
-                    (List<SnowflakeStreamingIngestChannelInternal>)
-                        invocationOnMock.getArguments()[0];
-                if (channels.size() == 2) {
-                  return response1;
-                } else {
-                  return response2;
-                }
-              }
-            })
-        .when(client)
-        .getChannelsStatus(Mockito.any());
-
-    try {
-      client.close().get();
-      Assert.fail("close should throw an exception for channels with uncommitted rows");
-    } catch (ExecutionException e) {
-      Assert.assertTrue(e.getMessage().contains("contain uncommitted rows"));
-    }
-  }
-
-  @Test
-  public void testVerifyChannelsAreFullyCommittedSuccess()
-      throws ExecutionException, InterruptedException {
+  public void testVerifyChannelsAreFullyCommittedSuccess() {
     SnowflakeStreamingIngestClientInternal client =
         Mockito.spy(new SnowflakeStreamingIngestClientInternal("client"));
     SnowflakeStreamingIngestChannelInternal channel =
@@ -803,6 +709,6 @@ public class SnowflakeStreamingIngestClientTest {
 
     Mockito.doReturn(response).when(client).getChannelsStatus(Mockito.any());
 
-    client.close().get();
+    client.close();
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -133,6 +133,7 @@ public class SnowflakeStreamingIngestClientTest {
         SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
 
     Assert.assertEquals("client", client.getName());
+    Assert.assertFalse(client.isClosed());
   }
 
   @Test
@@ -623,7 +624,9 @@ public class SnowflakeStreamingIngestClientTest {
 
     Mockito.doReturn(response).when(client).getChannelsStatus(Mockito.any());
 
+    Assert.assertFalse(client.isClosed());
     client.close();
+    Assert.assertTrue(client.isClosed());
     // Calling close again on closed client shouldn't fail
     client.close();
 
@@ -657,12 +660,14 @@ public class SnowflakeStreamingIngestClientTest {
     future.completeExceptionally(new Exception("Simulating Error"));
     Mockito.when(client.flush(true)).thenReturn(future);
 
+    Assert.assertFalse(client.isClosed());
     try {
       client.close();
       Assert.fail("close should throw");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.RESOURCE_CLEANUP_FAILURE.getMessageCode(), e.getVendorCode());
     }
+    Assert.assertTrue(client.isClosed());
 
     // Calling close again on closed client shouldn't fail
     client.close();

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -73,7 +73,7 @@ public class StreamingIngestIT {
 
   @After
   public void afterAll() throws Exception {
-    client.close().get();
+    client.close();
     jdbcConnection.createStatement().execute(String.format("drop database %s", TEST_DB));
   }
 


### PR DESCRIPTION
This PR contains a few changes related to simplify the client interface:
1. Add AutoCloseable support
2. Simplify the logic in `close` so it doesn't check for uncommitted channels anymore, our recommendation should be always close the channel or check for uncommitted rows after using it