### PR TITLE
SNOW-534105: Enable encryption by default

### DIFF
--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -60,5 +60,4 @@ public class Constants {
   public static final boolean COMPRESS_BLOB_TWICE = false;
   public static final boolean ENABLE_PERF_MEASUREMENT = false;
   public static final boolean BLOB_NO_HEADER = true;
-  public static final boolean ENABLE_ENCRYPTION = false;
 }

--- a/src/main/java/net/snowflake/ingest/utils/Cryptor.java
+++ b/src/main/java/net/snowflake/ingest/utils/Cryptor.java
@@ -1,6 +1,5 @@
 package net.snowflake.ingest.utils;
 
-import static net.snowflake.ingest.utils.Constants.ENABLE_ENCRYPTION;
 import static net.snowflake.ingest.utils.Constants.ENCRYPTION_ALGORITHM;
 
 import java.nio.charset.StandardCharsets;
@@ -101,10 +100,6 @@ public class Cryptor {
   public static byte[] encrypt(byte[] compressedChunkData, String encryptionKey, String diversifier)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException,
           InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
-    if (!ENABLE_ENCRYPTION) {
-      return compressedChunkData;
-    }
-
     // Generate the derived key
     SecretKey derivedKey = deriveKey(encryptionKey, diversifier);
 
@@ -126,10 +121,6 @@ public class Cryptor {
   public static byte[] decrypt(byte[] input, String encryptionKey, String diversifier)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException,
           InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
-    if (!ENABLE_ENCRYPTION) {
-      return input;
-    }
-
     // Generate the derived key
     SecretKey derivedKey = deriveKey(encryptionKey, diversifier);
 


### PR DESCRIPTION
After the [fix](https://github.com/snowflakedb/snowflake/pull/46339) at server side, encryption is working properly, now it's the time to remove any non-encrypted code path in the client SDK