### PR TITLE
Pass in row index corresponding to input rows in response

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/InsertValidationResponse.java
+++ b/src/main/java/net/snowflake/ingest/streaming/InsertValidationResponse.java
@@ -49,9 +49,15 @@ public class InsertValidationResponse {
     private final Object rowContent;
     private final SFException exception;
 
-    public InsertError(Object row, SFException exception) {
+    // Used to map this error row with original row in the insertRows Iterable.
+    // i.e the rowIndex can be index 9 in the list of 10 rows.
+    // index is 0 based so as to match with incoming Iterable
+    private final long rowIndex;
+
+    public InsertError(Object row, SFException exception, long rowIndex) {
       this.rowContent = row;
       this.exception = exception;
+      this.rowIndex = rowIndex;
     }
 
     /** Get the row content */
@@ -67,6 +73,14 @@ public class InsertValidationResponse {
     /** Get the exception */
     public SFException getException() {
       return this.exception;
+    }
+
+    /**
+     * Get the rowIndex. Please note, this index is 0 based so it can be used in fetching nth row
+     * from list.
+     */
+    public long getRowIndex() {
+      return rowIndex;
     }
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/InsertValidationResponse.java
+++ b/src/main/java/net/snowflake/ingest/streaming/InsertValidationResponse.java
@@ -77,7 +77,7 @@ public class InsertValidationResponse {
 
     /**
      * Get the rowIndex. Please note, this index is 0 based so it can be used in fetching nth row
-     * from list.
+     * from the input. ({@link SnowflakeStreamingIngestChannel#insertRows(Iterable, String)})
      */
     public long getRowIndex() {
       return rowIndex;


### PR DESCRIPTION
- Useful to map Kafka offsets with insertErrors so as to send specific records to DLQ. 
- It is possible that rows 1, 5, 9 are bad in on error = continue given 10 rows. 
- We will respond with 0 based indices in insertError.
Included a test. 