### PR TITLE
NO-SNOW: multiple small adjustments/fixes for Snowpipe Streaming

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -226,7 +226,7 @@ class ArrowRowBuffer {
       this.tempVectorsRoot.close();
     }
     this.fields.clear();
-    this.allocator.close();
+    Utils.closeAllocator(this.allocator);
   }
 
   /** Reset the variables after each flush. Note that the caller needs to handle synchronization */

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
@@ -4,8 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigInteger;
 import java.util.Objects;
 
-// TODO https://snowflakecomputing.atlassian.net/browse/SNOW-354886.
-//  Audit register endpoint/FileColumnPorpertyDTO property list.
+/** Audit register endpoint/FileColumnPropertyDTO property list. */
 class FileColumnProperties {
   private String minStrValue;
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -340,6 +340,8 @@ class FlushService {
                 CompletableFuture.supplyAsync(
                     () -> {
                       try {
+                        logger.logDebug(
+                            "buildUploadWorkers stats={}", this.buildUploadWorkers.toString());
                         return buildAndUpload(filePath, blobData);
                       } catch (IOException e) {
                         logger.logError(

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -303,15 +303,10 @@ class FlushService {
     Iterator<Map.Entry<String, ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal>>>
         itr = this.channelCache.iterator();
     List<Pair<BlobData, CompletableFuture<BlobMetadata>>> blobs = new ArrayList<>();
-    String filePath = null;
 
     while (itr.hasNext()) {
       List<List<ChannelData>> blobData = new ArrayList<>();
       float totalBufferSize = 0;
-      filePath = filePath == null ? getFilePath(this.targetStage.getClientPrefix()) : filePath;
-      if (this.owningClient.flushLatency != null) {
-        latencyTimerContextMap.putIfAbsent(filePath, this.owningClient.flushLatency.time());
-      }
 
       // Distribute work at table level, create a new blob if reaching the blob size limit
       while (itr.hasNext() && totalBufferSize <= MAX_BLOB_SIZE_IN_BYTES) {
@@ -335,20 +330,22 @@ class FlushService {
 
       // Kick off a build job
       if (!blobData.isEmpty()) {
-        String finalFilePath = filePath;
-        filePath = null;
+        String filePath = getFilePath(this.targetStage.getClientPrefix());
+        if (this.owningClient.flushLatency != null) {
+          latencyTimerContextMap.putIfAbsent(filePath, this.owningClient.flushLatency.time());
+        }
         blobs.add(
             new Pair<>(
-                new BlobData(finalFilePath, blobData),
+                new BlobData(filePath, blobData),
                 CompletableFuture.supplyAsync(
                     () -> {
                       try {
-                        return buildAndUpload(finalFilePath, blobData);
+                        return buildAndUpload(filePath, blobData);
                       } catch (IOException e) {
                         logger.logError(
                             "Building blob failed={}, exception={}, detail={}, all channels in the"
                                 + " blob will be invalidated",
-                            finalFilePath,
+                            filePath,
                             e,
                             e.getMessage());
                         invalidateAllChannelsInBlob(blobData);
@@ -376,9 +373,8 @@ class FlushService {
    *
    * @param filePath Path of the destination file in cloud storage
    * @param blobData All the data for one blob. Assumes that all ChannelData in the inner List
-   *     belong to the same table. Will error if this is not the case
+   *     belongs to the same table. Will error if this is not the case
    * @return BlobMetadata for FlushService.upload
-   * @throws IOException
    */
   BlobMetadata buildAndUpload(String filePath, List<List<ChannelData>> blobData)
       throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException,

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -50,6 +50,7 @@ import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.HttpUtil;
 import net.snowflake.ingest.utils.Logging;
+import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;
@@ -433,13 +434,7 @@ public class SnowflakeStreamingIngestClientInternal implements SnowflakeStreamin
       throw new SFException(e, ErrorCode.RESOURCE_CLEANUP_FAILURE, "client close");
     } finally {
       this.flushService.shutdown();
-
-      for (BufferAllocator alloc : this.allocator.getChildAllocators()) {
-        alloc.releaseBytes(alloc.getAllocatedMemory());
-        alloc.close();
-      }
-      this.allocator.releaseBytes(this.allocator.getAllocatedMemory());
-      this.allocator.close();
+      Utils.closeAllocator(this.allocator);
     }
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -269,6 +269,11 @@ public class SnowflakeStreamingIngestClientInternal implements SnowflakeStreamin
 
       // Check for Snowflake specific response code
       if (response.getStatusCode() != RESPONSE_SUCCESS) {
+        logger.logDebug(
+            "Open channel request failed, channel={}, table={}, message={}",
+            request.getChannelName(),
+            request.getFullyQualifiedTableName(),
+            response.getMessage());
         throw new SFException(ErrorCode.OPEN_CHANNEL_FAILURE, response.getMessage());
       }
 
@@ -370,6 +375,11 @@ public class SnowflakeStreamingIngestClientInternal implements SnowflakeStreamin
 
       // Check for Snowflake specific response code
       if (response.getStatusCode() != RESPONSE_SUCCESS) {
+        logger.logDebug(
+            "Register blob request failed for blob={}, client={}, message={}",
+            blobs.stream().map(BlobMetadata::getPath).collect(Collectors.toList()),
+            this.name,
+            response.getMessage());
         throw new SFException(ErrorCode.REGISTER_BLOB_FAILURE, response.getMessage());
       }
     } catch (IOException | IngestResponseException e) {

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -60,5 +60,4 @@ public class Constants {
   public static final boolean COMPRESS_BLOB_TWICE = false;
   public static final boolean ENABLE_PERF_MEASUREMENT = false;
   public static final boolean BLOB_NO_HEADER = true;
-  public static final boolean ENABLE_ENCRYPTION = false;
 }

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -27,8 +27,8 @@ public class Constants {
   public static final long BLOB_UPLOAD_TIMEOUT_IN_SEC = 5L;
   public static final int BLOB_UPLOAD_MAX_RETRY_COUNT = 12;
   public static final int INSERT_THROTTLE_MAX_RETRY_COUNT = 10;
-  public static final long MAX_BLOB_SIZE_IN_BYTES = 256000000L;
-  public static final long MAX_CHUNK_SIZE_IN_BYTES = 16000000L;
+  public static final long MAX_BLOB_SIZE_IN_BYTES = 512000000L;
+  public static final long MAX_CHUNK_SIZE_IN_BYTES = 32000000L;
   public static final byte BLOB_FORMAT_VERSION = 0;
   public static final int BLOB_TAG_SIZE_IN_BYTES = 4;
   public static final int BLOB_VERSION_SIZE_IN_BYTES = 1;

--- a/src/main/java/net/snowflake/ingest/utils/Cryptor.java
+++ b/src/main/java/net/snowflake/ingest/utils/Cryptor.java
@@ -1,6 +1,5 @@
 package net.snowflake.ingest.utils;
 
-import static net.snowflake.ingest.utils.Constants.ENABLE_ENCRYPTION;
 import static net.snowflake.ingest.utils.Constants.ENCRYPTION_ALGORITHM;
 
 import java.nio.charset.StandardCharsets;
@@ -101,10 +100,6 @@ public class Cryptor {
   public static byte[] encrypt(byte[] compressedChunkData, String encryptionKey, String diversifier)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException,
           InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
-    if (!ENABLE_ENCRYPTION) {
-      return compressedChunkData;
-    }
-
     // Generate the derived key
     SecretKey derivedKey = deriveKey(encryptionKey, diversifier);
 
@@ -126,10 +121,6 @@ public class Cryptor {
   public static byte[] decrypt(byte[] input, String encryptionKey, String diversifier)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException,
           InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
-    if (!ENABLE_ENCRYPTION) {
-      return input;
-    }
-
     // Generate the derived key
     SecretKey derivedKey = deriveKey(encryptionKey, diversifier);
 

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -1,4 +1,4 @@
-package net.snowflake.ingest.streaming.internal;
+package net.snowflake.ingest.utils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,13 +16,13 @@ public class ParameterProvider {
       "STREAMING_INGEST_CLIENT_SDK_INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE".toLowerCase();
 
   // Default values
-  static final long BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT = 1000;
-  static final long BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT = 100;
-  static final long INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT = 500;
-  static final long INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_DEFAULT = 5;
+  public static final long BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT = 1000;
+  public static final long BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT = 100;
+  public static final long INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT = 500;
+  public static final long INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_DEFAULT = 15;
 
   /** Map of parameter name to parameter value. This will be set by client/configure API Call. */
-  private Map<String, Object> parameterMap = new HashMap<>();
+  private final Map<String, Object> parameterMap = new HashMap<>();
 
   /**
    * Constructor. Takes properties from profile file and properties from client constructor and
@@ -36,7 +36,7 @@ public class ParameterProvider {
   }
 
   /** Empty constructor for tests */
-  ParameterProvider() {
+  public ParameterProvider() {
     this(null, null);
   }
 

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -19,7 +19,7 @@ public class ParameterProvider {
   public static final long BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT = 1000;
   public static final long BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT = 100;
   public static final long INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT = 500;
-  public static final long INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_DEFAULT = 15;
+  public static final long INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_DEFAULT = 10;
 
   /** Map of parameter name to parameter value. This will be set by client/configure API Call. */
   private final Map<String, Object> parameterMap = new HashMap<>();

--- a/src/main/java/net/snowflake/ingest/utils/Utils.java
+++ b/src/main/java/net/snowflake/ingest/utils/Utils.java
@@ -32,6 +32,7 @@ import net.snowflake.client.jdbc.internal.org.bouncycastle.openssl.jcajce.JcaPEM
 import net.snowflake.client.jdbc.internal.org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.operator.InputDecryptorProvider;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.commons.codec.binary.Base64;
 
 /** Contains Ingest related utility functions */
@@ -268,5 +269,15 @@ public class Utils {
   /** Utility function to check whether a streing is null or empty */
   public static boolean isNullOrEmpty(String string) {
     return string == null || string.isEmpty();
+  }
+
+  /** Release any outstanding memory and then close the buffer allocator */
+  public static void closeAllocator(BufferAllocator alloc) {
+    for (BufferAllocator childAlloc : alloc.getChildAllocators()) {
+      childAlloc.releaseBytes(childAlloc.getAllocatedMemory());
+      childAlloc.close();
+    }
+    alloc.releaseBytes(alloc.getAllocatedMemory());
+    alloc.close();
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -36,6 +36,7 @@ import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Cryptor;
 import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.Utils;
 import org.apache.arrow.memory.BufferAllocator;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -3,6 +3,7 @@ package net.snowflake.ingest.streaming.internal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import net.snowflake.ingest.utils.ParameterProvider;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -12,10 +13,10 @@ public class ParameterProviderTest {
   public void withValuesSet() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = new HashMap<>();
-    parameterMap.put(ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS_MAP_KEY, 3l);
-    parameterMap.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_MAP_KEY, 4l);
-    parameterMap.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_MAP_KEY, 6l);
-    parameterMap.put(ParameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS_MAP_KEY, 7l);
+    parameterMap.put(ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS_MAP_KEY, 3L);
+    parameterMap.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_MAP_KEY, 4L);
+    parameterMap.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_MAP_KEY, 6L);
+    parameterMap.put(ParameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS_MAP_KEY, 7L);
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
 
     Assert.assertEquals(3, parameterProvider.getBufferFlushIntervalInMs());
@@ -27,32 +28,32 @@ public class ParameterProviderTest {
   @Test
   public void withNullProps() {
     Map<String, Object> parameterMap = new HashMap<>();
-    parameterMap.put(ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS_MAP_KEY, 3l);
-    parameterMap.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_MAP_KEY, 4l);
-    parameterMap.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_MAP_KEY, 6l);
+    parameterMap.put(ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS_MAP_KEY, 3L);
+    parameterMap.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_MAP_KEY, 4L);
+    parameterMap.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_MAP_KEY, 6L);
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, null);
 
     Assert.assertEquals(3, parameterProvider.getBufferFlushIntervalInMs());
     Assert.assertEquals(4, parameterProvider.getBufferFlushCheckIntervalInMs());
     Assert.assertEquals(6, parameterProvider.getInsertThrottleThresholdInPercentage());
     Assert.assertEquals(
-        parameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT,
+        ParameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT,
         parameterProvider.getInsertThrottleIntervalInMs());
   }
 
   @Test
   public void withNullParameterMap() {
     Properties props = new Properties();
-    props.put(ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS_MAP_KEY, 3l);
-    props.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_MAP_KEY, 4l);
-    props.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_MAP_KEY, 6l);
+    props.put(ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS_MAP_KEY, 3L);
+    props.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_MAP_KEY, 4L);
+    props.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_MAP_KEY, 6L);
     ParameterProvider parameterProvider = new ParameterProvider(null, props);
 
     Assert.assertEquals(3, parameterProvider.getBufferFlushIntervalInMs());
     Assert.assertEquals(4, parameterProvider.getBufferFlushCheckIntervalInMs());
     Assert.assertEquals(6, parameterProvider.getInsertThrottleThresholdInPercentage());
     Assert.assertEquals(
-        parameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT,
+        ParameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT,
         parameterProvider.getInsertThrottleIntervalInMs());
   }
 
@@ -61,16 +62,16 @@ public class ParameterProviderTest {
     ParameterProvider parameterProvider = new ParameterProvider(null, null);
 
     Assert.assertEquals(
-        parameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT,
+        ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT,
         parameterProvider.getBufferFlushIntervalInMs());
     Assert.assertEquals(
-        parameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT,
+        ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT,
         parameterProvider.getBufferFlushCheckIntervalInMs());
     Assert.assertEquals(
-        parameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_DEFAULT,
+        ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_DEFAULT,
         parameterProvider.getInsertThrottleThresholdInPercentage());
     Assert.assertEquals(
-        parameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT,
+        ParameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT,
         parameterProvider.getInsertThrottleIntervalInMs());
   }
 
@@ -79,16 +80,16 @@ public class ParameterProviderTest {
     ParameterProvider parameterProvider = new ParameterProvider();
 
     Assert.assertEquals(
-        parameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT,
+        ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT,
         parameterProvider.getBufferFlushIntervalInMs());
     Assert.assertEquals(
-        parameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT,
+        ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT,
         parameterProvider.getBufferFlushCheckIntervalInMs());
     Assert.assertEquals(
-        parameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_DEFAULT,
+        ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_DEFAULT,
         parameterProvider.getInsertThrottleThresholdInPercentage());
     Assert.assertEquals(
-        parameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT,
+        ParameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT,
         parameterProvider.getInsertThrottleIntervalInMs());
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -24,6 +24,7 @@ import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -35,6 +35,7 @@ import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
 import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
@@ -30,6 +30,7 @@ import net.snowflake.client.jdbc.internal.google.common.util.concurrent.ThreadFa
 import net.snowflake.ingest.TestUtils;
 import net.snowflake.ingest.connection.RequestBuilder;
 import net.snowflake.ingest.utils.Constants;
+import net.snowflake.ingest.utils.ParameterProvider;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;


### PR DESCRIPTION
This PR contains multiple small adjustments/fixes for the Snowpipe Streaming SDK:
1. Always release the allocator first before close, to avoid a memory leak error from the Apache Arrow dependency which might be confusing to customer
2. SNOW-354886 is done, remove the comment in `FileColumnProperties`
3. Adjustment the file name generation logic so the last number should be continuous increasing, instead of having gaps as shown during the KC testing
4. Update some logging to include more information
5. Update MAX_CHUNK_SIZE_IN_BYTES to 32MB and MAX_BLOB_SIZE_IN_BYTES to 512MB, given that we want to have files bigger than 1MB after compression
7. Move ParameterProvider.java to the Utils folder, since this could be used acrossed the SDK