### PR TITLE
@snow SNOW-554959 Align chunk encryption with block size and count for the whole interleaved file

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
@@ -147,11 +147,23 @@ class BlobBuilder {
    * @throws NoSuchAlgorithmException
    */
   static String computeMD5(byte[] data) throws NoSuchAlgorithmException {
+    return computeMD5(data, data.length);
+  }
+
+  /**
+   * Compute the MD5 for a byte array
+   *
+   * @param data the input byte array
+   * @param length the number of bytes from the input byte array starting from zero index
+   * @return lower case MD5 for the compressed chunk data
+   * @throws NoSuchAlgorithmException
+   */
+  static String computeMD5(byte[] data, int length) throws NoSuchAlgorithmException {
     // CASEC-2936
     // https://github.com/snowflakedb/snowflake-ingest-java-private/pull/22
     MessageDigest md = // nosem: java.lang.security.audit.crypto.weak-hash.use-of-md5
         MessageDigest.getInstance("MD5");
-    md.update(data);
+    md.update(data, 0, length);
     byte[] digest = md.digest();
     return DatatypeConverter.printHexBinary(digest).toLowerCase();
   }

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -43,7 +43,8 @@ public class Constants {
   public static final int COMMIT_MAX_RETRY_COUNT = 10;
   public static final int COMMIT_RETRY_INTERVAL_IN_MS = 500;
   public static final int ROW_SEQUENCER_IS_COMMITTED = 26;
-  public static final String ENCRYPTION_ALGORITHM = "AES/CTR/NoPadding";
+  public static final String ENCRYPTION_ALGORITHM = "AES/CTR/PKCS7Padding";
+  public static final long ENCRYPTION_ALGORITHM_BLOCK_SIZE_BYTES = 16;
 
   // Channel level constants
   public static final String CHANNEL_STATUS_ENDPOINT = "/v1/streaming/channels/status/";

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -605,8 +605,8 @@ public class FlushServiceTest {
         Base64.getEncoder().encodeToString("encryption_key".getBytes(StandardCharsets.UTF_8));
     String diversifier = "2021/08/10/blob.bdec";
 
-    byte[] encryptedData = Cryptor.encrypt(data, encryptionKey, diversifier);
-    byte[] decryptedData = Cryptor.decrypt(encryptedData, encryptionKey, diversifier);
+    byte[] encryptedData = Cryptor.encrypt(data, encryptionKey, diversifier, 0);
+    byte[] decryptedData = Cryptor.decrypt(encryptedData, encryptionKey, diversifier, 0);
 
     Assert.assertArrayEquals(data, decryptedData);
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -33,12 +33,12 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
+import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Cryptor;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
-import net.snowflake.ingest.utils.Utils;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
@@ -49,25 +49,9 @@ import org.apache.arrow.vector.util.Text;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@PowerMockIgnore({
-  "com.sun.org.apache.xerces.*",
-  "javax.xml.*",
-  "org.xml.*",
-  "javax.management.*",
-  "javax.crypto.JceSecurity.*",
-  "javax.crypto.*"
-})
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({
-  Utils.class,
-})
 public class FlushServiceTest {
   private SnowflakeStreamingIngestClientInternal client;
   private ChannelCache channelCache;
@@ -81,6 +65,8 @@ public class FlushServiceTest {
 
   @Before
   public void setup() {
+    java.security.Security.addProvider(new BouncyCastleProvider());
+
     ParameterProvider parameterProvider = new ParameterProvider();
     client = Mockito.mock(SnowflakeStreamingIngestClientInternal.class);
     Mockito.when(client.getParameterProvider()).thenReturn(parameterProvider);


### PR DESCRIPTION
[SNOW-554959](https://snowflakecomputing.atlassian.net/browse/SNOW-554959)

The decryption happens block-wise on the query side. The block size is 16 bytes for AES/CTR. Hence the SfFile downloads and decrypts file sections aligned to the block size, starting at the beginning of the whole file. The IV is also incremented for each block starting with zero at the beginning of the whole file.

The problem is that the interleaved chunks are not aligned or padded to the block size in the client. The IV starts from zero for each chunk. This breaks the decryption on the query side.

This PR changes the encryption algorithm to use padding to get the file-wide alignment.
The PR also adds block counting starting from the beginning of the file to use it as the IV for each chunk encryption.

The change is tested by ingesting a file with chunks from three tables in devvm.