### PR TITLE
@snow SNOW-572229 Streaning Ingest: Manual padding of compressed chunk for encryption

### DIFF
--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -44,8 +44,8 @@ public class Constants {
   public static final int COMMIT_RETRY_INTERVAL_IN_MS = 500;
   public static final int RESPONSE_ROW_SEQUENCER_IS_COMMITTED =
       26; // Don't change, should match server side
-  public static final String ENCRYPTION_ALGORITHM = "AES/CTR/PKCS7Padding";
-  public static final long ENCRYPTION_ALGORITHM_BLOCK_SIZE_BYTES = 16;
+  public static final String ENCRYPTION_ALGORITHM = "AES/CTR/NoPadding";
+  public static final int ENCRYPTION_ALGORITHM_BLOCK_SIZE_BYTES = 16;
 
   // Channel level constants
   public static final String CHANNEL_STATUS_ENDPOINT = "/v1/streaming/channels/status/";


### PR DESCRIPTION
File scan code in XP requires encrypted data block alignment. We change the encryption to use PKCS7Padding for that. This causes unclear problems that this type of encryption is not available in some cases, e.g. when we try to build and push release version:
```
java.security.NoSuchAlgorithmException: Cannot find any provider supporting AES/CTR/PKCS7Padding
```

According to this stackoverflow [thread](https://stackoverflow.com/questions/10193567/java-security-nosuchalgorithmexceptioncannot-find-any-provider-supporting-aes-e), PKCS5Padding is usually used with block size of up to 8 bytes. It should be the same as PKCS7Padding in case of AES with block size of 16 bytes. PKCS5Padding does not cause NoSuchAlgorithmException but the padding does not work as excepted.

A potential solution is to look into `BouncyCastleProvider` that is unclear yet.

Alternatively, this PR implements a manual padding of compressed data before encryption in the client.
