### PR TITLE
BUG_FIX Consume the response entity to free up connection

### DIFF
--- a/src/main/java/net/snowflake/ingest/connection/ServiceResponseHandler.java
+++ b/src/main/java/net/snowflake/ingest/connection/ServiceResponseHandler.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import net.snowflake.ingest.utils.BackOffException;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
@@ -76,7 +77,12 @@ public final class ServiceResponseHandler {
     }
 
     // grab the response entity
-    String blob = EntityUtils.toString(response.getEntity());
+    HttpEntity responseEntity = response.getEntity();
+    String blob = EntityUtils.toString(responseEntity);
+
+    // consume entity as recommended in
+    // https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
+    EntityUtils.consume(responseEntity);
 
     // Read out the blob entity into a class
     return mapper.readValue(blob, IngestResponse.class);
@@ -113,7 +119,12 @@ public final class ServiceResponseHandler {
     }
 
     // grab the string version of the response entity
-    String blob = EntityUtils.toString(response.getEntity());
+    HttpEntity responseEntity = response.getEntity();
+    String blob = EntityUtils.toString(responseEntity);
+
+    // consume entity as recommended in
+    // https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
+    EntityUtils.consume(responseEntity);
 
     // read out our blob into a pojo
     return mapper.readValue(blob, HistoryResponse.class);
@@ -142,7 +153,12 @@ public final class ServiceResponseHandler {
     }
 
     // grab the string version of the response entity
-    String blob = EntityUtils.toString(response.getEntity());
+    HttpEntity responseEntity = response.getEntity();
+    String blob = EntityUtils.toString(responseEntity);
+
+    // consume entity as recommended in
+    // https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
+    EntityUtils.consume(responseEntity);
 
     // read out our blob into a pojo
     return mapper.readValue(blob, HistoryRangeResponse.class);

--- a/src/main/java/net/snowflake/ingest/connection/ServiceResponseHandler.java
+++ b/src/main/java/net/snowflake/ingest/connection/ServiceResponseHandler.java
@@ -76,13 +76,7 @@ public final class ServiceResponseHandler {
       return null;
     }
 
-    // grab the response entity
-    HttpEntity responseEntity = response.getEntity();
-    String blob = EntityUtils.toString(responseEntity);
-
-    // consume entity as recommended in
-    // https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
-    EntityUtils.consume(responseEntity);
+    String blob = consumeAndReturnResponseEntityAsString(response.getEntity());
 
     // Read out the blob entity into a class
     return mapper.readValue(blob, IngestResponse.class);
@@ -118,13 +112,7 @@ public final class ServiceResponseHandler {
       return null;
     }
 
-    // grab the string version of the response entity
-    HttpEntity responseEntity = response.getEntity();
-    String blob = EntityUtils.toString(responseEntity);
-
-    // consume entity as recommended in
-    // https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
-    EntityUtils.consume(responseEntity);
+    String blob = consumeAndReturnResponseEntityAsString(response.getEntity());
 
     // read out our blob into a pojo
     return mapper.readValue(blob, HistoryResponse.class);
@@ -152,14 +140,7 @@ public final class ServiceResponseHandler {
       return null;
     }
 
-    // grab the string version of the response entity
-    HttpEntity responseEntity = response.getEntity();
-    String blob = EntityUtils.toString(responseEntity);
-
-    // consume entity as recommended in
-    // https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
-    EntityUtils.consume(responseEntity);
-
+    String blob = consumeAndReturnResponseEntityAsString(response.getEntity());
     // read out our blob into a pojo
     return mapper.readValue(blob, HistoryRangeResponse.class);
   }
@@ -183,10 +164,31 @@ public final class ServiceResponseHandler {
         // We don't know how to respond now...
       default:
         LOGGER.error("Status code {} found in response from service", statusLine.getStatusCode());
-        String blob = EntityUtils.toString(response.getEntity());
+        String blob = consumeAndReturnResponseEntityAsString(response.getEntity());
         throw new IngestResponseException(
             statusLine.getStatusCode(),
             IngestResponseException.IngestExceptionBody.parseBody(blob));
     }
+  }
+
+  /**
+   * Consumes the HttpEntity as mentioned in <a
+   * href="https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html">HttpClient Docs</a>
+   *
+   * <p>Also returns the string version of this entity.
+   *
+   * @param httpResponseEntity the response entity obtained after successfully calling associated
+   *     Rest APIs
+   * @return String version of this http response which will be later used to deserialize into
+   *     respective Response Object
+   * @throws IOException if parsing error
+   */
+  private static String consumeAndReturnResponseEntityAsString(HttpEntity httpResponseEntity)
+      throws IOException {
+    // grab the string version of the response entity
+    String responseEntityAsString = EntityUtils.toString(httpResponseEntity);
+
+    EntityUtils.consumeQuietly(httpResponseEntity);
+    return responseEntityAsString;
   }
 }


### PR DESCRIPTION
- As mentioned in httpclient docs
- https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
- https://stackoverflow.com/questions/4775618/httpclient-4-0-1-how-to-release-connection
```
Please note that if response content is not fully consumed the underlying
connection cannot be safely re-used and will be shut down and discarded
by the connection manager.
```

I am also seeing few NoHttpResponseException in existing snowpipe + KC where load is increased. This could be one of the potential reasons, although I don't have a thread dump. 

- no test
- I will push this to master and release a new version on top of `0.10.3`
- I will also send out pr for doing this in other APIs which are not GA

Steps:
1. Push this on top of 0.10.3. 
2. CP this commit on top of master.
3. Do this for rest of APIs called. 