### PR TITLE
V0.10.4 beta.2 release branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- Arifact name and version information -->
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-ingest-sdk</artifactId>
-    <version>0.10.4-beta</version>
+    <version>0.10.4-beta.2</version>
     <packaging>jar</packaging>
     <name>Snowflake Ingest SDK</name>
     <description>Snowflake Ingest SDK</description>

--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -35,10 +35,10 @@ import net.snowflake.ingest.connection.ServiceResponseHandler;
 import net.snowflake.ingest.utils.BackOffException;
 import net.snowflake.ingest.utils.HttpUtil;
 import net.snowflake.ingest.utils.StagedFileWrapper;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -200,7 +200,7 @@ public class SimpleIngestManager implements AutoCloseable {
   // logger object for this class
   private static final Logger LOGGER = LoggerFactory.getLogger(SimpleIngestManager.class);
   // HTTP Client that we use for sending requests to the service
-  private HttpClient httpClient;
+  private CloseableHttpClient httpClient;
 
   // the account in which the user lives
   private String account;
@@ -592,13 +592,13 @@ public class SimpleIngestManager implements AutoCloseable {
             requestId, pipe, files, showSkippedFiles, Optional.ofNullable(clientInfo));
 
     // send the request and get a response....
-    HttpResponse response = httpClient.execute(httpPostForIngestFile);
-
-    LOGGER.info(
-        "Attempting to unmarshall insert response - {}, with clientInfo - {}",
-        response,
-        clientInfo);
-    return ServiceResponseHandler.unmarshallIngestResponse(response, requestId);
+    try (CloseableHttpResponse response = httpClient.execute(httpPostForIngestFile)) {
+      LOGGER.info(
+          "Attempting to unmarshall insert response - {}, with clientInfo - {}",
+          response,
+          clientInfo);
+      return ServiceResponseHandler.unmarshallIngestResponse(response, requestId);
+    }
   }
 
   /**
@@ -625,10 +625,10 @@ public class SimpleIngestManager implements AutoCloseable {
         builder.generateHistoryRequest(requestId, pipe, recentSeconds, beginMark);
 
     // send the request and get a response...
-    HttpResponse response = httpClient.execute(httpGetHistory);
-
-    LOGGER.info("Attempting to unmarshall history response - {}", response);
-    return ServiceResponseHandler.unmarshallHistoryResponse(response, requestId);
+    try (CloseableHttpResponse response = httpClient.execute(httpGetHistory)) {
+      LOGGER.info("Attempting to unmarshall history response - {}", response);
+      return ServiceResponseHandler.unmarshallHistoryResponse(response, requestId);
+    }
   }
 
   /**
@@ -654,13 +654,13 @@ public class SimpleIngestManager implements AutoCloseable {
       requestId = UUID.randomUUID();
     }
 
-    HttpResponse response =
+    try (CloseableHttpResponse response =
         httpClient.execute(
             builder.generateHistoryRangeRequest(
-                requestId, pipe, startTimeInclusive, endTimeExclusive));
-
-    LOGGER.info("Attempting to unmarshall history range response - {}", response);
-    return ServiceResponseHandler.unmarshallHistoryRangeResponse(response, requestId);
+                requestId, pipe, startTimeInclusive, endTimeExclusive))) {
+      LOGGER.info("Attempting to unmarshall history range response - {}", response);
+      return ServiceResponseHandler.unmarshallHistoryRangeResponse(response, requestId);
+    }
   }
 
   /**
@@ -679,10 +679,11 @@ public class SimpleIngestManager implements AutoCloseable {
     if (requestId == null || requestId.toString().isEmpty()) {
       requestId = UUID.randomUUID();
     }
-    HttpResponse response =
-        httpClient.execute(builder.generateConfigureClientRequest(requestId, pipe));
-    LOGGER.info("Attempting to unmarshall configure client response - {}", response);
-    return ServiceResponseHandler.unmarshallConfigureClientResponse(response, requestId);
+    try (CloseableHttpResponse response =
+        httpClient.execute(builder.generateConfigureClientRequest(requestId, pipe))) {
+      LOGGER.info("Attempting to unmarshall configure client response - {}", response);
+      return ServiceResponseHandler.unmarshallConfigureClientResponse(response, requestId);
+    }
   }
 
   /**
@@ -701,10 +702,11 @@ public class SimpleIngestManager implements AutoCloseable {
     if (requestId == null || requestId.toString().isEmpty()) {
       requestId = UUID.randomUUID();
     }
-    HttpResponse response =
-        httpClient.execute(builder.generateGetClientStatusRequest(requestId, pipe));
-    LOGGER.info("Attempting to unmarshall get client status response - {}", response);
-    return ServiceResponseHandler.unmarshallGetClientStatus(response, requestId);
+    try (CloseableHttpResponse response =
+        httpClient.execute(builder.generateGetClientStatusRequest(requestId, pipe))) {
+      LOGGER.info("Attempting to unmarshall get client status response - {}", response);
+      return ServiceResponseHandler.unmarshallGetClientStatus(response, requestId);
+    }
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -122,7 +122,7 @@ public final class RequestBuilder {
   // Don't change!
   public static final String CLIENT_NAME = "SnowpipeJavaSDK";
 
-  public static final String DEFAULT_VERSION = "0.10.4-beta";
+  public static final String DEFAULT_VERSION = "0.10.4-beta.2";
 
   public static final String JAVA_USER_AGENT = "JAVA";
 

--- a/src/main/java/net/snowflake/ingest/connection/ServiceResponseHandler.java
+++ b/src/main/java/net/snowflake/ingest/connection/ServiceResponseHandler.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.UUID;
 import net.snowflake.ingest.utils.BackOffException;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
@@ -88,7 +89,12 @@ public final class ServiceResponseHandler {
     handleExceptionalStatus(response, requestId, ApiName.INSERT_FILES);
 
     // grab the response entity
-    String blob = EntityUtils.toString(response.getEntity());
+    HttpEntity responseEntity = response.getEntity();
+    String blob = EntityUtils.toString(responseEntity);
+
+    // consume entity as recommended in
+    // https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
+    EntityUtils.consume(responseEntity);
 
     // Read out the blob entity into a class
     return mapper.readValue(blob, IngestResponse.class);
@@ -117,7 +123,12 @@ public final class ServiceResponseHandler {
     handleExceptionalStatus(response, requestId, ApiName.INSERT_REPORT);
 
     // grab the string version of the response entity
-    String blob = EntityUtils.toString(response.getEntity());
+    HttpEntity responseEntity = response.getEntity();
+    String blob = EntityUtils.toString(responseEntity);
+
+    // consume entity as recommended in
+    // https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
+    EntityUtils.consume(responseEntity);
 
     // read out our blob into a pojo
     return mapper.readValue(blob, HistoryResponse.class);
@@ -147,7 +158,12 @@ public final class ServiceResponseHandler {
     handleExceptionalStatus(response, requestId, ApiName.LOAD_HISTORY_SCAN);
 
     // grab the string version of the response entity
-    String blob = EntityUtils.toString(response.getEntity());
+    HttpEntity responseEntity = response.getEntity();
+    String blob = EntityUtils.toString(responseEntity);
+
+    // consume entity as recommended in
+    // https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
+    EntityUtils.consume(responseEntity);
 
     // read out our blob into a pojo
     return mapper.readValue(blob, HistoryRangeResponse.class);

--- a/src/main/java/net/snowflake/ingest/connection/ServiceResponseHandler.java
+++ b/src/main/java/net/snowflake/ingest/connection/ServiceResponseHandler.java
@@ -88,13 +88,7 @@ public final class ServiceResponseHandler {
     // handle the exceptional status code
     handleExceptionalStatus(response, requestId, ApiName.INSERT_FILES);
 
-    // grab the response entity
-    HttpEntity responseEntity = response.getEntity();
-    String blob = EntityUtils.toString(responseEntity);
-
-    // consume entity as recommended in
-    // https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
-    EntityUtils.consume(responseEntity);
+    String blob = consumeAndReturnResponseEntityAsString(response.getEntity());
 
     // Read out the blob entity into a class
     return mapper.readValue(blob, IngestResponse.class);
@@ -122,13 +116,7 @@ public final class ServiceResponseHandler {
     // handle the exceptional status code
     handleExceptionalStatus(response, requestId, ApiName.INSERT_REPORT);
 
-    // grab the string version of the response entity
-    HttpEntity responseEntity = response.getEntity();
-    String blob = EntityUtils.toString(responseEntity);
-
-    // consume entity as recommended in
-    // https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
-    EntityUtils.consume(responseEntity);
+    String blob = consumeAndReturnResponseEntityAsString(response.getEntity());
 
     // read out our blob into a pojo
     return mapper.readValue(blob, HistoryResponse.class);
@@ -157,14 +145,7 @@ public final class ServiceResponseHandler {
     // handle the exceptional status code
     handleExceptionalStatus(response, requestId, ApiName.LOAD_HISTORY_SCAN);
 
-    // grab the string version of the response entity
-    HttpEntity responseEntity = response.getEntity();
-    String blob = EntityUtils.toString(responseEntity);
-
-    // consume entity as recommended in
-    // https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html
-    EntityUtils.consume(responseEntity);
-
+    String blob = consumeAndReturnResponseEntityAsString(response.getEntity());
     // read out our blob into a pojo
     return mapper.readValue(blob, HistoryRangeResponse.class);
   }
@@ -192,7 +173,7 @@ public final class ServiceResponseHandler {
     handleExceptionalStatus(response, requestId, ApiName.CLIENT_CONFIGURE);
 
     // grab the string version of the response entity
-    String blob = EntityUtils.toString(response.getEntity());
+    String blob = consumeAndReturnResponseEntityAsString(response.getEntity());
 
     // read out our blob into a pojo
     return mapper.readValue(blob, ConfigureClientResponse.class);
@@ -221,7 +202,7 @@ public final class ServiceResponseHandler {
     handleExceptionalStatus(response, requestId, ApiName.CLIENT_STATUS);
 
     // grab the string version of the response entity
-    String blob = EntityUtils.toString(response.getEntity());
+    String blob = consumeAndReturnResponseEntityAsString(response.getEntity());
 
     // read out our blob into a pojo
     return mapper.readValue(blob, ClientStatusResponse.class);
@@ -254,11 +235,32 @@ public final class ServiceResponseHandler {
               apiName,
               statusLine.getStatusCode(),
               requestId.toString());
-          String blob = EntityUtils.toString(response.getEntity());
+          String blob = consumeAndReturnResponseEntityAsString(response.getEntity());
           throw new IngestResponseException(
               statusLine.getStatusCode(),
               IngestResponseException.IngestExceptionBody.parseBody(blob));
       }
     }
+  }
+
+  /**
+   * Consumes the HttpEntity as mentioned in <a
+   * href="https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html">HttpClient Docs</a>
+   *
+   * <p>Also returns the string version of this entity.
+   *
+   * @param httpResponseEntity the response entity obtained after successfully calling associated
+   *     Rest APIs
+   * @return String version of this http response which will be later used to deserialize into
+   *     respective Response Object
+   * @throws IOException if parsing error
+   */
+  private static String consumeAndReturnResponseEntityAsString(HttpEntity httpResponseEntity)
+      throws IOException {
+    // grab the string version of the response entity
+    String responseEntityAsString = EntityUtils.toString(httpResponseEntity);
+
+    EntityUtils.consumeQuietly(httpResponseEntity);
+    return responseEntityAsString;
   }
 }

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -17,7 +17,6 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.client.ServiceUnavailableRetryStrategy;
 import org.apache.http.client.config.RequestConfig;
@@ -25,6 +24,7 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
@@ -46,9 +46,10 @@ public class HttpUtil {
   private static final int MAX_RETRIES = 3;
   static final int DEFAULT_CONNECTION_TIMEOUT = 1; // minute
   static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 5; // minutes
-  private static HttpClient httpClient;
 
-  public static HttpClient getHttpClient() {
+  private static CloseableHttpClient httpClient;
+
+  public static CloseableHttpClient getHttpClient() {
     if (httpClient == null) {
       initHttpClient();
     }


### PR DESCRIPTION
- This is to release a version which is also safe for customers using version >=1.7.0 for kafka connector 

This is no different than 0.10.6 except that it also fixes closing of httpResponse and consuming entity in new Snowpipe APIs for Exactly once Feature. 