### PR TITLE
Release version 1.0.2-beta.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- Arifact name and version information -->
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-ingest-sdk</artifactId>
-    <version>1.0.2-beta</version>
+    <version>1.0.2-beta.1</version>
     <packaging>jar</packaging>
     <name>Snowflake Ingest SDK</name>
     <description>Snowflake Ingest SDK</description>

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -127,7 +127,7 @@ public class RequestBuilder {
   // Don't change!
   public static final String CLIENT_NAME = "SnowpipeJavaSDK";
 
-  public static final String DEFAULT_VERSION = "1.0.2-beta";
+  public static final String DEFAULT_VERSION = "1.0.2-beta.1";
 
   public static final String JAVA_USER_AGENT = "JAVA";
 


### PR DESCRIPTION
Release note:

- On top of `1.0.2-beta`
- Fix a critical bug in channel.close to avoid wrong result
- Retry HTTP APIs on certain status code returned from SF