### PR TITLE
SNOW-585421 use custom connection pooling manager for Apache httpClient

### DIFF
--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -634,6 +634,7 @@ public class SimpleIngestManager implements AutoCloseable {
   @Override
   public void close() {
     builder.closeResources();
+    HttpUtil.shutdownHttpConnectionManagerDaemonThread();
   }
 
   /* Used for testing */

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -55,7 +55,7 @@ public class HttpUtil {
   private static final int DEFAULT_MAX_CONNECTIONS_PER_ROUTE = 100;
   private static final int DEFAULT_MAX_CONNECTIONS = 100;
 
-  private static final int DEFAULT_TTL_CONNECTION = 120;
+  private static final int DEFAULT_TTL_CONNECTION_MINUTES = 2;
 
   private static final long MONITOR_THREAD_INTERVAL_MS = TimeUnit.SECONDS.toMillis(5);
 
@@ -102,7 +102,7 @@ public class HttpUtil {
             .build();
 
     PoolingHttpClientConnectionManager connectionManager =
-        new PoolingHttpClientConnectionManager(DEFAULT_TTL_CONNECTION, TimeUnit.SECONDS);
+        new PoolingHttpClientConnectionManager(DEFAULT_TTL_CONNECTION_MINUTES, TimeUnit.MINUTES);
     connectionManager.setDefaultMaxPerRoute(DEFAULT_MAX_CONNECTIONS_PER_ROUTE);
     connectionManager.setMaxTotal(DEFAULT_MAX_CONNECTIONS);
 
@@ -252,7 +252,7 @@ public class HttpUtil {
 
             if (routes != null) {
               for (HttpRoute route : routes) {
-                sb.append(createRouteInfo(connectionManager, route));
+                sb.append(createPoolStatsForRoute(connectionManager, route));
               }
             }
 
@@ -280,13 +280,15 @@ public class HttpUtil {
     }
   }
 
-  private static String createRouteInfo(
+  /** Create Pool stats for a route */
+  private static String createPoolStatsForRoute(
       PoolingHttpClientConnectionManager connectionManager, HttpRoute route) {
     PoolStats routeStats = connectionManager.getStats(route);
     return createPoolStatsInfo(
         String.format("Pool Stats for route %s = ", route.getTargetHost().toURI()), routeStats);
   }
 
+  /** Returns a string with a title and pool stats. */
   private static String createPoolStatsInfo(String title, PoolStats poolStats) {
     StringBuilder sb = new StringBuilder();
 

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -152,6 +152,7 @@ public class HttpUtil {
     // https://hc.apache.org/httpcomponents-client-4.5.x/current/tutorial/html/connmgmt.html
     IdleConnectionMonitorThread idleConnectionMonitorThread =
         new IdleConnectionMonitorThread(connectionManager);
+    idleConnectionMonitorThread.setDaemon(true);
     idleConnectionMonitorThread.start();
   }
 


### PR DESCRIPTION
Adding few configurations for `httpClient` as mentioned here. 

- The default implementation of ConnectionManager has just 20 max connections and 2 max connections per route.
- Adding commit https://github.com/snowflakedb/snowflake-ingest-java/pull/104 on top of 0.10.6 release too.
- Adding a background thread for closingIdleConnections as described in [here](https://hc.apache.org/httpcomponents-client-4.5.x/current/tutorial/html/connmgmt.html#d5e405).

Overall guide for HttpClient
- https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html

