### PR TITLE
NO-SNOW: Update Arrow library to 7.0.0 to support VectorSchemaRootAppender

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,12 +319,12 @@
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-vector</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-memory-netty</artifactId>
-            <version>7.0.0</version>
+            <version>8.0.0</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -319,12 +319,12 @@
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-vector</artifactId>
-            <version>4.0.0</version>
+            <version>7.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-memory-netty</artifactId>
-            <version>4.0.0</version>
+            <version>7.0.0</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
[Apache Arrow library 7.0.0](https://arrow.apache.org/blog/2022/02/08/7.0.0-release/) and plus now supports VectorSchemaRootAppender with BitVector now, switch to the latest 8.0.0 so we could use VectorSchemaRootAppender to append vector to another vector