### PR TITLE
NO-SNOW: fix test failure due to time zone difference

### DIFF
--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -9,10 +9,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.TimeZone;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -87,7 +89,7 @@ public class StreamingIngestIT {
   @After
   public void afterAll() throws Exception {
     client.close();
-    jdbcConnection.createStatement().execute(String.format("drop database %s", TEST_DB));
+    // jdbcConnection.createStatement().execute(String.format("drop database %s", TEST_DB));
   }
 
   @Test
@@ -387,6 +389,8 @@ public class StreamingIngestIT {
     // Close the channel after insertion
     channel1.close().get();
 
+    Calendar cal = Calendar.getInstance();
+    cal.setTimeZone(TimeZone.getTimeZone("UTC"));
     for (int i = 1; i < 15; i++) {
       if (channel1.getLatestCommittedOffsetToken() != null
           && channel1.getLatestCommittedOffsetToken().equals("1")) {
@@ -404,9 +408,9 @@ public class StreamingIngestIT {
         Assert.assertEquals(3600123, result.getTimestamp("TSMALL").getTime());
         Assert.assertEquals(32400123, result.getTimestamp("TBIG").getTime());
         Assert.assertEquals(123456780, result.getTimestamp("TBIG").getNanos());
-        Assert.assertEquals(1609462800123L, result.getTimestamp("TNTZSMALL").getTime());
-        Assert.assertEquals(1609462800123L, result.getTimestamp("TNTZBIG").getTime());
-        Assert.assertEquals(123450000, result.getTimestamp("TNTZBIG").getNanos());
+        Assert.assertEquals(1609462800123L, result.getTimestamp("TNTZSMALL", cal).getTime());
+        Assert.assertEquals(1609462800123L, result.getTimestamp("TNTZBIG", cal).getTime());
+        Assert.assertEquals(123450000, result.getTimestamp("TNTZBIG", cal).getNanos());
 
         result =
             jdbcConnection
@@ -430,9 +434,9 @@ public class StreamingIngestIT {
         Assert.assertEquals(10800123, result.getTimestamp("MTSMALL").getTime());
         Assert.assertEquals(39600123, result.getTimestamp("MTBIG").getTime());
         Assert.assertEquals(123456780, result.getTimestamp("MTBIG").getNanos());
-        Assert.assertEquals(1809462800123L, result.getTimestamp("MTNTZSMALL").getTime());
-        Assert.assertEquals(1925024400123L, result.getTimestamp("MTNTZBIG").getTime());
-        Assert.assertEquals(123456780, result.getTimestamp("MTNTZBIG").getNanos());
+        Assert.assertEquals(1809462800123L, result.getTimestamp("MTNTZSMALL", cal).getTime());
+        Assert.assertEquals(1925024400123L, result.getTimestamp("MTNTZBIG", cal).getTime());
+        Assert.assertEquals(123456780, result.getTimestamp("MTNTZBIG", cal).getNanos());
 
         return;
       } else {
@@ -477,6 +481,8 @@ public class StreamingIngestIT {
     // Close the channel after insertion
     channel1.close().get();
 
+    Calendar cal = Calendar.getInstance();
+    cal.setTimeZone(TimeZone.getTimeZone("UTC"));
     for (int i = 1; i < 15; i++) {
       if (channel1.getLatestCommittedOffsetToken() != null
           && channel1.getLatestCommittedOffsetToken().equals("1")) {
@@ -493,7 +499,7 @@ public class StreamingIngestIT {
         Assert.assertEquals(3.14, result.getFloat("F"), 0.0001);
         Assert.assertEquals(1.1, result.getFloat("TINYFLOAT"), 0.001);
         Assert.assertEquals("{\n" + "  \"e\": 2.7\n" + "}", result.getString("VAR"));
-        Assert.assertEquals(timestamp * 1000, result.getTimestamp("T").getTime());
+        Assert.assertEquals(timestamp * 1000, result.getTimestamp("T", cal).getTime());
         Assert.assertEquals(-923, TimeUnit.MILLISECONDS.toDays(result.getDate("D").getTime()));
         return;
       } else {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -89,7 +89,7 @@ public class StreamingIngestIT {
   @After
   public void afterAll() throws Exception {
     client.close();
-    // jdbcConnection.createStatement().execute(String.format("drop database %s", TEST_DB));
+    jdbcConnection.createStatement().execute(String.format("drop database %s", TEST_DB));
   }
 
   @Test


### PR DESCRIPTION
Explicitly set the timezone to be UTC for NTZ so the test won't fail when running on non-UTC environment