### PR TITLE
SNOW-608483 fix column stats for collated strings

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
@@ -51,8 +51,11 @@ class FileColumnProperties {
     this.setMinRealValue(stats.getCurrentMinRealValue());
     this.setMaxRealValue(stats.getCurrentMaxRealValue());
     this.setMaxLength(stats.getCurrentMaxLength());
+
+    //Collated and non-collated strings are intentionally equal here as required by Snowflake
     this.setMaxStrNonCollated(stats.getCurrentMaxColStrValue());
     this.setMinStrNonCollated(stats.getCurrentMinColStrValue());
+
     this.setMaxStrValue(stats.getCurrentMaxColStrValue());
     this.setMinStrValue(stats.getCurrentMinColStrValue());
     this.setNullCount(stats.getCurrentNullCount());

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
@@ -52,7 +52,7 @@ class FileColumnProperties {
     this.setMaxRealValue(stats.getCurrentMaxRealValue());
     this.setMaxLength(stats.getCurrentMaxLength());
 
-    //Collated and non-collated strings are intentionally equal here as required by Snowflake
+    // Collated and non-collated strings are intentionally equal here as required by Snowflake
     this.setMaxStrNonCollated(stats.getCurrentMaxColStrValue());
     this.setMinStrNonCollated(stats.getCurrentMinColStrValue());
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
@@ -51,8 +51,8 @@ class FileColumnProperties {
     this.setMinRealValue(stats.getCurrentMinRealValue());
     this.setMaxRealValue(stats.getCurrentMaxRealValue());
     this.setMaxLength(stats.getCurrentMaxLength());
-    this.setMaxStrNonCollated(stats.getCurrentMaxStrValue());
-    this.setMinStrNonCollated(stats.getCurrentMinStrValue());
+    this.setMaxStrNonCollated(stats.getCurrentMaxColStrValue());
+    this.setMinStrNonCollated(stats.getCurrentMinColStrValue());
     this.setMaxStrValue(stats.getCurrentMaxColStrValue());
     this.setMinStrValue(stats.getCurrentMinColStrValue());
     this.setNullCount(stats.getCurrentNullCount());

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -302,8 +302,6 @@ class RowBufferStats {
   private String currentMaxColStrValue;
   private byte[] currentMinColStrValueInBytes;
   private byte[] currentMaxColStrValueInBytes;
-  //  private byte[] currentMinStrValueInBytes;
-  //  private byte[] currentMaxStrValueInBytes;
   private BigInteger currentMinIntValue;
   private BigInteger currentMaxIntValue;
   private Double currentMinRealValue;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -302,8 +302,8 @@ class RowBufferStats {
   private String currentMaxColStrValue;
   private byte[] currentMinColStrValueInBytes;
   private byte[] currentMaxColStrValueInBytes;
-  private byte[] currentMinStrValueInBytes;
-  private byte[] currentMaxStrValueInBytes;
+  //  private byte[] currentMinStrValueInBytes;
+  //  private byte[] currentMaxStrValueInBytes;
   private BigInteger currentMinIntValue;
   private BigInteger currentMaxIntValue;
   private Double currentMinRealValue;
@@ -336,8 +336,6 @@ class RowBufferStats {
     this.currentMinColStrValue = null;
     this.currentMaxColStrValueInBytes = null;
     this.currentMinColStrValueInBytes = null;
-    this.currentMinStrValueInBytes = null;
-    this.currentMaxStrValueInBytes = null;
     this.currentMaxIntValue = null;
     this.currentMinIntValue = null;
     this.currentMaxRealValue = null;
@@ -417,7 +415,6 @@ class RowBufferStats {
     if (this.currentMinStrValue == null) {
       this.currentMinStrValue = value;
       this.currentMinColStrValue = value;
-      this.currentMinStrValueInBytes = valueBytes;
       this.currentMinColStrValueInBytes = collatedValueBytes;
 
       /*
@@ -433,42 +430,17 @@ class RowBufferStats {
         String incrementedValue = new String(incrementedValueBytes);
         this.currentMaxStrValue = incrementedValue;
         this.currentMaxColStrValue = incrementedValue;
-        this.currentMaxStrValueInBytes = incrementedValueBytes;
         this.currentMaxColStrValueInBytes = incrementedCollatedValueBytes;
       } else {
         this.currentMaxStrValue = value;
         this.currentMaxColStrValue = value;
-        this.currentMaxStrValueInBytes = valueBytes;
         this.currentMaxColStrValueInBytes = collatedValueBytes;
       }
     } else {
-      // Non-collated comparison
-      if (compare(currentMinStrValueInBytes, valueBytes) > 0) {
-        this.currentMinStrValue = value;
-        this.currentMinStrValueInBytes = valueBytes;
-      } else if (compare(currentMaxStrValueInBytes, valueBytes) < 0) {
-        /*
-        Snowflake stores the first MAX_LOB_LEN characters of a string.
-        When truncating the max value, we increment the last max value
-        byte by one to ensure the max value stat is greater than the actual max value.
-         */
-        if (inputValue.length() > MAX_LOB_LEN) {
-          byte[] incrementedValueBytes = valueBytes.clone();
-          byte[] incrementedCollatedValueBytes = collatedValueBytes.clone();
-          incrementedValueBytes[MAX_LOB_LEN - 1]++;
-          incrementedCollatedValueBytes[MAX_LOB_LEN - 1]++;
-          String incrementedValue = new String(incrementedValueBytes);
-          this.currentMaxStrValue = incrementedValue;
-          this.currentMaxStrValueInBytes = incrementedValueBytes;
-        } else {
-          this.currentMaxStrValue = value;
-          this.currentMaxStrValueInBytes = valueBytes;
-        }
-      }
-
       // Collated comparison
       if (compare(currentMinColStrValueInBytes, collatedValueBytes) > 0) {
         this.currentMinColStrValue = value;
+        this.currentMinStrValue = value;
         this.currentMinColStrValueInBytes = collatedValueBytes;
       } else if (compare(currentMaxColStrValueInBytes, collatedValueBytes) < 0) {
         /*
@@ -483,9 +455,11 @@ class RowBufferStats {
           incrementedCollatedValueBytes[MAX_LOB_LEN - 1]++;
           String incrementedValue = new String(incrementedValueBytes);
           this.currentMaxColStrValue = incrementedValue;
+          this.currentMaxStrValue = incrementedValue;
           this.currentMaxColStrValueInBytes = incrementedCollatedValueBytes;
         } else {
           this.currentMaxColStrValue = value;
+          this.currentMaxStrValue = value;
           this.currentMaxColStrValueInBytes = collatedValueBytes;
         }
       }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -296,8 +296,6 @@ class RowBufferStats {
     }
   }
 
-  private String currentMinStrValue;
-  private String currentMaxStrValue;
   private String currentMinColStrValue;
   private String currentMaxColStrValue;
   private byte[] currentMinColStrValueInBytes;
@@ -328,8 +326,6 @@ class RowBufferStats {
   }
 
   void reset() {
-    this.currentMaxStrValue = null;
-    this.currentMinStrValue = null;
     this.currentMaxColStrValue = null;
     this.currentMinColStrValue = null;
     this.currentMaxColStrValueInBytes = null;
@@ -371,16 +367,12 @@ class RowBufferStats {
       combined.addIntValue(right.currentMaxIntValue);
     }
 
-    if (left.currentMinStrValue != null) {
-      combined.addStrValue(left.currentMinStrValue);
-      combined.addStrValue(left.currentMaxStrValue);
+    if (left.currentMinColStrValue != null) {
       combined.addStrValue(left.currentMinColStrValue);
       combined.addStrValue(left.currentMaxColStrValue);
     }
 
-    if (right.currentMinStrValue != null) {
-      combined.addStrValue(right.currentMinStrValue);
-      combined.addStrValue(right.currentMaxStrValue);
+    if (right.currentMinColStrValue != null) {
       combined.addStrValue(right.currentMinColStrValue);
       combined.addStrValue(right.currentMaxColStrValue);
     }
@@ -410,8 +402,7 @@ class RowBufferStats {
     byte[] collatedValueBytes = value != null ? getCollatedBytes(value) : null;
 
     // Check if new min/max string
-    if (this.currentMinStrValue == null) {
-      this.currentMinStrValue = value;
+    if (this.currentMinColStrValue == null) {
       this.currentMinColStrValue = value;
       this.currentMinColStrValueInBytes = collatedValueBytes;
 
@@ -426,11 +417,9 @@ class RowBufferStats {
         incrementedValueBytes[MAX_LOB_LEN - 1]++;
         incrementedCollatedValueBytes[MAX_LOB_LEN - 1]++;
         String incrementedValue = new String(incrementedValueBytes);
-        this.currentMaxStrValue = incrementedValue;
         this.currentMaxColStrValue = incrementedValue;
         this.currentMaxColStrValueInBytes = incrementedCollatedValueBytes;
       } else {
-        this.currentMaxStrValue = value;
         this.currentMaxColStrValue = value;
         this.currentMaxColStrValueInBytes = collatedValueBytes;
       }
@@ -438,7 +427,6 @@ class RowBufferStats {
       // Collated comparison
       if (compare(currentMinColStrValueInBytes, collatedValueBytes) > 0) {
         this.currentMinColStrValue = value;
-        this.currentMinStrValue = value;
         this.currentMinColStrValueInBytes = collatedValueBytes;
       } else if (compare(currentMaxColStrValueInBytes, collatedValueBytes) < 0) {
         /*
@@ -453,23 +441,13 @@ class RowBufferStats {
           incrementedCollatedValueBytes[MAX_LOB_LEN - 1]++;
           String incrementedValue = new String(incrementedValueBytes);
           this.currentMaxColStrValue = incrementedValue;
-          this.currentMaxStrValue = incrementedValue;
           this.currentMaxColStrValueInBytes = incrementedCollatedValueBytes;
         } else {
           this.currentMaxColStrValue = value;
-          this.currentMaxStrValue = value;
           this.currentMaxColStrValueInBytes = collatedValueBytes;
         }
       }
     }
-  }
-
-  String getCurrentMinStrValue() {
-    return currentMinStrValue;
-  }
-
-  String getCurrentMaxStrValue() {
-    return currentMaxStrValue;
   }
 
   String getCurrentMinColStrValue() {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelDataTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelDataTest.java
@@ -107,13 +107,13 @@ public class ChannelDataTest {
     Assert.assertEquals(new BigInteger("10"), oneCombined.getCurrentMinIntValue());
     Assert.assertEquals(new BigInteger("17"), oneCombined.getCurrentMaxIntValue());
     Assert.assertEquals(-1, oneCombined.getDistinctValues());
-    Assert.assertNull(oneCombined.getCurrentMinStrValue());
-    Assert.assertNull(oneCombined.getCurrentMaxStrValue());
+    Assert.assertNull(oneCombined.getCurrentMinColStrValue());
+    Assert.assertNull(oneCombined.getCurrentMaxColStrValue());
     Assert.assertNull(oneCombined.getCurrentMinRealValue());
     Assert.assertNull(oneCombined.getCurrentMaxRealValue());
 
-    Assert.assertEquals("10", twoCombined.getCurrentMinStrValue());
-    Assert.assertEquals("17", twoCombined.getCurrentMaxStrValue());
+    Assert.assertEquals("10", twoCombined.getCurrentMinColStrValue());
+    Assert.assertEquals("17", twoCombined.getCurrentMaxColStrValue());
     Assert.assertEquals(-1, twoCombined.getDistinctValues());
     Assert.assertNull(twoCombined.getCurrentMinIntValue());
     Assert.assertNull(twoCombined.getCurrentMaxIntValue());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
@@ -153,7 +153,7 @@ public class RowBufferStatsTest {
     Assert.assertEquals(-1, stats.getDistinctValues());
 
     stats.addStrValue("Bob");
-    Assert.assertEquals("Bob", stats.getCurrentMinStrValue());
+    Assert.assertEquals("bob", stats.getCurrentMinStrValue());
     Assert.assertEquals("bob", stats.getCurrentMaxStrValue());
     Assert.assertEquals("bob", stats.getCurrentMinColStrValue());
     Assert.assertEquals("bob", stats.getCurrentMaxColStrValue());
@@ -359,7 +359,7 @@ public class RowBufferStatsTest {
     two.incCurrentNullCount();
 
     result = RowBufferStats.getCombinedStats(one, two);
-    Assert.assertEquals("Alpha", result.getCurrentMinStrValue());
+    Assert.assertEquals("a", result.getCurrentMinStrValue());
     Assert.assertEquals("g", result.getCurrentMaxStrValue());
     Assert.assertEquals("a", result.getCurrentMinColStrValue());
     Assert.assertEquals("g", result.getCurrentMaxColStrValue());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
@@ -78,8 +78,6 @@ public class RowBufferStatsTest {
     Assert.assertNull(stats.getCurrentMaxColStrValue());
     Assert.assertNull(stats.getCurrentMinIntValue());
     Assert.assertNull(stats.getCurrentMaxIntValue());
-    Assert.assertNull(stats.getCurrentMinStrValue());
-    Assert.assertNull(stats.getCurrentMaxStrValue());
 
     Assert.assertEquals(0, stats.getCurrentNullCount());
     Assert.assertEquals(-1, stats.getDistinctValues());
@@ -90,22 +88,16 @@ public class RowBufferStatsTest {
     RowBufferStats stats = new RowBufferStats();
 
     stats.addStrValue("bob");
-    Assert.assertEquals("bob", stats.getCurrentMinStrValue());
-    Assert.assertEquals("bob", stats.getCurrentMaxStrValue());
     Assert.assertEquals("bob", stats.getCurrentMinColStrValue());
     Assert.assertEquals("bob", stats.getCurrentMaxColStrValue());
     Assert.assertEquals(-1, stats.getDistinctValues());
 
     stats.addStrValue("charlie");
-    Assert.assertEquals("bob", stats.getCurrentMinStrValue());
-    Assert.assertEquals("charlie", stats.getCurrentMaxStrValue());
     Assert.assertEquals("bob", stats.getCurrentMinColStrValue());
     Assert.assertEquals("charlie", stats.getCurrentMaxColStrValue());
     Assert.assertEquals(-1, stats.getDistinctValues());
 
     stats.addStrValue("alice");
-    Assert.assertEquals("alice", stats.getCurrentMinStrValue());
-    Assert.assertEquals("charlie", stats.getCurrentMaxStrValue());
     Assert.assertEquals("alice", stats.getCurrentMinColStrValue());
     Assert.assertEquals("charlie", stats.getCurrentMaxColStrValue());
     Assert.assertEquals(-1, stats.getDistinctValues());
@@ -122,12 +114,12 @@ public class RowBufferStatsTest {
   public void testStrTruncation() throws Exception {
     RowBufferStats stats = new RowBufferStats();
     stats.addStrValue("abcde|abcde|abcde|abcde|abcde|abcde|");
-    Assert.assertEquals("abcde|abcde|abcde|abcde|abcde|ab", stats.getCurrentMinStrValue());
-    Assert.assertEquals("abcde|abcde|abcde|abcde|abcde|ac", stats.getCurrentMaxStrValue());
+    Assert.assertEquals("abcde|abcde|abcde|abcde|abcde|ab", stats.getCurrentMinColStrValue());
+    Assert.assertEquals("abcde|abcde|abcde|abcde|abcde|ac", stats.getCurrentMaxColStrValue());
 
     stats.addStrValue("zabcde|abcde|abcde|abcde|abcde|abcde|");
-    Assert.assertEquals("abcde|abcde|abcde|abcde|abcde|ab", stats.getCurrentMinStrValue());
-    Assert.assertEquals("zabcde|abcde|abcde|abcde|abcde|b", stats.getCurrentMaxStrValue());
+    Assert.assertEquals("abcde|abcde|abcde|abcde|abcde|ab", stats.getCurrentMinColStrValue());
+    Assert.assertEquals("zabcde|abcde|abcde|abcde|abcde|b", stats.getCurrentMaxColStrValue());
 
     RowBufferStats ai = new RowBufferStats("en-ai");
     ai.addStrValue("abcde|abcde|abcde|abcde|abcde|abcde|");
@@ -146,22 +138,16 @@ public class RowBufferStatsTest {
     Assert.assertEquals("en-ci", stats.getCollationDefinitionString());
 
     stats.addStrValue("bob");
-    Assert.assertEquals("bob", stats.getCurrentMinStrValue());
-    Assert.assertEquals("bob", stats.getCurrentMaxStrValue());
     Assert.assertEquals("bob", stats.getCurrentMinColStrValue());
     Assert.assertEquals("bob", stats.getCurrentMaxColStrValue());
     Assert.assertEquals(-1, stats.getDistinctValues());
 
     stats.addStrValue("Bob");
-    Assert.assertEquals("bob", stats.getCurrentMinStrValue());
-    Assert.assertEquals("bob", stats.getCurrentMaxStrValue());
     Assert.assertEquals("bob", stats.getCurrentMinColStrValue());
     Assert.assertEquals("bob", stats.getCurrentMaxColStrValue());
     Assert.assertEquals(-1, stats.getDistinctValues());
 
     stats.addStrValue("Alice");
-    Assert.assertEquals("Alice", stats.getCurrentMinStrValue());
-    Assert.assertEquals("bob", stats.getCurrentMaxStrValue());
     Assert.assertEquals("Alice", stats.getCurrentMinColStrValue());
     Assert.assertEquals("bob", stats.getCurrentMaxColStrValue());
     Assert.assertEquals(-1, stats.getDistinctValues());
@@ -194,8 +180,6 @@ public class RowBufferStatsTest {
 
     Assert.assertNull(stats.getCurrentMinRealValue());
     Assert.assertNull(stats.getCurrentMaxRealValue());
-    Assert.assertNull(stats.getCurrentMinStrValue());
-    Assert.assertNull(stats.getCurrentMaxStrValue());
     Assert.assertNull(stats.getCollationDefinitionString());
     Assert.assertNull(stats.getCurrentMinColStrValue());
     Assert.assertNull(stats.getCurrentMaxColStrValue());
@@ -223,8 +207,6 @@ public class RowBufferStatsTest {
 
     Assert.assertNull(stats.getCurrentMinIntValue());
     Assert.assertNull(stats.getCurrentMaxIntValue());
-    Assert.assertNull(stats.getCurrentMinStrValue());
-    Assert.assertNull(stats.getCurrentMaxStrValue());
     Assert.assertNull(stats.getCollationDefinitionString());
     Assert.assertNull(stats.getCurrentMinColStrValue());
     Assert.assertNull(stats.getCurrentMaxColStrValue());
@@ -277,8 +259,8 @@ public class RowBufferStatsTest {
     Assert.assertEquals(-1, result.getDistinctValues());
     Assert.assertEquals(2, result.getCurrentNullCount());
 
-    Assert.assertNull(result.getCurrentMinStrValue());
-    Assert.assertNull(result.getCurrentMaxStrValue());
+    Assert.assertNull(result.getCurrentMinColStrValue());
+    Assert.assertNull(result.getCurrentMaxColStrValue());
     Assert.assertNull(result.getCurrentMinRealValue());
     Assert.assertNull(result.getCurrentMaxRealValue());
 
@@ -302,8 +284,6 @@ public class RowBufferStatsTest {
     Assert.assertEquals(-1, result.getDistinctValues());
     Assert.assertEquals(0, result.getCurrentNullCount());
 
-    Assert.assertNull(result.getCurrentMinStrValue());
-    Assert.assertNull(result.getCurrentMaxStrValue());
     Assert.assertNull(result.getCollationDefinitionString());
     Assert.assertNull(result.getCurrentMinColStrValue());
     Assert.assertNull(result.getCurrentMaxColStrValue());
@@ -329,8 +309,6 @@ public class RowBufferStatsTest {
     two.setCurrentMaxLength(1);
 
     result = RowBufferStats.getCombinedStats(one, two);
-    Assert.assertEquals("a", result.getCurrentMinStrValue());
-    Assert.assertEquals("g", result.getCurrentMaxStrValue());
     Assert.assertEquals("a", result.getCurrentMinColStrValue());
     Assert.assertEquals("g", result.getCurrentMaxColStrValue());
     Assert.assertEquals(-1, result.getDistinctValues());
@@ -359,8 +337,6 @@ public class RowBufferStatsTest {
     two.incCurrentNullCount();
 
     result = RowBufferStats.getCombinedStats(one, two);
-    Assert.assertEquals("a", result.getCurrentMinStrValue());
-    Assert.assertEquals("g", result.getCurrentMaxStrValue());
     Assert.assertEquals("a", result.getCurrentMinColStrValue());
     Assert.assertEquals("g", result.getCurrentMaxColStrValue());
     Assert.assertEquals(-1, result.getDistinctValues());
@@ -391,8 +367,8 @@ public class RowBufferStatsTest {
     Assert.assertEquals(-1, result.getDistinctValues());
     Assert.assertEquals(2, result.getCurrentNullCount());
 
-    Assert.assertNull(result.getCurrentMinStrValue());
-    Assert.assertNull(result.getCurrentMaxStrValue());
+    Assert.assertNull(result.getCurrentMinColStrValue());
+    Assert.assertNull(result.getCurrentMaxColStrValue());
     Assert.assertNull(result.getCurrentMinRealValue());
     Assert.assertNull(result.getCurrentMaxRealValue());
 
@@ -410,8 +386,8 @@ public class RowBufferStatsTest {
     Assert.assertEquals(-1, result.getDistinctValues());
     Assert.assertEquals(0, result.getCurrentNullCount());
 
-    Assert.assertNull(result.getCurrentMinStrValue());
-    Assert.assertNull(result.getCurrentMaxStrValue());
+    Assert.assertNull(result.getCurrentMinColStrValue());
+    Assert.assertNull(result.getCurrentMaxColStrValue());
     Assert.assertNull(result.getCurrentMinIntValue());
     Assert.assertNull(result.getCurrentMaxIntValue());
 
@@ -426,8 +402,8 @@ public class RowBufferStatsTest {
     one.incCurrentNullCount();
 
     result = RowBufferStats.getCombinedStats(one, two);
-    Assert.assertEquals("alpha", result.getCurrentMinStrValue());
-    Assert.assertEquals("g", result.getCurrentMaxStrValue());
+    Assert.assertEquals("alpha", result.getCurrentMinColStrValue());
+    Assert.assertEquals("g", result.getCurrentMaxColStrValue());
     Assert.assertEquals(-1, result.getDistinctValues());
     Assert.assertEquals(1, result.getCurrentNullCount());
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -1179,8 +1179,8 @@ public class RowBufferTest {
     Assert.assertEquals(0, columnEpStats.get("COLBIGINT").getCurrentNullCount());
     Assert.assertEquals(-1, columnEpStats.get("COLBIGINT").getDistinctValues());
 
-    Assert.assertEquals("alice", columnEpStats.get("COLCHAR").getCurrentMaxStrValue());
-    Assert.assertEquals("2", columnEpStats.get("COLCHAR").getCurrentMinStrValue());
+    Assert.assertEquals("alice", columnEpStats.get("COLCHAR").getCurrentMaxColStrValue());
+    Assert.assertEquals("2", columnEpStats.get("COLCHAR").getCurrentMinColStrValue());
     Assert.assertEquals(0, columnEpStats.get("COLCHAR").getCurrentNullCount());
     Assert.assertEquals(-1, columnEpStats.get("COLCHAR").getDistinctValues());
 
@@ -1572,9 +1572,9 @@ public class RowBufferTest {
     Assert.assertEquals(3, result.getRowCount());
     Assert.assertEquals(11L, result.getColumnEps().get("COLBINARY").getCurrentMaxLength());
     Assert.assertEquals(
-        "Hello World", result.getColumnEps().get("COLBINARY").getCurrentMinStrValue());
+        "Hello World", result.getColumnEps().get("COLBINARY").getCurrentMinColStrValue());
     Assert.assertEquals(
-        "Honk Honk", result.getColumnEps().get("COLBINARY").getCurrentMaxStrValue());
+        "Honk Honk", result.getColumnEps().get("COLBINARY").getCurrentMaxColStrValue());
     Assert.assertEquals(1, result.getColumnEps().get("COLBINARY").getCurrentNullCount());
   }
 


### PR DESCRIPTION
Reporting the same min/max string information for collated and non-collated text fields