### PR TITLE
@snow SNOW-612516 Streaming ingest: add random file reader to scan single columns, format version 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <shadeBase>net.snowflake.ingest.internal</shadeBase>
         <jacoco.skip.instrument>true</jacoco.skip.instrument>
         <jacoco.version>0.8.5</jacoco.version>
+        <arrow.version>8.0.0</arrow.version>
     </properties>
 
     <build>
@@ -319,13 +320,18 @@
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-vector</artifactId>
-            <version>8.0.0</version>
+            <version>${arrow.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-memory-netty</artifactId>
-            <version>8.0.0</version>
+            <version>${arrow.version}</version>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-compression</artifactId>
+            <version>${arrow.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/scripts/check_content.sh
+++ b/scripts/check_content.sh
@@ -5,7 +5,7 @@
 set -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v mime.types | grep -v project.properties | grep -v -E "javax" | grep -v -E "^org/" | grep -v -E "^com/google" | grep -v -E "^com/sun" | grep -v "log4j.properties" | grep -v "git.properties" | grep -v "io/" | grep -v "codegen/" | grep -v "com/codahale/" | grep -v "com/ibm/" | grep -v "LICENSE"; then
+if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v mime.types | grep -v project.properties | grep -v -E "javax" | grep -v -E "^org/" | grep -v -E "^com/google" | grep -v -E "^com/sun" | grep -v "log4j.properties" | grep -v "git.properties" | grep -v "io/" | grep -v "codegen/" | grep -v "com/codahale/" | grep -v "com/ibm/" | grep -v "LICENSE" | grep -v "aix/" | grep -v "darwin/" | grep -v "win/" | grep -v "freebsd/" | grep -v "linux/" | grep -v "com/github/"; then
   echo "[ERROR] Ingest SDK jar includes class not under the snowflake namespace"
   exit 1
 fi

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowFileWriterWithCompression.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowFileWriterWithCompression.java
@@ -1,0 +1,65 @@
+package net.snowflake.ingest.streaming.internal;
+
+import java.io.IOException;
+import java.nio.channels.WritableByteChannel;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.VectorUnloader;
+import org.apache.arrow.vector.compression.CompressionCodec;
+import org.apache.arrow.vector.compression.NoCompressionCodec;
+import org.apache.arrow.vector.ipc.ArrowFileWriter;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+
+/**
+ * {@link ArrowFileWriter} with configurable {@link CompressionCodec}
+ *
+ * <p>{@link ArrowFileWriter} cannot be configured to use a custom {@link CompressionCodec}. {@link
+ * ArrowFileWriter} internally has a {@link VectorUnloader} that can be configured with a custom
+ * {@link CompressionCodec} but {@link ArrowFileWriter} does not forward this configuration in its
+ * public constructors. This class extends {@link ArrowFileWriter} to override the underlying {@link
+ * VectorUnloader} and configure it with a custom {@link CompressionCodec}.
+ */
+class ArrowFileWriterWithCompression extends ArrowFileWriter {
+  private final VectorUnloader unloader;
+  private final boolean compressed;
+
+  ArrowFileWriterWithCompression(
+      VectorSchemaRoot root, WritableByteChannel out, CompressionCodec codec) {
+    // Note: the dictionary provider is null, this allows to simplify writeBatch() in this class
+    // and exclude ensureDictionariesWritten() call from the original ArrowWriter#writeBatch()
+    // implementation
+    super(root, null, out);
+
+    // we have to create an unloader, different to ArrowWriter#unloader
+    // because it is private and we need to configure it with CompressionCodec
+    // that is not available in ArrowWriter
+    this.unloader = new VectorUnloader(root, true, codec, true);
+    this.compressed = codec != NoCompressionCodec.INSTANCE;
+  }
+
+  // same as ArrowWriter#writeBatch but does not write dictionaries
+  // and uses an unloader configured with a custom CompressionCodec
+  @Override
+  public void writeBatch() throws IOException {
+    start(); // same as ensureStarted() in ArrowWriter#writeBatch()
+
+    // not called as in ArrowWriter#writeBatch
+    // because the dictionary provider is always null in ArrowFileWriterWithCompression()
+    // constructor
+    // ensureDictionariesWritten();
+
+    // ArrowWriter#unloader is private but we need to configure it with CompressionCodec
+    // hence we use here a different unloader
+    // the compression happenes in unloader.getRecordBatch() -> appendNodes() ->
+    // buffers.add(codec.compress(..)..)
+    try (ArrowRecordBatch batch = unloader.getRecordBatch()) {
+      writeRecordBatch(batch);
+      if (compressed) {
+        // compression creates new compressed buffers added to the ArrowRecordBatch
+        // their reference counter is incremented twice:
+        // once in CompressionCodec on create and once in ArrowRecordBatch to retain
+        // first the buffers are released here, second in the ArrowRecordBatch#close on try exit
+        batch.getBuffers().forEach(arrowBuf -> arrowBuf.getReferenceManager().release());
+      }
+    }
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadata.java
@@ -4,19 +4,34 @@
 
 package net.snowflake.ingest.streaming.internal;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import net.snowflake.ingest.utils.Constants;
+import net.snowflake.ingest.utils.ParameterProvider;
 
 /** Metadata for a blob that sends to Snowflake as part of the register blob request */
 class BlobMetadata {
   private final String path;
   private final String md5;
+  private final Constants.BdecVerion bdecVersion;
   private final List<ChunkMetadata> chunks;
 
   BlobMetadata(String path, String md5, List<ChunkMetadata> chunks) {
+    this(path, md5, ParameterProvider.BLOB_FORMAT_VERSION_DEFAULT, chunks);
+  }
+
+  BlobMetadata(
+      String path, String md5, Constants.BdecVerion bdecVersion, List<ChunkMetadata> chunks) {
     this.path = path;
     this.md5 = md5;
+    this.bdecVersion = bdecVersion;
     this.chunks = chunks;
+  }
+
+  @JsonIgnore
+  Constants.BdecVerion getVersion() {
+    return bdecVersion;
   }
 
   @JsonProperty("path")
@@ -32,5 +47,10 @@ class BlobMetadata {
   @JsonProperty("chunks")
   List<ChunkMetadata> getChunks() {
     return this.chunks;
+  }
+
+  @JsonProperty("bdec_version")
+  byte getVersionByte() {
+    return bdecVersion.toByte();
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/CustomCompressionCodec.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/CustomCompressionCodec.java
@@ -1,0 +1,108 @@
+package net.snowflake.ingest.streaming.internal;
+
+import org.apache.arrow.compression.ZstdCompressionCodec;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.util.MemoryUtil;
+import org.apache.arrow.vector.compression.CompressionCodec;
+import org.apache.arrow.vector.compression.CompressionUtil;
+
+/**
+ * This is custom wrapper on top of {@link CompressionCodec} implementations.
+ *
+ * <p>The main stream {@link CompressionCodec} implementations are based on {@link
+ * org.apache.arrow.vector.compression.AbstractCompressionCodec}. This implementation is similar to
+ * it with some tweaks.
+ *
+ * <p>The reason to have this custom implementation is to fix certain issues with mainstream codecs
+ * that lead to buffer reference counting problems due to creation of new compressed buffers and
+ * releasing uncompressed. The release of uncompressed buffer from the original vectors to write
+ * into file results in double release when the original vector gets released as usual.
+ *
+ * <p>The custom code extraction is not optimal in a long term and there is a TODO: SNOW-629844 - to
+ * follow up on this.
+ */
+public class CustomCompressionCodec implements CompressionCodec {
+  private final CompressionCodec actualCodec;
+
+  public CustomCompressionCodec(CompressionUtil.CodecType codecType) {
+    switch (codecType) {
+        // TODO: SNOW-629836 - LZ4 compression currently breaks server side decompression
+      case ZSTD:
+        actualCodec =
+            new ZstdCompressionCodec() {
+              @Override
+              public ArrowBuf compress(BufferAllocator allocator, ArrowBuf uncompressedBuffer) {
+                return doCompress(allocator, uncompressedBuffer);
+              }
+            };
+        break;
+      case NO_COMPRESSION:
+        actualCodec = new CustomNoCompressionCodec();
+        break;
+      default:
+        throw new IllegalArgumentException("unsupported compression type: " + codecType);
+    }
+  }
+
+  @Override
+  public ArrowBuf compress(BufferAllocator allocator, ArrowBuf uncompressedBuffer) {
+    if (uncompressedBuffer.writerIndex() == 0L) {
+      // shortcut for empty buffer
+      ArrowBuf compressedBuffer = allocator.buffer(CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH);
+      compressedBuffer.setLong(0, 0);
+      compressedBuffer.writerIndex(CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH);
+      uncompressedBuffer.close();
+      return compressedBuffer;
+    }
+
+    ArrowBuf compressedBuffer = actualCodec.compress(allocator, uncompressedBuffer);
+    // Here we simplify the original AbstractCompressionCodec#compress
+    // and always write the compressed data even if the compression does not give anything
+    // in case of e.g. random integers.
+    // The reason is that mixing compressed and uncompressed buffers breaks the server side
+    // decompression that happens to expect only compressed buffers for version 8.0.0.
+    long uncompressedLength = uncompressedBuffer.writerIndex();
+    writeUncompressedLength(compressedBuffer, uncompressedLength);
+
+    // Here we again simplify the original AbstractCompressionCodec#compress
+    // and do not release the uncompressedBuffer because it is part of the root vector to write.
+    // This root vector will be released as usual by client.
+    return compressedBuffer;
+  }
+
+  @Override
+  public ArrowBuf decompress(BufferAllocator allocator, ArrowBuf compressedBuffer) {
+    throw new UnsupportedOperationException("decompress is not supported");
+  }
+
+  protected void writeUncompressedLength(ArrowBuf compressedBuffer, long uncompressedLength) {
+    if (!MemoryUtil.LITTLE_ENDIAN) {
+      uncompressedLength = Long.reverseBytes(uncompressedLength);
+    }
+    // first 8 bytes reserved for uncompressed length, according to the specification
+    compressedBuffer.setLong(0, uncompressedLength);
+  }
+
+  @Override
+  public CompressionUtil.CodecType getCodecType() {
+    return actualCodec.getCodecType();
+  }
+
+  private static class CustomNoCompressionCodec implements CompressionCodec {
+    @Override
+    public ArrowBuf compress(BufferAllocator allocator, ArrowBuf uncompressedBuffer) {
+      return CompressionUtil.packageRawBuffer(allocator, uncompressedBuffer);
+    }
+
+    @Override
+    public ArrowBuf decompress(BufferAllocator allocator, ArrowBuf compressedBuffer) {
+      return compressedBuffer;
+    }
+
+    @Override
+    public CompressionUtil.CodecType getCodecType() {
+      return CompressionUtil.CodecType.NO_COMPRESSION;
+    }
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -15,6 +15,7 @@ import com.codahale.metrics.Timer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.nio.channels.Channels;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -50,7 +51,9 @@ import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.VectorLoader;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.VectorUnloader;
+import org.apache.arrow.vector.compression.CompressionUtil;
 import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.ipc.ArrowWriter;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 
 /**
@@ -121,6 +124,9 @@ class FlushService {
   // A map which stores the timer for each blob in order to capture the flush latency
   private final Map<String, Timer.Context> latencyTimerContextMap;
 
+  // blob file version
+  private final Constants.BdecVerion bdecVersion;
+
   /**
    * Constructor for TESTING that takes (usually mocked) StreamingIngestStage
    *
@@ -142,6 +148,7 @@ class FlushService {
     this.lastFlushTime = System.currentTimeMillis();
     this.isTestMode = isTestMode;
     this.latencyTimerContextMap = new HashMap<>();
+    this.bdecVersion = this.owningClient.getParameterProvider().getBlobFormatVersion();
     createWorkers();
   }
 
@@ -174,6 +181,7 @@ class FlushService {
     this.lastFlushTime = System.currentTimeMillis();
     this.isTestMode = isTestMode;
     this.latencyTimerContextMap = new HashMap<>();
+    this.bdecVersion = this.owningClient.getParameterProvider().getBlobFormatVersion();
     createWorkers();
   }
 
@@ -403,7 +411,7 @@ class FlushService {
       List<ChannelMetadata> channelsMetadataList = new ArrayList<>();
       long rowCount = 0L;
       VectorSchemaRoot root = null;
-      ArrowStreamWriter streamWriter = null;
+      ArrowWriter arrowWriter = null;
       VectorLoader loader = null;
       SnowflakeStreamingIngestChannelInternal firstChannel = null;
       ByteArrayOutputStream chunkData = new ByteArrayOutputStream();
@@ -431,10 +439,16 @@ class FlushService {
           if (root == null) {
             columnEpStatsMapCombined = data.getColumnEps();
             root = data.getVectors();
-            streamWriter = new ArrowStreamWriter(root, null, chunkData);
+            arrowWriter =
+                getArrowBatchWriteMode() == Constants.ArrowBatchWriteMode.STREAM
+                    ? new ArrowStreamWriter(root, null, chunkData)
+                    : new ArrowFileWriterWithCompression(
+                        root,
+                        Channels.newChannel(chunkData),
+                        new CustomCompressionCodec(CompressionUtil.CodecType.ZSTD));
             loader = new VectorLoader(root);
             firstChannel = data.getChannel();
-            streamWriter.start();
+            arrowWriter.start();
           } else {
             // This method assumes that channelsDataPerTable is grouped by table. We double check
             // here and throw an error if the assumption is violated
@@ -456,7 +470,7 @@ class FlushService {
           }
 
           // Write channel data using the stream writer
-          streamWriter.writeBatch();
+          arrowWriter.writeBatch();
           rowCount += data.getRowCount();
 
           logger.logDebug(
@@ -467,23 +481,19 @@ class FlushService {
               filePath);
         }
       } finally {
-        if (streamWriter != null) {
-          streamWriter.close();
+        if (arrowWriter != null) {
+          arrowWriter.close();
           root.close();
         }
       }
 
       if (!channelsMetadataList.isEmpty()) {
-        // Compress the chunk data and pad it for encryption.
-        // Encryption needs padding to the ENCRYPTION_ALGORITHM_BLOCK_SIZE_BYTES
-        // to align with decryption on the Snowflake query path starting from this chunk offset.
-        // The padding does not have arrow data and not compressed.
-        // Hence, the actual chunk size is smaller by the padding size.
-        // The compression on the Snowflake query path needs the correct size of the compressed
-        // data.
         Pair<byte[], Integer> compressionResult =
-            BlobBuilder.compress(
-                filePath, chunkData, Constants.ENCRYPTION_ALGORITHM_BLOCK_SIZE_BYTES);
+            BlobBuilder.compressIfNeededAndPadChunk(
+                filePath,
+                chunkData,
+                Constants.ENCRYPTION_ALGORITHM_BLOCK_SIZE_BYTES,
+                getArrowBatchWriteMode());
         byte[] compressedAndPaddedChunkData = compressionResult.getFirst();
         int compressedChunkLength = compressionResult.getSecond();
 
@@ -502,12 +512,13 @@ class FlushService {
         int encryptedCompressedChunkDataSize = encryptedCompressedChunkData.length;
 
         // Create chunk metadata
+        long startOffset = curDataSize;
         ChunkMetadata chunkMetadata =
             ChunkMetadata.builder()
                 .setOwningTable(firstChannel)
                 // The start offset will be updated later in BlobBuilder#build to include the blob
                 // header
-                .setChunkStartOffset(curDataSize)
+                .setChunkStartOffset(startOffset)
                 // The compressedChunkLength is used because it is the actual data size used for
                 // decompression and md5 calculation on server side.
                 .setChunkLength(compressedChunkLength)
@@ -524,26 +535,40 @@ class FlushService {
         crc.update(encryptedCompressedChunkData, 0, encryptedCompressedChunkDataSize);
 
         logger.logInfo(
-            "Finish building chunk in blob={}, table={}, rowCount={}, uncompressedSize={},"
-                + " compressedChunkLength={}, encryptedCompressedSize={}",
+            "Finish building chunk in blob={}, table={}, rowCount={}, startOffset={},"
+                + " uncompressedSize={}, compressedChunkLength={}, encryptedCompressedSize={},"
+                + " arrowBatchWriteMode={}",
             filePath,
             firstChannel.getFullyQualifiedTableName(),
             rowCount,
+            startOffset,
             chunkData.size(),
             compressedChunkLength,
             encryptedCompressedChunkDataSize,
-            compressedChunkLength);
+            getArrowBatchWriteMode());
       }
     }
 
     // Build blob file, and then upload to streaming ingest dedicated stage
     byte[] blob =
-        BlobBuilder.build(chunksMetadataList, chunksDataList, crc.getValue(), curDataSize);
+        BlobBuilder.build(
+            chunksMetadataList, chunksDataList, crc.getValue(), curDataSize, bdecVersion);
     if (buildContext != null) {
       buildContext.stop();
     }
 
     return upload(filePath, blob, chunksMetadataList);
+  }
+
+  private Constants.ArrowBatchWriteMode getArrowBatchWriteMode() {
+    switch (bdecVersion) {
+      case ONE:
+        return Constants.ArrowBatchWriteMode.STREAM;
+      case TWO:
+        return Constants.ArrowBatchWriteMode.FILE;
+      default:
+        throw new IllegalArgumentException("Unsupported BLOB_FORMAT_VERSION: " + bdecVersion);
+    }
   }
 
   /**
@@ -577,7 +602,7 @@ class FlushService {
         blob.length,
         System.currentTimeMillis() - startTime);
 
-    return new BlobMetadata(filePath, BlobBuilder.computeMD5(blob), metadata);
+    return new BlobMetadata(filePath, BlobBuilder.computeMD5(blob), bdecVersion, metadata);
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -531,7 +531,11 @@ public class SnowflakeStreamingIngestClientInternal implements SnowflakeStreamin
                   .collect(Collectors.toList());
           if (!relevantChunks.isEmpty()) {
             retryBlobs.add(
-                new BlobMetadata(blobMetadata.getPath(), blobMetadata.getMD5(), relevantChunks));
+                new BlobMetadata(
+                    blobMetadata.getPath(),
+                    blobMetadata.getMD5(),
+                    blobMetadata.getVersion(),
+                    relevantChunks));
           }
         });
 

--- a/src/test/java/net/snowflake/ingest/TestUtils.java
+++ b/src/test/java/net/snowflake/ingest/TestUtils.java
@@ -13,6 +13,8 @@ import static net.snowflake.ingest.utils.Constants.SCHEME;
 import static net.snowflake.ingest.utils.Constants.SSL;
 import static net.snowflake.ingest.utils.Constants.USER;
 import static net.snowflake.ingest.utils.Constants.WAREHOUSE;
+import static net.snowflake.ingest.utils.ParameterProvider.BLOB_FORMAT_VERSION;
+import static net.snowflake.ingest.utils.ParameterProvider.BLOB_FORMAT_VERSION_DEFAULT;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -187,7 +189,14 @@ public class TestUtils {
     props.put(PRIVATE_KEY, privateKeyPem);
     props.put(ROLE, role);
     props.put(ACCOUNT_URL, getAccountURL());
+    props.put(BLOB_FORMAT_VERSION, getBlobFormatVersion());
     return props;
+  }
+
+  private static byte getBlobFormatVersion() {
+    return profile.has(BLOB_FORMAT_VERSION)
+        ? (byte) profile.get(BLOB_FORMAT_VERSION).asInt()
+        : BLOB_FORMAT_VERSION_DEFAULT.toByte();
   }
 
   /**

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -4,7 +4,6 @@ import static net.snowflake.ingest.utils.Constants.BLOB_CHECKSUM_SIZE_IN_BYTES;
 import static net.snowflake.ingest.utils.Constants.BLOB_CHUNK_METADATA_LENGTH_SIZE_IN_BYTES;
 import static net.snowflake.ingest.utils.Constants.BLOB_EXTENSION_TYPE;
 import static net.snowflake.ingest.utils.Constants.BLOB_FILE_SIZE_SIZE_IN_BYTES;
-import static net.snowflake.ingest.utils.Constants.BLOB_FORMAT_VERSION;
 import static net.snowflake.ingest.utils.Constants.BLOB_NO_HEADER;
 import static net.snowflake.ingest.utils.Constants.BLOB_TAG_SIZE_IN_BYTES;
 import static net.snowflake.ingest.utils.Constants.BLOB_VERSION_SIZE_IN_BYTES;
@@ -35,6 +34,7 @@ import javax.crypto.NoSuchPaddingException;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.Cryptor;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.ParameterProvider;
@@ -516,7 +516,9 @@ public class FlushServiceTest {
 
     chunksMetadataList.add(chunkMetadata);
 
-    byte[] blob = BlobBuilder.build(chunksMetadataList, chunksDataList, checksum, dataSize);
+    final Constants.BdecVerion bdecVersion = ParameterProvider.BLOB_FORMAT_VERSION_DEFAULT;
+    byte[] blob =
+        BlobBuilder.build(chunksMetadataList, chunksDataList, checksum, dataSize, bdecVersion);
 
     // Read the blob byte array back to valid the behavior
     InputStream input = new ByteArrayInputStream(blob);
@@ -528,8 +530,7 @@ public class FlushServiceTest {
               Arrays.copyOfRange(blob, offset, offset += BLOB_TAG_SIZE_IN_BYTES),
               StandardCharsets.UTF_8));
       Assert.assertEquals(
-          BLOB_FORMAT_VERSION,
-          Arrays.copyOfRange(blob, offset, offset += BLOB_VERSION_SIZE_IN_BYTES)[0]);
+          bdecVersion, Arrays.copyOfRange(blob, offset, offset += BLOB_VERSION_SIZE_IN_BYTES)[0]);
       long totalSize =
           ByteBuffer.wrap(Arrays.copyOfRange(blob, offset, offset += BLOB_FILE_SIZE_SIZE_IN_BYTES))
               .getLong();

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -618,6 +618,7 @@ public class SnowflakeStreamingIngestClientTest {
         result.get(0).getChunks().get(0).getChannels().stream()
             .map(c -> c.getChannelName())
             .collect(Collectors.toSet()));
+    Assert.assertEquals(ParameterProvider.BLOB_FORMAT_VERSION_DEFAULT, result.get(0).getVersion());
   }
 
   @Test


### PR DESCRIPTION
[SNOW-612516](https://snowflakecomputing.atlassian.net/browse/SNOW-612516)

# Problem

The high level problem is that even if the mixed table has 100 columns and a user needs to read only one from a BDEC file, the query scanner will always read and parse the whole file.

# New format

The BDEC file format is currently based on the Arrow Stream format (ArrowStreamWriter in Java Arrow client). This means that the arrow record batches are just written into the file with their own schema headers. The XP scan code has to use the same type of stream reader. The problem is that the stream read API does not have random access methods to read individual columns. This results in loading the whole file every time.

FlushService in client currently uses ArrowStreamWriter to write record batches. The Java Arrow library also provides an ArrowFileWriter that appends the footer at the end for subsequent random column seek.

# Compression

The Java Arrow client supports writing LZ4 and ZSTD compressed columns in VectorUnloader. Currently the Arrow vectors in client are serialised into ArrowRecordBatches and written with ArrowStreamWriter/ArrowWriter that also uses a private hidden VectorUnloader. Both ArrowStreamWriter and ArrowFileWriter extend ArrowWriter. The ArrowWriter does not forward the compression config API from the hidden VectorUnloader. Hence, FlushService cannot currently configure the compression that is set to no compression in ArrowWriter’s VectorUnloader.

The proposal here is to implement a custom ArrowFileWriter that configures its own VectorUnloader with compression. This also allows to fix some subtle Arrow buffer allocation issues with the custom compression implementation.

The compression rate comparison, based on `StreamingIngestIT#testDataTypes`, total size of produced files:
- No compression: 27Mb
- GZIP: 17Mb, compression time: ~2000 milliseconds
- New ZSTD: 16Mb - slightly better than GZIP, compression time: ~100-200 milliseconds

# Format version

The client SDK currently has a blob file version, hardcoded in constants to zero. It is not used anywhere except the BDEC header that is not written.

The client can send the version to GS in BlobMetadata / BlobDTO. The StreamingResource can send to the buffering service in chunk messages and then the buffering service can add the version to the queued BlobChunkDTOs.


See also design doc in JIRA.