### PR TITLE
NO-SNOW check the retry logic with millis instead of ms and seconds

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
@@ -111,7 +111,8 @@ class RegisterService {
           List<BlobMetadata> blobs = new ArrayList<>();
           long startTime = System.currentTimeMillis();
           while (idx < oldList.size()
-              && System.currentTimeMillis() - startTime <= BLOB_UPLOAD_TIMEOUT_IN_SEC * 2) {
+              && System.currentTimeMillis() - startTime
+                  <= TimeUnit.SECONDS.toMillis(BLOB_UPLOAD_TIMEOUT_IN_SEC * 2)) {
             Pair<FlushService.BlobData, CompletableFuture<BlobMetadata>> futureBlob =
                 oldList.get(idx);
             try {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import net.snowflake.ingest.utils.Pair;
 import org.junit.Assert;
@@ -27,6 +28,15 @@ public class RegisterServiceTest {
     Assert.assertEquals(0, errorBlobs.size());
   }
 
+  /**
+   * Note that this exception will not perform retries since the completeExceptionally throws the
+   * exception by wrapping inside ExecutionException. Check method {@link
+   * CompletableFuture#get(long, TimeUnit)} javadocs
+   *
+   * <p>The check for retries checks the original exception instead of the exception.getCause()
+   *
+   * @throws Exception
+   */
   @Test
   public void testRegisterServiceTimeoutException() throws Exception {
     SnowflakeStreamingIngestClientInternal client =

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
@@ -1,5 +1,7 @@
 package net.snowflake.ingest.streaming.internal;
 
+import static net.snowflake.ingest.utils.Constants.BLOB_UPLOAD_TIMEOUT_IN_SEC;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -9,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import net.snowflake.ingest.utils.Pair;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class RegisterServiceTest {
@@ -49,6 +52,42 @@ public class RegisterServiceTest {
             CompletableFuture.completedFuture(new BlobMetadata("path", "md5", null)));
     CompletableFuture future = new CompletableFuture();
     future.completeExceptionally(new TimeoutException());
+    Pair<FlushService.BlobData, CompletableFuture<BlobMetadata>> blobFuture2 =
+        new Pair<>(new FlushService.BlobData("fail", new ArrayList<>()), future);
+    rs.addBlobs(Arrays.asList(blobFuture1, blobFuture2));
+    Assert.assertEquals(2, rs.getBlobsList().size());
+    try {
+      List<FlushService.BlobData> errorBlobs = rs.registerBlobs(null);
+      Assert.assertEquals(0, rs.getBlobsList().size());
+      Assert.assertEquals(1, errorBlobs.size());
+      Assert.assertEquals("fail", errorBlobs.get(0).getFilePath());
+    } catch (Exception e) {
+      Assert.fail("The timeout exception should be caught in registerBlobs");
+    }
+  }
+
+  // Ignore since it runs for BLOB_UPLOAD_TIMEOUT_IN_SEC * BLOB_UPLOAD_MAX_RETRY_COUNT
+  @Ignore
+  @Test
+  public void testRegisterServiceTimeoutException_testRetries() throws Exception {
+    SnowflakeStreamingIngestClientInternal client =
+        new SnowflakeStreamingIngestClientInternal("client");
+    RegisterService rs = new RegisterService(client, true);
+
+    Pair<FlushService.BlobData, CompletableFuture<BlobMetadata>> blobFuture1 =
+        new Pair<>(
+            new FlushService.BlobData("success", new ArrayList<>()),
+            CompletableFuture.completedFuture(new BlobMetadata("path", "md5", null)));
+    CompletableFuture future = new CompletableFuture();
+    future.thenRunAsync(
+        () -> {
+          try {
+            Thread.sleep(TimeUnit.SECONDS.toMillis(BLOB_UPLOAD_TIMEOUT_IN_SEC) + 5);
+          } catch (InterruptedException e) {
+            e.printStackTrace();
+          }
+          return;
+        });
     Pair<FlushService.BlobData, CompletableFuture<BlobMetadata>> blobFuture2 =
         new Pair<>(new FlushService.BlobData("fail", new ArrayList<>()), future);
     rs.addBlobs(Arrays.asList(blobFuture1, blobFuture2));


### PR DESCRIPTION
Found out that it was not retrying while debugging streaming ingest with Client SDK. 

- Existing test which doesnt validate the retry mechanism though! 
- Added a test which checks the retries logic. (Ignored)