### PR TITLE
@snow SNOW-633432 Parquet file generator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,46 @@
                                     <pattern>org.apache</pattern>
                                     <shadedPattern>${shadeBase}.apache</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>com.ctc.wstx</pattern>
+                                    <shadedPattern>${shadeBase}.com.ctc.wstx</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>edu.umd.cs.findbugs.annotations</pattern>
+                                    <shadedPattern>${shadeBase}.edu.umd.cs.findbugs.annotations</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.jcraft.jsch</pattern>
+                                    <shadedPattern>${shadeBase}.com.jcraft.jsch</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.microsoft.sqlserver.jdbc</pattern>
+                                    <shadedPattern>${shadeBase}.com.microsoft.sqlserver.jdbc</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>contribs.mx</pattern>
+                                    <shadedPattern>${shadeBase}.contribs.mx</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.zaxxer.hikari</pattern>
+                                    <shadedPattern>${shadeBase}.com.zaxxer.hikari</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.squareup.okhttp</pattern>
+                                    <shadedPattern>${shadeBase}.com.squareup.okhttp</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.thoughtworks.paranamer</pattern>
+                                    <shadedPattern>${shadeBase}.com.thoughtworks.paranamer</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.jamesmurty.utils</pattern>
+                                    <shadedPattern>${shadeBase}.com.jamesmurty.utils</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.iharder.base64</pattern>
+                                    <shadedPattern>${shadeBase}.net.iharder.base64</shadedPattern>
+                                </relocation>
                             </relocations>
                             <filters>
                                 <filter>

--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,12 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/pom.xml
+++ b/pom.xml
@@ -307,16 +307,12 @@
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-hadoop</artifactId>
             <version>1.11.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-mapreduce-client-core</artifactId>
-            <version>${hadoop.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-client</artifactId>
-            <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -326,6 +322,26 @@
                 <exclusion>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet.jsp</groupId>
+                    <artifactId>jsp-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -389,46 +389,6 @@
                                     <pattern>org.apache</pattern>
                                     <shadedPattern>${shadeBase}.apache</shadedPattern>
                                 </relocation>
-                                <relocation>
-                                    <pattern>com.ctc.wstx</pattern>
-                                    <shadedPattern>${shadeBase}.com.ctc.wstx</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>edu.umd.cs.findbugs.annotations</pattern>
-                                    <shadedPattern>${shadeBase}.edu.umd.cs.findbugs.annotations</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.jcraft.jsch</pattern>
-                                    <shadedPattern>${shadeBase}.com.jcraft.jsch</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.microsoft.sqlserver.jdbc</pattern>
-                                    <shadedPattern>${shadeBase}.com.microsoft.sqlserver.jdbc</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>contribs.mx</pattern>
-                                    <shadedPattern>${shadeBase}.contribs.mx</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.zaxxer.hikari</pattern>
-                                    <shadedPattern>${shadeBase}.com.zaxxer.hikari</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.squareup.okhttp</pattern>
-                                    <shadedPattern>${shadeBase}.com.squareup.okhttp</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.thoughtworks.paranamer</pattern>
-                                    <shadedPattern>${shadeBase}.com.thoughtworks.paranamer</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.jamesmurty.utils</pattern>
-                                    <shadedPattern>${shadeBase}.com.jamesmurty.utils</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>net.iharder.base64</pattern>
-                                    <shadedPattern>${shadeBase}.net.iharder.base64</shadedPattern>
-                                </relocation>
                             </relocations>
                             <filters>
                                 <filter>

--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,22 @@
                     <groupId>javax.servlet.jsp</groupId>
                     <artifactId>jsp-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <jacoco.skip.instrument>true</jacoco.skip.instrument>
         <jacoco.version>0.8.5</jacoco.version>
         <arrow.version>9.0.0</arrow.version>
+        <hadoop.version>2.10.1</hadoop.version>
     </properties>
 
     <build>
@@ -300,6 +301,27 @@
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-compression</artifactId>
             <version>${arrow.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop</artifactId>
+            <version>1.11.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/scripts/check_content.sh
+++ b/scripts/check_content.sh
@@ -5,7 +5,20 @@
 set -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v mime.types | grep -v project.properties | grep -v -E "javax" | grep -v -E "^org/" | grep -v -E "^com/google" | grep -v -E "^com/sun" | grep -v "log4j.properties" | grep -v "git.properties" | grep -v "io/" | grep -v "codegen/" | grep -v "com/codahale/" | grep -v "com/ibm/" | grep -v "LICENSE" | grep -v "aix/" | grep -v "darwin/" | grep -v "win/" | grep -v "freebsd/" | grep -v "linux/" | grep -v "com/github/"; then
+if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" \
+    | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v mime.types \
+    | grep -v project.properties | grep -v -E "javax" | grep -v -E "^org/" | grep -v -E "^com/google" \
+    | grep -v -E "^com/sun" | grep -v "log4j.properties" | grep -v "git.properties" | grep -v "io/" \
+    | grep -v "codegen/" | grep -v "com/codahale/" | grep -v "com/ibm/" | grep -v "LICENSE" | grep -v "aix/" \
+    | grep -v "darwin/" | grep -v "win/" | grep -v "freebsd/" | grep -v "linux/" | grep -v "com/github/" \
+    | grep -v -E "shaded/" | grep -v "webapps/"  | grep -v "microsoft/" | grep -v -E "^core-default.xml" \
+    | grep -v "yarn-version-info.properties" | grep -v "yarn-version-info.properties" \
+    | grep -v "common-version-info.properties" | grep -v "LocalizedFormats_fr.properties" \
+    | grep -v "org.apache.hadoop.application-classloader.properties" | grep -v "assets/" | grep -v "ehcache-core.xsd" \
+    | grep -v "ehcache-107ext.xsd" | grep -v "parquet.thrift" | grep -v "mapred-default.xml" \
+    | grep -v "yarn-default.xml" | grep -v ".keep"  | grep -v "NOTICE" | grep -v "digesterRules.xml" \
+    | grep -v "properties.dtd" | grep -v "PropertyList-1.0.dtd"  \
+    ; then
   echo "[ERROR] Ingest SDK jar includes class not under the snowflake namespace"
   exit 1
 fi

--- a/scripts/check_content.sh
+++ b/scripts/check_content.sh
@@ -11,7 +11,10 @@ if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v
     | grep -v -E "^com/sun" | grep -v "log4j.properties" | grep -v "git.properties" | grep -v "io/" \
     | grep -v "codegen/" | grep -v "com/codahale/" | grep -v "com/ibm/" | grep -v "LICENSE" | grep -v "aix/" \
     | grep -v "darwin/" | grep -v "win/" | grep -v "freebsd/" | grep -v "linux/" | grep -v "com/github/" \
-    | grep -v -E "shaded/" | grep -v "webapps/"  | grep -v "microsoft/" | grep -v -E "^core-default.xml" \
+    | grep -v -E "shaded/" | grep -v "webapps/"  | grep -v "microsoft/" | grep -v "com/ctc/" \
+    | grep -v "edu/" | grep -v "com/jcraft/" | grep -v "contribs/" | grep -v "com/zaxxer/"  | grep -v "com/squareup/" \
+    | grep -v "com/thoughtworks/" | grep -v "com/jamesmurty/"  | grep -v "net/iharder/" \
+    | grep -v -E "^core-default.xml" \
     | grep -v "yarn-version-info.properties" | grep -v "yarn-version-info.properties" \
     | grep -v "common-version-info.properties" | grep -v "LocalizedFormats_fr.properties" \
     | grep -v "org.apache.hadoop.application-classloader.properties" | grep -v "assets/" | grep -v "ehcache-core.xsd" \

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -471,15 +471,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
             // vector.setSafe requires the BigDecimal input scale explicitly match its scale
             inputAsBigDecimal = inputAsBigDecimal.setScale(columnScale, RoundingMode.HALF_UP);
 
-            if (inputAsBigDecimal.abs().compareTo(BigDecimal.TEN.pow(columnPrecision - columnScale))
-                >= 0) {
-              throw new SFException(
-                  ErrorCode.INVALID_ROW,
-                  inputAsBigDecimal,
-                  String.format(
-                      "Number out of representable exclusive range of (-1e%s..1e%s)",
-                      columnPrecision - columnScale, columnPrecision - columnScale));
-            }
+            DataValidationUtil.checkValueInRange(inputAsBigDecimal, columnScale, columnPrecision);
 
             if (columnScale != 0 || physicalType == ColumnPhysicalType.SB16) {
               ((DecimalVector) vector).setSafe(curRowIndex, inputAsBigDecimal);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadata.java
@@ -14,7 +14,7 @@ import net.snowflake.ingest.utils.ParameterProvider;
 class BlobMetadata {
   private final String path;
   private final String md5;
-  final Constants.BdecVersion bdecVersion;
+  private final Constants.BdecVersion bdecVersion;
   private final List<ChunkMetadata> chunks;
 
   BlobMetadata(String path, String md5, List<ChunkMetadata> chunks) {
@@ -55,8 +55,8 @@ class BlobMetadata {
    */
   static BlobMetadata createBlobMetadata(
       String path, String md5, Constants.BdecVersion bdecVersion, List<ChunkMetadata> chunks) {
-    // TODO: Unify BlobMetadata with BlobMetadataWithBdecVersion once server side BdecVersion in
-    // production
+    // TODO SNOW-659721: Unify BlobMetadata with BlobMetadataWithBdecVersion once server side
+    // BdecVersion in production
     return bdecVersion == Constants.BdecVersion.ONE
         ? new BlobMetadata(path, md5, bdecVersion, chunks)
         : new BlobMetadataWithBdecVersion(path, md5, bdecVersion, chunks);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadata.java
@@ -14,7 +14,7 @@ import net.snowflake.ingest.utils.ParameterProvider;
 class BlobMetadata {
   private final String path;
   private final String md5;
-  private final Constants.BdecVersion bdecVersion;
+  final Constants.BdecVersion bdecVersion;
   private final List<ChunkMetadata> chunks;
 
   BlobMetadata(String path, String md5, List<ChunkMetadata> chunks) {
@@ -49,9 +49,16 @@ class BlobMetadata {
     return this.chunks;
   }
 
-  // TODO: send the bdec_version once server side supports this in production
-  //  @JsonProperty("bdec_version")
-  //  byte getVersionByte() {
-  //    return bdecVersion.toByte();
-  //  }
+  /**
+   * Create {@link BlobMetadata} in case of {@link Constants.BdecVersion#ONE} and {@link
+   * BlobMetadataWithBdecVersion} otherwise to send BDEC version to server side.
+   */
+  static BlobMetadata createBlobMetadata(
+      String path, String md5, Constants.BdecVersion bdecVersion, List<ChunkMetadata> chunks) {
+    // TODO: Unify BlobMetadata with BlobMetadataWithBdecVersion once server side BdecVersion in
+    // production
+    return bdecVersion == Constants.BdecVersion.ONE
+        ? new BlobMetadata(path, md5, bdecVersion, chunks)
+        : new BlobMetadataWithBdecVersion(path, md5, bdecVersion, chunks);
+  }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadataWithBdecVersion.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadataWithBdecVersion.java
@@ -1,0 +1,21 @@
+package net.snowflake.ingest.streaming.internal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import net.snowflake.ingest.utils.Constants;
+
+/**
+ * Same as {@link BlobMetadata} but with {@link Constants.BdecVersion} to send it to server side if
+ * the version is greater than {@link Constants.BdecVersion#ONE}.
+ */
+class BlobMetadataWithBdecVersion extends BlobMetadata {
+  BlobMetadataWithBdecVersion(
+      String path, String md5, Constants.BdecVersion bdecVersion, List<ChunkMetadata> chunks) {
+    super(path, md5, bdecVersion, chunks);
+  }
+
+  @JsonProperty("bdec_version")
+  byte getVersionByte() {
+    return bdecVersion.toByte();
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadataWithBdecVersion.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadataWithBdecVersion.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -16,6 +20,6 @@ class BlobMetadataWithBdecVersion extends BlobMetadata {
 
   @JsonProperty("bdec_version")
   byte getVersionByte() {
-    return bdecVersion.toByte();
+    return getVersion().toByte();
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
@@ -14,7 +14,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * during flush. The key is a fully qualified table name and the value is a set of channels that
  * belongs to this table
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 class ChannelCache<T> {
   // Cache to hold all the valid channels, the key for the outer map is FullyQualifiedTableName and

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -674,6 +674,17 @@ class DataValidationUtil {
         input.getClass(), "BOOLEAN", new String[] {"boolean", "Number", "String"});
   }
 
+  static void checkValueInRange(BigDecimal bigDecimalValue, int scale, int precision) {
+    if (bigDecimalValue.abs().compareTo(BigDecimal.TEN.pow(precision - scale)) >= 0) {
+      throw new SFException(
+          ErrorCode.INVALID_ROW,
+          bigDecimalValue,
+          String.format(
+              "Number out of representable exclusive range of (-1e%s..1e%s)",
+              precision - scale, precision - scale));
+    }
+  }
+
   static Set<String> allowedBooleanStringsLowerCased =
       Sets.newHashSet("1", "0", "yes", "no", "y", "n", "t", "f", "true", "false", "on", "off");
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -62,7 +62,6 @@ import org.apache.arrow.vector.VectorSchemaRoot;
  *     ParquetChunkData})
  */
 class FlushService<T> {
-  private static final long NO_ENCRYPTION_KEY_ID = 0L;
 
   // Static class to save the list of channels that are used to build a blob, which is mainly used
   // to invalidate all the channels when there is a failure

--- a/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
@@ -13,7 +13,8 @@ import java.util.Map;
  * Interface to convert {@link ChannelData} buffered in {@link RowBuffer} to the underlying format
  * implementation for faster processing.
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 public interface Flusher<T> {
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
@@ -1,0 +1,21 @@
+package net.snowflake.ingest.streaming.internal;
+
+import java.util.List;
+import java.util.Map;
+
+/** Parquet data holder to buffer rows. */
+public class ParquetChunkData {
+  final List<List<Object>> rows;
+  final Map<String, String> metadata;
+
+  /**
+   * Construct parquet data chunk.
+   *
+   * @param rows chunk row set
+   * @param metadata chunk metadata
+   */
+  public ParquetChunkData(List<List<Object>> rows, Map<String, String> metadata) {
+    this.rows = rows;
+    this.metadata = metadata;
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal;
 
 import java.util.List;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -250,22 +250,22 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
   private static class BdecWriteSupport extends WriteSupport<List<Object>> {
     MessageType schema;
     RecordConsumer recordConsumer;
-    Map<String, String> extraMetaData;
+    Map<String, String> extraMetadata;
     List<ChannelMetadata> channelsMetadataList;
 
     // TODO SNOW-672156: support specifying encodings and compression
     BdecWriteSupport(
         MessageType schema,
-        Map<String, String> extraMetaData,
+        Map<String, String> extraMetadata,
         List<ChannelMetadata> channelsMetadataList) {
       this.schema = schema;
-      this.extraMetaData = extraMetaData;
+      this.extraMetadata = extraMetadata;
       this.channelsMetadataList = channelsMetadataList;
     }
 
     @Override
     public WriteContext init(Configuration config) {
-      return new WriteContext(schema, extraMetaData);
+      return new WriteContext(schema, extraMetadata);
     }
 
     @Override

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -122,12 +122,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       ParquetWriter<List<Object>> writer =
           new BdecParquetWriterBuilder(bdecOutput, schema, metadata)
               // PARQUET_2_0 uses Encoding.DELTA_BYTE_ARRAY for byte arrays (e.g. SF sb16)
-              // server side does not support it
-              // another fix could be to use lower level column writers and custom
-              // ValuesWriterFactory
-              // that uses plain byte array encoding used by PARQUET_1_0 and supported by server
-              // side
-              // TODO: SNOW-620624
+              // server side does not support it TODO: SNOW-657238
               .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0)
               // the dictionary encoding (Encoding.*_DICTIONARY) is not supported by server side
               // scanner yet
@@ -137,6 +132,9 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
               .withWriteMode(ParquetFileWriter.Mode.CREATE)
               .build();
 
+      // We can use lower level column writers and custom ValuesWriterFactory that uses plain byte
+      // array encoding used by PARQUET_1_0 and supported by server side
+      // TODO: SNOW-672143
       for (List<Object> row : chunkRows) {
         writer.write(row);
       }
@@ -244,7 +242,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
     RecordConsumer recordConsumer;
     Map<String, String> extraMetaData;
 
-    // TODO: support specifying encodings and compression
+    // TODO SNOW-672156: support specifying encodings and compression
     BdecWriteSupport(MessageType schema, Map<String, String> extraMetaData) {
       this.schema = schema;
       this.extraMetaData = extraMetaData;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import static net.snowflake.ingest.utils.Constants.MAX_CHUNK_SIZE_IN_BYTES;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.Logging;
+import net.snowflake.ingest.utils.SFException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.api.WriteSupport;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.DelegatingPositionOutputStream;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.ParquetEncodingException;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.RecordConsumer;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+
+/**
+ * Converts {@link ChannelData} buffered in {@link RowBuffer} to the Parquet format for faster
+ * processing.
+ */
+public class ParquetFlusher implements Flusher<ParquetChunkData> {
+  private static final Logging logger = new Logging(ParquetFlusher.class);
+  private final MessageType schema;
+
+  /** Construct parquet flusher from its schema. */
+  public ParquetFlusher(MessageType schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public SerializationResult serialize(
+      List<ChannelData<ParquetChunkData>> channelsDataPerTable,
+      ByteArrayOutputStream chunkData,
+      String filePath)
+      throws IOException {
+    List<ChannelMetadata> channelsMetadataList = new ArrayList<>();
+    long rowCount = 0L;
+    SnowflakeStreamingIngestChannelInternal<ParquetChunkData> firstChannel = null;
+    Map<String, RowBufferStats> columnEpStatsMapCombined = null;
+    List<List<Object>> rows = null;
+
+    for (ChannelData<ParquetChunkData> data : channelsDataPerTable) {
+      // Create channel metadata
+      ChannelMetadata channelMetadata =
+          ChannelMetadata.builder()
+              .setOwningChannel(data.getChannel())
+              .setRowSequencer(data.getRowSequencer())
+              .setOffsetToken(data.getOffsetToken())
+              .build();
+      // Add channel metadata to the metadata list
+      channelsMetadataList.add(channelMetadata);
+
+      logger.logDebug(
+          "Parquet Flusher: Start building channel={}, rowCount={}, bufferSize={} in blob={}",
+          data.getChannel().getFullyQualifiedName(),
+          data.getRowCount(),
+          data.getBufferSize(),
+          filePath);
+
+      if (rows == null) {
+        columnEpStatsMapCombined = data.getColumnEps();
+        rows = new ArrayList<>();
+        firstChannel = data.getChannel();
+      } else {
+        // This method assumes that channelsDataPerTable is grouped by table. We double check
+        // here and throw an error if the assumption is violated
+        if (!data.getChannel()
+            .getFullyQualifiedTableName()
+            .equals(firstChannel.getFullyQualifiedTableName())) {
+          throw new SFException(ErrorCode.INVALID_DATA_IN_CHUNK);
+        }
+
+        columnEpStatsMapCombined =
+            ChannelData.getCombinedColumnStatsMap(columnEpStatsMapCombined, data.getColumnEps());
+      }
+      rows.addAll(data.getVectors().rows);
+
+      rowCount += data.getRowCount();
+
+      logger.logDebug(
+          "Parquet Flusher: Finish building channel={}, rowCount={}, bufferSize={} in blob={}",
+          data.getChannel().getFullyQualifiedName(),
+          data.getRowCount(),
+          data.getBufferSize(),
+          filePath);
+    }
+
+    Map<String, String> metadata = channelsDataPerTable.get(0).getVectors().metadata;
+
+    flushToParquetBdecChunk(chunkData, rows, metadata);
+    return new SerializationResult(channelsMetadataList, columnEpStatsMapCombined, rowCount);
+  }
+
+  /**
+   * Flushes a parquet row chunk to the given BDEC output stream.
+   *
+   * @param bdecOutput BDEC output stream
+   * @param chunkRows chunk rows
+   * @param metadata chunk metadata
+   * @throws IOException thrown from Parquet library in case of writing problems
+   */
+  private void flushToParquetBdecChunk(
+      ByteArrayOutputStream bdecOutput, List<List<Object>> chunkRows, Map<String, String> metadata)
+      throws IOException {
+    try {
+      ParquetWriter<List<Object>> writer =
+          new BdecParquetWriterBuilder(bdecOutput, schema, metadata)
+              // PARQUET_2_0 uses Encoding.DELTA_BYTE_ARRAY for byte arrays (e.g. SF sb16)
+              // server side does not support it
+              // another fix could be to use lower level column writers and custom
+              // ValuesWriterFactory
+              // that uses plain byte array encoding used by PARQUET_1_0 and supported by server
+              // side
+              // TODO: SNOW-620624
+              .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0)
+              // the dictionary encoding (Encoding.*_DICTIONARY) is not supported by server side
+              // scanner yet
+              .withDictionaryEncoding(false)
+              .enableValidation()
+              .withCompressionCodec(CompressionCodecName.GZIP)
+              .withWriteMode(ParquetFileWriter.Mode.CREATE)
+              .build();
+
+      for (List<Object> row : chunkRows) {
+        writer.write(row);
+      }
+      writer.close();
+    } catch (Throwable t) {
+      logger.logError("Parquet Flusher: failed to write", t);
+      throw t;
+    }
+  }
+
+  /**
+   * A parquet specific write builder.
+   *
+   * <p>This class is implemented as parquet library API requires, mostly to provide {@link
+   * BdecWriteSupport} implementation.
+   */
+  private static class BdecParquetWriterBuilder
+      extends ParquetWriter.Builder<List<Object>, BdecParquetWriterBuilder> {
+    private final MessageType schema;
+    private final Map<String, String> extraMetaData;
+
+    protected BdecParquetWriterBuilder(
+        ByteArrayOutputStream stream, MessageType schema, Map<String, String> extraMetaData) {
+      super(new ByteArrayOutputFile(stream));
+      this.schema = schema;
+      this.extraMetaData = extraMetaData;
+    }
+
+    @Override
+    protected BdecParquetWriterBuilder self() {
+      return this;
+    }
+
+    @Override
+    protected WriteSupport<List<Object>> getWriteSupport(Configuration conf) {
+      return new BdecWriteSupport(schema, extraMetaData);
+    }
+  }
+
+  /**
+   * A parquet specific file output implementation.
+   *
+   * <p>This class is implemented as parquet library API requires, mostly to create our {@link
+   * ByteArrayDelegatingPositionOutputStream} implementation.
+   */
+  private static class ByteArrayOutputFile implements OutputFile {
+    private final ByteArrayOutputStream stream;
+
+    private ByteArrayOutputFile(ByteArrayOutputStream stream) {
+      this.stream = stream;
+    }
+
+    @Override
+    public PositionOutputStream create(long blockSizeHint) throws IOException {
+      stream.reset();
+      return new ByteArrayDelegatingPositionOutputStream(stream);
+    }
+
+    @Override
+    public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
+      return create(blockSizeHint);
+    }
+
+    @Override
+    public boolean supportsBlockSize() {
+      return false;
+    }
+
+    @Override
+    public long defaultBlockSize() {
+      return (int) MAX_CHUNK_SIZE_IN_BYTES;
+    }
+  }
+
+  /**
+   * A parquet specific output stream implementation.
+   *
+   * <p>This class is implemented as parquet library API requires, mostly to wrap our BDEC output
+   * {@link ByteArrayOutputStream}.
+   */
+  private static class ByteArrayDelegatingPositionOutputStream
+      extends DelegatingPositionOutputStream {
+    private final ByteArrayOutputStream stream;
+
+    public ByteArrayDelegatingPositionOutputStream(ByteArrayOutputStream stream) {
+      super(stream);
+      this.stream = stream;
+    }
+
+    @Override
+    public long getPos() {
+      return stream.size();
+    }
+  }
+
+  /**
+   * A parquet specific write support implementation.
+   *
+   * <p>This class is implemented as parquet library API requires, mostly to serialize user column
+   * values depending on type into Parquet {@link RecordConsumer} in {@link
+   * BdecWriteSupport#write(List)}.
+   */
+  private static class BdecWriteSupport extends WriteSupport<List<Object>> {
+    MessageType schema;
+    RecordConsumer recordConsumer;
+    Map<String, String> extraMetaData;
+
+    // TODO: support specifying encodings and compression
+    BdecWriteSupport(MessageType schema, Map<String, String> extraMetaData) {
+      this.schema = schema;
+      this.extraMetaData = extraMetaData;
+    }
+
+    @Override
+    public WriteContext init(Configuration config) {
+      return new WriteContext(schema, extraMetaData);
+    }
+
+    @Override
+    public void prepareForWrite(RecordConsumer recordConsumer) {
+      this.recordConsumer = recordConsumer;
+    }
+
+    @Override
+    public void write(List<Object> values) {
+      List<ColumnDescriptor> cols = schema.getColumns();
+      if (values.size() != cols.size()) {
+        throw new ParquetEncodingException(
+            "Invalid input data. Expecting "
+                + cols.size()
+                + " columns. Input had "
+                + values.size()
+                + " columns ("
+                + cols
+                + ") : "
+                + values);
+      }
+
+      recordConsumer.startMessage();
+      for (int i = 0; i < cols.size(); ++i) {
+        Object val = values.get(i);
+        // val.length() == 0 indicates a NULL value.
+        if (val != null) {
+          String fieldName = cols.get(i).getPath()[0];
+          recordConsumer.startField(fieldName, i);
+          PrimitiveType.PrimitiveTypeName typeName =
+              cols.get(i).getPrimitiveType().getPrimitiveTypeName();
+          switch (typeName) {
+            case BOOLEAN:
+              recordConsumer.addBoolean((boolean) val);
+              break;
+            case FLOAT:
+              recordConsumer.addFloat((float) val);
+              break;
+            case DOUBLE:
+              recordConsumer.addDouble((double) val);
+              break;
+            case INT32:
+              recordConsumer.addInteger((int) val);
+              break;
+            case INT64:
+              recordConsumer.addLong((long) val);
+              break;
+            case BINARY:
+              recordConsumer.addBinary(Binary.fromString((String) val));
+              break;
+            case FIXED_LEN_BYTE_ARRAY:
+              Binary binary = Binary.fromConstantByteArray((byte[]) val);
+              recordConsumer.addBinary(binary);
+              break;
+            default:
+              throw new ParquetEncodingException(
+                  "Unsupported column type: " + cols.get(i).getPrimitiveType());
+          }
+          recordConsumer.endField(fieldName, i);
+        }
+      }
+      recordConsumer.endMessage();
+    }
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -10,7 +10,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -18,16 +17,12 @@ import java.util.Set;
 import net.snowflake.client.jdbc.internal.google.common.collect.Sets;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Constants;
-import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.Pair;
-import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.column.ColumnDescriptor;
-import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
-import org.apache.parquet.schema.Types;
 
 /**
  * The buffer in the Streaming Ingest channel that holds the un-flushed rows, these rows will be
@@ -36,10 +31,6 @@ import org.apache.parquet.schema.Types;
 public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   private static final Logging logger = new Logging(ParquetRowBuffer.class);
 
-  private static final Set<ColumnPhysicalType> TIME_SUPPORTED_PHYSICAL_TYPES =
-      new HashSet<>(Arrays.asList(ColumnPhysicalType.SB4, ColumnPhysicalType.SB8));
-  private static final Set<ColumnPhysicalType> TIMESTAMP_SUPPORTED_PHYSICAL_TYPES =
-      new HashSet<>(Arrays.asList(ColumnPhysicalType.SB8, ColumnPhysicalType.SB16));
   private static final String PARQUET_MESSAGE_TYPE_NAME = "bdec";
 
   private final Map<String, Pair<ColumnMetadata, Integer>> fieldIndex;
@@ -72,8 +63,10 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
     // precision
     int id = 1;
     for (ColumnMetadata column : columns) {
-      Type type = getColumnParquetType(column, id);
-      parquetTypes.add(type);
+      ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+          ParquetTypeGenerator.generateColumnParquetTypeInfo(column, id);
+      parquetTypes.add(typeInfo.getParquetType());
+      this.metadata.putAll(typeInfo.getMetadata());
       fieldIndex.put(column.getName(), new Pair<>(column, parquetTypes.size() - 1));
       if (!column.getNullable()) {
         addNonNullableFieldName(column.getName());
@@ -87,244 +80,6 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       id++;
     }
     schema = new MessageType(PARQUET_MESSAGE_TYPE_NAME, parquetTypes);
-  }
-
-  /**
-   * Get the column parquet type from the metadata received from server side.
-   *
-   * @param column column metadata
-   * @return column parquet type
-   */
-  private Type getColumnParquetType(ColumnMetadata column, int id) {
-    Type parquetType;
-    String name = column.getName();
-
-    ColumnPhysicalType physicalType;
-    ColumnLogicalType logicalType;
-    try {
-      physicalType = ColumnPhysicalType.valueOf(column.getPhysicalType());
-      logicalType = ColumnLogicalType.valueOf(column.getLogicalType());
-    } catch (IllegalArgumentException e) {
-      throw new SFException(
-          ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
-    }
-
-    this.metadata.put(
-        Integer.toString(id), logicalType.getOrdinal() + "," + physicalType.getOrdinal());
-
-    // Parquet Type.Repetition in general supports repeated values for the same row column, like a
-    // list of values.
-    // This generator uses only
-    // either 0 or 1 value for nullable data type (OPTIONAL: 0 or none value if it is null)
-    // or exactly 1 value for non-nullable data type (REQUIRED)
-    Type.Repetition repetition =
-        column.getNullable() ? Type.Repetition.OPTIONAL : Type.Repetition.REQUIRED;
-
-    // Handle differently depends on the column logical and physical types
-    switch (logicalType) {
-      case FIXED:
-        parquetType = getFixedColumnParquetType(column, id, physicalType, repetition);
-        break;
-      case ARRAY:
-      case OBJECT:
-      case VARIANT:
-        // mark the column metadata as being an object json for the server side scanner
-        this.metadata.put(id + ":obj_enc", "1");
-        // parquetType is same as the next one
-      case ANY:
-      case CHAR:
-      case TEXT:
-      case BINARY:
-        parquetType =
-            Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition)
-                .as(LogicalTypeAnnotation.stringType())
-                .id(id)
-                .named(name);
-        break;
-      case TIMESTAMP_LTZ:
-      case TIMESTAMP_NTZ:
-      case TIMESTAMP_TZ:
-        parquetType =
-            getTimeColumnParquetType(
-                column.getScale(),
-                physicalType,
-                logicalType,
-                TIMESTAMP_SUPPORTED_PHYSICAL_TYPES,
-                repetition,
-                id,
-                name);
-        break;
-      case DATE:
-        parquetType =
-            Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
-                .as(LogicalTypeAnnotation.dateType())
-                .id(id)
-                .named(name);
-        break;
-      case TIME:
-        parquetType =
-            getTimeColumnParquetType(
-                column.getScale(),
-                physicalType,
-                logicalType,
-                TIME_SUPPORTED_PHYSICAL_TYPES,
-                repetition,
-                id,
-                name);
-        break;
-      case BOOLEAN:
-        parquetType =
-            Types.primitive(PrimitiveType.PrimitiveTypeName.BOOLEAN, repetition).id(id).named(name);
-        break;
-      case REAL:
-        parquetType =
-            Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, repetition).id(id).named(name);
-        break;
-      default:
-        throw new SFException(
-            ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
-    }
-
-    return parquetType;
-  }
-
-  /**
-   * Get the parquet type for column of Snowflake FIXED logical type.
-   *
-   * @param column column metadata
-   * @param id column id in Snowflake table schema
-   * @param physicalType Snowflake physical type of column
-   * @param repetition parquet repetition type of column
-   * @return column parquet type
-   */
-  private Type getFixedColumnParquetType(
-      ColumnMetadata column, int id, ColumnPhysicalType physicalType, Type.Repetition repetition) {
-    String name = column.getName();
-    // the LogicalTypeAnnotation.DecimalLogicalTypeAnnotation is used by server side scanner
-    // to discover data type scale and precision
-    LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimalLogicalTypeAnnotation =
-        column.getScale() != null && column.getPrecision() != null
-            ? LogicalTypeAnnotation.DecimalLogicalTypeAnnotation.decimalType(
-                column.getScale(), column.getPrecision())
-            : null;
-    Type parquetType;
-    if ((column.getScale() != null && column.getScale() != 0)
-        || physicalType == ColumnPhysicalType.SB16) {
-      parquetType =
-          Types.primitive(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, repetition)
-              .length(16)
-              .as(decimalLogicalTypeAnnotation)
-              .id(id)
-              .named(name);
-    } else {
-      switch (physicalType) {
-        case SB1:
-        case SB2:
-        case SB4:
-          parquetType =
-              Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
-                  .as(decimalLogicalTypeAnnotation)
-                  .id(id)
-                  .length(4)
-                  .named(name);
-          break;
-        case SB8:
-          parquetType =
-              Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition)
-                  .as(decimalLogicalTypeAnnotation)
-                  .id(id)
-                  .length(8)
-                  .named(name);
-          break;
-        default:
-          throw new SFException(
-              ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
-      }
-    }
-    return parquetType;
-  }
-
-  /**
-   * Get the parquet type for column of a Snowflake time logical type.
-   *
-   * @param scale column scale
-   * @param physicalType Snowflake physical type of column
-   * @param logicalType Snowflake logical type of column
-   * @param supportedPhysicalTypes supported Snowflake physical types for the given column
-   * @param repetition parquet repetition type of column
-   * @param id column id in Snowflake table schema
-   * @param name column name
-   * @return column parquet type
-   */
-  private static Type getTimeColumnParquetType(
-      Integer scale,
-      ColumnPhysicalType physicalType,
-      ColumnLogicalType logicalType,
-      Set<ColumnPhysicalType> supportedPhysicalTypes,
-      Type.Repetition repetition,
-      int id,
-      String name) {
-    if (scale == null || scale > 9 || scale < 0 || !supportedPhysicalTypes.contains(physicalType)) {
-      throw new SFException(
-          ErrorCode.UNKNOWN_DATA_TYPE,
-          "Data type: " + logicalType + ", " + physicalType + ", scale: " + scale);
-    }
-    LogicalTypeAnnotation.TimeUnit timeUnit = getTimeUnitFromScale(scale);
-
-    PrimitiveType.PrimitiveTypeName type = getTimePrimitiveType(physicalType);
-    if (physicalType == ColumnPhysicalType.SB16) {
-      LogicalTypeAnnotation typeAnnotation = LogicalTypeAnnotation.decimalType(scale, 38);
-      return Types.primitive(type, repetition).as(typeAnnotation).length(16).id(id).named(name);
-    } else {
-      LogicalTypeAnnotation typeAnnotation =
-          logicalType == ColumnLogicalType.TIME
-              ? LogicalTypeAnnotation.timeType(false, timeUnit)
-              : LogicalTypeAnnotation.timestampType(false, timeUnit);
-      return Types.primitive(type, repetition).as(typeAnnotation).id(id).named(name);
-    }
-  }
-
-  /**
-   * Get the parquet primitive type name for column of a Snowflake time logical type.
-   *
-   * @param physicalType Snowflake physical type of column
-   * @return column parquet primitive type name
-   */
-  private static PrimitiveType.PrimitiveTypeName getTimePrimitiveType(
-      ColumnPhysicalType physicalType) {
-    PrimitiveType.PrimitiveTypeName type;
-    switch (physicalType) {
-      case SB4:
-        type = PrimitiveType.PrimitiveTypeName.INT32;
-        break;
-      case SB8:
-        type = PrimitiveType.PrimitiveTypeName.INT64;
-        break;
-      case SB16:
-        type = PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
-        break;
-      default:
-        throw new UnsupportedOperationException("Time physical type: " + physicalType);
-    }
-    return type;
-  }
-
-  /**
-   * Get the parquet time unit for column of a Snowflake time logical type.
-   *
-   * @param scale Snowflake column scale
-   * @return column parquet time unit
-   */
-  private static LogicalTypeAnnotation.TimeUnit getTimeUnitFromScale(int scale) {
-    LogicalTypeAnnotation.TimeUnit timeUnit;
-    if (scale <= 3) {
-      timeUnit = LogicalTypeAnnotation.TimeUnit.MILLIS;
-    } else if (scale <= 6) {
-      timeUnit = LogicalTypeAnnotation.TimeUnit.MICROS;
-    } else {
-      timeUnit = LogicalTypeAnnotation.TimeUnit.NANOS;
-    }
-    return timeUnit;
   }
 
   @Override

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import net.snowflake.client.jdbc.internal.google.common.collect.Sets;
+import net.snowflake.ingest.streaming.OpenChannelRequest;
+import net.snowflake.ingest.utils.Constants;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.Logging;
+import net.snowflake.ingest.utils.Pair;
+import net.snowflake.ingest.utils.SFException;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
+
+/**
+ * The buffer in the Streaming Ingest channel that holds the un-flushed rows, these rows will be
+ * converted to Parquet format for faster processing
+ */
+public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
+  private static final Logging logger = new Logging(ParquetRowBuffer.class);
+
+  private static final Set<ColumnPhysicalType> TIME_SUPPORTED_PHYSICAL_TYPES =
+      new HashSet<>(Arrays.asList(ColumnPhysicalType.SB4, ColumnPhysicalType.SB8));
+  private static final Set<ColumnPhysicalType> TIMESTAMP_SUPPORTED_PHYSICAL_TYPES =
+      new HashSet<>(Arrays.asList(ColumnPhysicalType.SB8, ColumnPhysicalType.SB16));
+  private static final String PARQUET_MESSAGE_TYPE_NAME = "bdec";
+
+  private final Map<String, Pair<ColumnMetadata, Integer>> fieldIndex;
+  private final Map<String, String> metadata;
+  private final List<List<Object>> data;
+  private final List<List<Object>> tempData;
+
+  private MessageType schema;
+
+  /**
+   * Construct a ParquetRowBuffer object
+   *
+   * @param channel client channel
+   */
+  ParquetRowBuffer(SnowflakeStreamingIngestChannelInternal<ParquetChunkData> channel) {
+    super(channel);
+    fieldIndex = new HashMap<>();
+    metadata = new HashMap<>();
+    data = new ArrayList<>();
+    tempData = new ArrayList<>();
+  }
+
+  @Override
+  public void setupSchema(List<ColumnMetadata> columns) {
+    fieldIndex.clear();
+    metadata.clear();
+    List<Type> parquetTypes = new ArrayList<>();
+    // Snowflake column id that corresponds to the order in 'columns' received from server
+    // id is required to pack column metadata for the server scanner, e.g. decimal scale and
+    // precision
+    int id = 1;
+    for (ColumnMetadata column : columns) {
+      Type type = getColumnParquetType(column, id);
+      parquetTypes.add(type);
+      fieldIndex.put(column.getName(), new Pair<>(column, parquetTypes.size() - 1));
+      if (!column.getNullable()) {
+        addNonNullableFieldName(column.getName());
+      }
+      this.statsMap.put(column.getName(), new RowBufferStats(column.getCollation()));
+
+      if (this.owningChannel.getOnErrorOption() == OpenChannelRequest.OnErrorOption.ABORT) {
+        this.tempStatsMap.put(column.getName(), new RowBufferStats(column.getCollation()));
+      }
+
+      id++;
+    }
+    schema = new MessageType(PARQUET_MESSAGE_TYPE_NAME, parquetTypes);
+  }
+
+  /**
+   * Get the column parquet type from the metadata received from server side.
+   *
+   * @param column column metadata
+   * @return column parquet type
+   */
+  private Type getColumnParquetType(ColumnMetadata column, int id) {
+    Type parquetType;
+    String name = column.getName();
+
+    ColumnPhysicalType physicalType;
+    ColumnLogicalType logicalType;
+    try {
+      physicalType = ColumnPhysicalType.valueOf(column.getPhysicalType());
+      logicalType = ColumnLogicalType.valueOf(column.getLogicalType());
+    } catch (IllegalArgumentException e) {
+      throw new SFException(
+          ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
+    }
+
+    this.metadata.put(
+        Integer.toString(id), logicalType.getOrdinal() + "," + physicalType.getOrdinal());
+
+    // Parquet Type.Repetition in general supports repeated values for the same row column, like a
+    // list of values.
+    // This generator uses only
+    // either 0 or 1 value for nullable data type (OPTIONAL: 0 or none value if it is null)
+    // or exactly 1 value for non-nullable data type (REQUIRED)
+    Type.Repetition repetition =
+        column.getNullable() ? Type.Repetition.OPTIONAL : Type.Repetition.REQUIRED;
+
+    // Handle differently depends on the column logical and physical types
+    switch (logicalType) {
+      case FIXED:
+        parquetType = getFixedColumnParquetType(column, id, physicalType, repetition);
+        break;
+      case ARRAY:
+      case OBJECT:
+      case VARIANT:
+        // mark the column metadata as being an object json for the server side scanner
+        this.metadata.put(id + ":obj_enc", "1");
+        // parquetType is same as the next one
+      case ANY:
+      case CHAR:
+      case TEXT:
+      case BINARY:
+        parquetType =
+            Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition)
+                .as(LogicalTypeAnnotation.stringType())
+                .id(id)
+                .named(name);
+        break;
+      case TIMESTAMP_LTZ:
+      case TIMESTAMP_NTZ:
+      case TIMESTAMP_TZ:
+        parquetType =
+            getTimeColumnParquetType(
+                column.getScale(),
+                physicalType,
+                logicalType,
+                TIMESTAMP_SUPPORTED_PHYSICAL_TYPES,
+                repetition,
+                id,
+                name);
+        break;
+      case DATE:
+        parquetType =
+            Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
+                .as(LogicalTypeAnnotation.dateType())
+                .id(id)
+                .named(name);
+        break;
+      case TIME:
+        parquetType =
+            getTimeColumnParquetType(
+                column.getScale(),
+                physicalType,
+                logicalType,
+                TIME_SUPPORTED_PHYSICAL_TYPES,
+                repetition,
+                id,
+                name);
+        break;
+      case BOOLEAN:
+        parquetType =
+            Types.primitive(PrimitiveType.PrimitiveTypeName.BOOLEAN, repetition).id(id).named(name);
+        break;
+      case REAL:
+        parquetType =
+            Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, repetition).id(id).named(name);
+        break;
+      default:
+        throw new SFException(
+            ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
+    }
+
+    return parquetType;
+  }
+
+  /**
+   * Get the parquet type for column of Snowflake FIXED logical type.
+   *
+   * @param column column metadata
+   * @param id column id in Snowflake table schema
+   * @param physicalType Snowflake physical type of column
+   * @param repetition parquet repetition type of column
+   * @return column parquet type
+   */
+  private Type getFixedColumnParquetType(
+      ColumnMetadata column, int id, ColumnPhysicalType physicalType, Type.Repetition repetition) {
+    String name = column.getName();
+    // the LogicalTypeAnnotation.DecimalLogicalTypeAnnotation is used by server side scanner
+    // to discover data type scale and precision
+    LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimalLogicalTypeAnnotation =
+        column.getScale() != null && column.getPrecision() != null
+            ? LogicalTypeAnnotation.DecimalLogicalTypeAnnotation.decimalType(
+                column.getScale(), column.getPrecision())
+            : null;
+    Type parquetType;
+    if ((column.getScale() != null && column.getScale() != 0)
+        || physicalType == ColumnPhysicalType.SB16) {
+      parquetType =
+          Types.primitive(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, repetition)
+              .length(16)
+              .as(decimalLogicalTypeAnnotation)
+              .id(id)
+              .named(name);
+    } else {
+      switch (physicalType) {
+        case SB1:
+        case SB2:
+        case SB4:
+          parquetType =
+              Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
+                  .as(decimalLogicalTypeAnnotation)
+                  .id(id)
+                  .length(4)
+                  .named(name);
+          break;
+        case SB8:
+          parquetType =
+              Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition)
+                  .as(decimalLogicalTypeAnnotation)
+                  .id(id)
+                  .length(8)
+                  .named(name);
+          break;
+        default:
+          throw new SFException(
+              ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
+      }
+    }
+    return parquetType;
+  }
+
+  /**
+   * Get the parquet type for column of a Snowflake time logical type.
+   *
+   * @param scale column scale
+   * @param physicalType Snowflake physical type of column
+   * @param logicalType Snowflake logical type of column
+   * @param supportedPhysicalTypes supported Snowflake physical types for the given column
+   * @param repetition parquet repetition type of column
+   * @param id column id in Snowflake table schema
+   * @param name column name
+   * @return column parquet type
+   */
+  private static Type getTimeColumnParquetType(
+      Integer scale,
+      ColumnPhysicalType physicalType,
+      ColumnLogicalType logicalType,
+      Set<ColumnPhysicalType> supportedPhysicalTypes,
+      Type.Repetition repetition,
+      int id,
+      String name) {
+    if (scale == null || scale > 9 || scale < 0 || !supportedPhysicalTypes.contains(physicalType)) {
+      throw new SFException(
+          ErrorCode.UNKNOWN_DATA_TYPE,
+          "Data type: " + logicalType + ", " + physicalType + ", scale: " + scale);
+    }
+    LogicalTypeAnnotation.TimeUnit timeUnit = getTimeUnitFromScale(scale);
+
+    PrimitiveType.PrimitiveTypeName type = getTimePrimitiveType(physicalType);
+    if (physicalType == ColumnPhysicalType.SB16) {
+      LogicalTypeAnnotation typeAnnotation = LogicalTypeAnnotation.decimalType(scale, 38);
+      return Types.primitive(type, repetition).as(typeAnnotation).length(16).id(id).named(name);
+    } else {
+      LogicalTypeAnnotation typeAnnotation =
+          logicalType == ColumnLogicalType.TIME
+              ? LogicalTypeAnnotation.timeType(false, timeUnit)
+              : LogicalTypeAnnotation.timestampType(false, timeUnit);
+      return Types.primitive(type, repetition).as(typeAnnotation).id(id).named(name);
+    }
+  }
+
+  /**
+   * Get the parquet primitive type name for column of a Snowflake time logical type.
+   *
+   * @param physicalType Snowflake physical type of column
+   * @return column parquet primitive type name
+   */
+  private static PrimitiveType.PrimitiveTypeName getTimePrimitiveType(
+      ColumnPhysicalType physicalType) {
+    PrimitiveType.PrimitiveTypeName type;
+    switch (physicalType) {
+      case SB4:
+        type = PrimitiveType.PrimitiveTypeName.INT32;
+        break;
+      case SB8:
+        type = PrimitiveType.PrimitiveTypeName.INT64;
+        break;
+      case SB16:
+        type = PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+        break;
+      default:
+        throw new UnsupportedOperationException("Time physical type: " + physicalType);
+    }
+    return type;
+  }
+
+  /**
+   * Get the parquet time unit for column of a Snowflake time logical type.
+   *
+   * @param scale Snowflake column scale
+   * @return column parquet time unit
+   */
+  private static LogicalTypeAnnotation.TimeUnit getTimeUnitFromScale(int scale) {
+    LogicalTypeAnnotation.TimeUnit timeUnit;
+    if (scale <= 3) {
+      timeUnit = LogicalTypeAnnotation.TimeUnit.MILLIS;
+    } else if (scale <= 6) {
+      timeUnit = LogicalTypeAnnotation.TimeUnit.MICROS;
+    } else {
+      timeUnit = LogicalTypeAnnotation.TimeUnit.NANOS;
+    }
+    return timeUnit;
+  }
+
+  @Override
+  boolean hasColumn(String name) {
+    return fieldIndex.containsKey(name);
+  }
+
+  @Override
+  float addRow(
+      Map<String, Object> row,
+      int curRowIndex,
+      Map<String, RowBufferStats> statsMap,
+      Set<String> formattedInputColumnNames) {
+    return addRow(row, data, statsMap, formattedInputColumnNames);
+  }
+
+  @Override
+  float addTempRow(
+      Map<String, Object> row,
+      int curRowIndex,
+      Map<String, RowBufferStats> statsMap,
+      Set<String> formattedInputColumnNames) {
+    return addRow(row, tempData, statsMap, formattedInputColumnNames);
+  }
+
+  /**
+   * Adds a row to the parquet buffer.
+   *
+   * @param row row to add
+   * @param out internal buffer to add to
+   * @param statsMap column stats map
+   * @param inputColumnNames list of input column names after formatting
+   * @return row size
+   */
+  private float addRow(
+      Map<String, Object> row,
+      List<List<Object>> out,
+      Map<String, RowBufferStats> statsMap,
+      Set<String> inputColumnNames) {
+    Object[] indexedRow = new Object[fieldIndex.size()];
+    float size = 0F;
+    for (Map.Entry<String, Object> entry : row.entrySet()) {
+      String key = entry.getKey();
+      Object value = entry.getValue();
+      String columnName = formatColumnName(key);
+      int colIndex = fieldIndex.get(columnName).getSecond();
+      RowBufferStats stats = statsMap.get(columnName);
+      ColumnMetadata column = fieldIndex.get(columnName).getFirst();
+      ColumnDescriptor columnDescriptor = schema.getColumns().get(colIndex);
+      PrimitiveType.PrimitiveTypeName typeName =
+          columnDescriptor.getPrimitiveType().getPrimitiveTypeName();
+      ParquetValueParser.ParquetBufferValue valueWithSize =
+          ParquetValueParser.parseColumnValueToParquet(value, column, typeName, stats);
+      indexedRow[colIndex] = valueWithSize.getValue();
+      size += valueWithSize.getSize();
+    }
+    out.add(Arrays.asList(indexedRow));
+
+    for (String columnName : Sets.difference(this.fieldIndex.keySet(), inputColumnNames)) {
+      statsMap.get(columnName).incCurrentNullCount();
+    }
+    return size;
+  }
+
+  @Override
+  void moveTempRowsToActualBuffer(int tempRowCount) {
+    data.addAll(tempData);
+  }
+
+  @Override
+  void clearTempRows() {
+    tempData.clear();
+  }
+
+  @Override
+  boolean hasColumns() {
+    return !fieldIndex.isEmpty();
+  }
+
+  @Override
+  Optional<ParquetChunkData> getSnapshot() {
+    List<List<Object>> oldData = new ArrayList<>();
+    data.forEach(r -> oldData.add(new ArrayList<>(r)));
+    return oldData.isEmpty()
+        ? Optional.empty()
+        : Optional.of(new ParquetChunkData(oldData, metadata));
+  }
+
+  @Override
+  Object getVectorValueAt(String column, int index) {
+    int colIndex = fieldIndex.get(column).getSecond();
+    Object value = data.get(index).get(colIndex);
+    ColumnMetadata columnMetadata = fieldIndex.get(column).getFirst();
+    String physicalTypeStr = columnMetadata.getPhysicalType();
+    ColumnPhysicalType physicalType = ColumnPhysicalType.valueOf(physicalTypeStr);
+    String logicalTypeStr = columnMetadata.getLogicalType();
+    ColumnLogicalType logicalType = ColumnLogicalType.valueOf(logicalTypeStr);
+    if (logicalType == ColumnLogicalType.FIXED) {
+      if (physicalType == ColumnPhysicalType.SB1) {
+        value = ((Integer) value).byteValue();
+      }
+      if (physicalType == ColumnPhysicalType.SB2) {
+        value = ((Integer) value).shortValue();
+      }
+      if (physicalType == ColumnPhysicalType.SB16) {
+        value = new BigDecimal(new BigInteger((byte[]) value), columnMetadata.getScale());
+      }
+    }
+    if (logicalType == ColumnLogicalType.BINARY && value != null) {
+      value = ((String) value).getBytes(StandardCharsets.UTF_8);
+    }
+    return value;
+  }
+
+  @Override
+  int getTempRowCount() {
+    return tempData.size();
+  }
+
+  @Override
+  void reset() {
+    super.reset();
+    data.clear();
+  }
+
+  @Override
+  public void close(String name) {
+    this.fieldIndex.clear();
+    logger.logInfo(
+        "Trying to close parquet buffer for channel={} from function={}",
+        this.owningChannel.getName(),
+        name);
+  }
+
+  @Override
+  public Flusher<ParquetChunkData> createFlusher(Constants.BdecVersion bdecVerion) {
+    return new ParquetFlusher(schema);
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -168,6 +168,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
         : Optional.of(new ParquetChunkData(oldData, metadata));
   }
 
+  /** Used only for testing. */
   @Override
   Object getVectorValueAt(String column, int index) {
     int colIndex = fieldIndex.get(column).getSecond();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
@@ -1,6 +1,14 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
@@ -75,8 +83,8 @@ public class ParquetTypeGenerator {
 
     // Parquet Type.Repetition in general supports repeated values for the same row column, like a
     // list of values.
-    // This generator uses only
-    // either 0 or 1 value for nullable data type (OPTIONAL: 0 or none value if it is null)
+    // This generator uses only either 0 or 1 value for nullable data type (OPTIONAL: 0 or none
+    // value if it is null)
     // or exactly 1 value for non-nullable data type (REQUIRED)
     Type.Repetition repetition =
         column.getNullable() ? Type.Repetition.OPTIONAL : Type.Repetition.REQUIRED;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
@@ -289,22 +289,4 @@ public class ParquetTypeGenerator {
     }
     return type;
   }
-
-  /**
-   * Get the parquet time unit for column of a Snowflake time logical type.
-   *
-   * @param scale Snowflake column scale
-   * @return column parquet time unit
-   */
-  private static LogicalTypeAnnotation.TimeUnit getTimeUnitFromScale(int scale) {
-    LogicalTypeAnnotation.TimeUnit timeUnit;
-    if (scale <= 3) {
-      timeUnit = LogicalTypeAnnotation.TimeUnit.MILLIS;
-    } else if (scale <= 6) {
-      timeUnit = LogicalTypeAnnotation.TimeUnit.MICROS;
-    } else {
-      timeUnit = LogicalTypeAnnotation.TimeUnit.NANOS;
-    }
-    return timeUnit;
-  }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
@@ -1,0 +1,302 @@
+package net.snowflake.ingest.streaming.internal;
+
+import java.util.*;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.SFException;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
+
+/** Generates the Parquet types for the Snowflake's column types */
+public class ParquetTypeGenerator {
+
+  /**
+   * Util class that contains Parquet type and other metadata for that type needed by the Snowflake
+   * server side scanner
+   */
+  static class ParquetTypeInfo {
+    private Type parquetType;
+    private Map<String, String> metadata;
+
+    public Type getParquetType() {
+      return this.parquetType;
+    }
+
+    public Map<String, String> getMetadata() {
+      return this.metadata;
+    }
+
+    public void setParquetType(Type parquetType) {
+      this.parquetType = parquetType;
+    }
+
+    public void setMetadata(Map<String, String> metadata) {
+      this.metadata = metadata;
+    }
+  }
+
+  private static final Set<AbstractRowBuffer.ColumnPhysicalType> TIME_SUPPORTED_PHYSICAL_TYPES =
+      new HashSet<>(
+          Arrays.asList(
+              AbstractRowBuffer.ColumnPhysicalType.SB4, AbstractRowBuffer.ColumnPhysicalType.SB8));
+  private static final Set<AbstractRowBuffer.ColumnPhysicalType>
+      TIMESTAMP_SUPPORTED_PHYSICAL_TYPES =
+          new HashSet<>(
+              Arrays.asList(
+                  AbstractRowBuffer.ColumnPhysicalType.SB8,
+                  AbstractRowBuffer.ColumnPhysicalType.SB16));
+
+  /**
+   * Generate the column parquet type and metadata from the column metadata received from server
+   * side.
+   *
+   * @param column column metadata as received from server side
+   * @param id column id
+   * @return column parquet type
+   */
+  static ParquetTypeInfo generateColumnParquetTypeInfo(ColumnMetadata column, int id) {
+    ParquetTypeInfo res = new ParquetTypeInfo();
+    Type parquetType;
+    Map<String, String> metadata = new HashMap<>();
+    String name = column.getName();
+
+    AbstractRowBuffer.ColumnPhysicalType physicalType;
+    AbstractRowBuffer.ColumnLogicalType logicalType;
+    try {
+      physicalType = AbstractRowBuffer.ColumnPhysicalType.valueOf(column.getPhysicalType());
+      logicalType = AbstractRowBuffer.ColumnLogicalType.valueOf(column.getLogicalType());
+    } catch (IllegalArgumentException e) {
+      throw new SFException(
+          ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
+    }
+
+    metadata.put(Integer.toString(id), logicalType.getOrdinal() + "," + physicalType.getOrdinal());
+
+    // Parquet Type.Repetition in general supports repeated values for the same row column, like a
+    // list of values.
+    // This generator uses only
+    // either 0 or 1 value for nullable data type (OPTIONAL: 0 or none value if it is null)
+    // or exactly 1 value for non-nullable data type (REQUIRED)
+    Type.Repetition repetition =
+        column.getNullable() ? Type.Repetition.OPTIONAL : Type.Repetition.REQUIRED;
+
+    // Handle differently depends on the column logical and physical types
+    switch (logicalType) {
+      case FIXED:
+        parquetType = getFixedColumnParquetType(column, id, physicalType, repetition);
+        break;
+      case ARRAY:
+      case OBJECT:
+      case VARIANT:
+        // mark the column metadata as being an object json for the server side scanner
+        metadata.put(id + ":obj_enc", "1");
+        // parquetType is same as the next one
+      case ANY:
+      case CHAR:
+      case TEXT:
+      case BINARY:
+        parquetType =
+            Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition)
+                .as(LogicalTypeAnnotation.stringType())
+                .id(id)
+                .named(name);
+        break;
+      case TIMESTAMP_LTZ:
+      case TIMESTAMP_NTZ:
+      case TIMESTAMP_TZ:
+        parquetType =
+            getTimeColumnParquetType(
+                column.getScale(),
+                physicalType,
+                logicalType,
+                TIMESTAMP_SUPPORTED_PHYSICAL_TYPES,
+                repetition,
+                id,
+                name);
+        break;
+      case DATE:
+        parquetType =
+            Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
+                .as(LogicalTypeAnnotation.dateType())
+                .id(id)
+                .named(name);
+        break;
+      case TIME:
+        parquetType =
+            getTimeColumnParquetType(
+                column.getScale(),
+                physicalType,
+                logicalType,
+                TIME_SUPPORTED_PHYSICAL_TYPES,
+                repetition,
+                id,
+                name);
+        break;
+      case BOOLEAN:
+        parquetType =
+            Types.primitive(PrimitiveType.PrimitiveTypeName.BOOLEAN, repetition).id(id).named(name);
+        break;
+      case REAL:
+        parquetType =
+            Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, repetition).id(id).named(name);
+        break;
+      default:
+        throw new SFException(
+            ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
+    }
+    res.setParquetType(parquetType);
+    res.setMetadata(metadata);
+    return res;
+  }
+
+  /**
+   * Get the parquet type for column of Snowflake FIXED logical type.
+   *
+   * @param column column metadata
+   * @param id column id in Snowflake table schema
+   * @param physicalType Snowflake physical type of column
+   * @param repetition parquet repetition type of column
+   * @return column parquet type
+   */
+  private static Type getFixedColumnParquetType(
+      ColumnMetadata column,
+      int id,
+      AbstractRowBuffer.ColumnPhysicalType physicalType,
+      Type.Repetition repetition) {
+    String name = column.getName();
+    // the LogicalTypeAnnotation.DecimalLogicalTypeAnnotation is used by server side scanner
+    // to discover data type scale and precision
+    LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimalLogicalTypeAnnotation =
+        column.getScale() != null && column.getPrecision() != null
+            ? LogicalTypeAnnotation.DecimalLogicalTypeAnnotation.decimalType(
+                column.getScale(), column.getPrecision())
+            : null;
+    Type parquetType;
+    if ((column.getScale() != null && column.getScale() != 0)
+        || physicalType == AbstractRowBuffer.ColumnPhysicalType.SB16) {
+      parquetType =
+          Types.primitive(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, repetition)
+              .length(16)
+              .as(decimalLogicalTypeAnnotation)
+              .id(id)
+              .named(name);
+    } else {
+      switch (physicalType) {
+        case SB1:
+        case SB2:
+        case SB4:
+          parquetType =
+              Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
+                  .as(decimalLogicalTypeAnnotation)
+                  .id(id)
+                  .length(4)
+                  .named(name);
+          break;
+        case SB8:
+          parquetType =
+              Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition)
+                  .as(decimalLogicalTypeAnnotation)
+                  .id(id)
+                  .length(8)
+                  .named(name);
+          break;
+        default:
+          throw new SFException(
+              ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
+      }
+    }
+    return parquetType;
+  }
+
+  /**
+   * Get the parquet type for column of a Snowflake time logical type.
+   *
+   * @param scale column scale
+   * @param physicalType Snowflake physical type of column
+   * @param logicalType Snowflake logical type of column
+   * @param supportedPhysicalTypes supported Snowflake physical types for the given column
+   * @param repetition parquet repetition type of column
+   * @param id column id in Snowflake table schema
+   * @param name column name
+   * @return column parquet type
+   */
+  private static Type getTimeColumnParquetType(
+      Integer scale,
+      AbstractRowBuffer.ColumnPhysicalType physicalType,
+      AbstractRowBuffer.ColumnLogicalType logicalType,
+      Set<AbstractRowBuffer.ColumnPhysicalType> supportedPhysicalTypes,
+      Type.Repetition repetition,
+      int id,
+      String name) {
+    if (scale == null || scale > 9 || scale < 0 || !supportedPhysicalTypes.contains(physicalType)) {
+      throw new SFException(
+          ErrorCode.UNKNOWN_DATA_TYPE,
+          "Data type: " + logicalType + ", " + physicalType + ", scale: " + scale);
+    }
+
+    PrimitiveType.PrimitiveTypeName type = getTimePrimitiveType(physicalType);
+    LogicalTypeAnnotation typeAnnotation;
+    int length;
+    switch (physicalType) {
+      case SB4:
+        typeAnnotation = LogicalTypeAnnotation.decimalType(scale, 9);
+        length = 4;
+        break;
+      case SB8:
+        typeAnnotation = LogicalTypeAnnotation.decimalType(scale, 18);
+        length = 8;
+        break;
+      case SB16:
+        typeAnnotation = LogicalTypeAnnotation.decimalType(scale, 38);
+        length = 16;
+        break;
+      default:
+        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
+    }
+    return Types.primitive(type, repetition).as(typeAnnotation).length(length).id(id).named(name);
+  }
+
+  /**
+   * Get the parquet primitive type name for column of a Snowflake time logical type.
+   *
+   * @param physicalType Snowflake physical type of column
+   * @return column parquet primitive type name
+   */
+  private static PrimitiveType.PrimitiveTypeName getTimePrimitiveType(
+      AbstractRowBuffer.ColumnPhysicalType physicalType) {
+    PrimitiveType.PrimitiveTypeName type;
+    switch (physicalType) {
+      case SB4:
+        type = PrimitiveType.PrimitiveTypeName.INT32;
+        break;
+      case SB8:
+        type = PrimitiveType.PrimitiveTypeName.INT64;
+        break;
+      case SB16:
+        type = PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+        break;
+      default:
+        throw new UnsupportedOperationException("Time physical type: " + physicalType);
+    }
+    return type;
+  }
+
+  /**
+   * Get the parquet time unit for column of a Snowflake time logical type.
+   *
+   * @param scale Snowflake column scale
+   * @return column parquet time unit
+   */
+  private static LogicalTypeAnnotation.TimeUnit getTimeUnitFromScale(int scale) {
+    LogicalTypeAnnotation.TimeUnit timeUnit;
+    if (scale <= 3) {
+      timeUnit = LogicalTypeAnnotation.TimeUnit.MILLIS;
+    } else if (scale <= 6) {
+      timeUnit = LogicalTypeAnnotation.TimeUnit.MICROS;
+    } else {
+      timeUnit = LogicalTypeAnnotation.TimeUnit.NANOS;
+    }
+    return timeUnit;
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
@@ -65,7 +65,7 @@ class ParquetValueParser {
               getInt32Value(
                   value,
                   columnMetadata.getScale(),
-                  columnMetadata.getPrecision(),
+                  Optional.ofNullable(columnMetadata.getPrecision()).orElse(0),
                   logicalType,
                   physicalType);
           value = intVal;
@@ -77,7 +77,7 @@ class ParquetValueParser {
               getInt64Value(
                   value,
                   columnMetadata.getScale(),
-                  columnMetadata.getPrecision(),
+                  Optional.ofNullable(columnMetadata.getPrecision()).orElse(0),
                   logicalType,
                   physicalType);
           value = longValue;
@@ -100,7 +100,7 @@ class ParquetValueParser {
               getSb16Value(
                   value,
                   columnMetadata.getScale(),
-                  columnMetadata.getPrecision(),
+                  Optional.ofNullable(columnMetadata.getPrecision()).orElse(0),
                   logicalType,
                   physicalType);
           stats.addIntValue(intRep);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal;
 
 import java.math.BigDecimal;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
@@ -1,0 +1,261 @@
+package net.snowflake.ingest.streaming.internal;
+
+import static java.math.RoundingMode.UNNECESSARY;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import net.snowflake.client.jdbc.internal.snowflake.common.util.Power10;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.SFException;
+import net.snowflake.ingest.utils.Utils;
+import org.apache.parquet.schema.PrimitiveType;
+
+/** Parses a user column value into Parquet internal representation for buffering. */
+class ParquetValueParser {
+  /** Parquet internal value representation for buffering. */
+  static class ParquetBufferValue {
+    private final Object value;
+    private final float size;
+
+    ParquetBufferValue(Object value, float size) {
+      this.value = value;
+      this.size = size;
+    }
+
+    Object getValue() {
+      return value;
+    }
+
+    float getSize() {
+      return size;
+    }
+  }
+
+  /**
+   * Parses a user column value into Parquet internal representation for buffering.
+   *
+   * @param value column value provided by user in a row
+   * @param columnMetadata column metadata
+   * @param typeName Parquet primitive type name
+   * @param stats column stats to update
+   * @return parsed value and byte size of Parquet internal representation
+   */
+  static ParquetBufferValue parseColumnValueToParquet(
+      Object value,
+      ColumnMetadata columnMetadata,
+      PrimitiveType.PrimitiveTypeName typeName,
+      RowBufferStats stats) {
+    Utils.assertNotNull("Arrow column stats", stats);
+    float size = 0F;
+    if (value != null) {
+      AbstractRowBuffer.ColumnLogicalType logicalType =
+          AbstractRowBuffer.ColumnLogicalType.valueOf(columnMetadata.getLogicalType());
+      AbstractRowBuffer.ColumnPhysicalType physicalType =
+          AbstractRowBuffer.ColumnPhysicalType.valueOf(columnMetadata.getPhysicalType());
+      switch (typeName) {
+        case BOOLEAN:
+          int intValue = DataValidationUtil.validateAndParseBoolean(value);
+          value = intValue > 0;
+          stats.addIntValue(BigInteger.valueOf(intValue));
+          size = 1;
+          break;
+        case INT32:
+          int intVal = getInt32Value(value, columnMetadata.getScale(), logicalType);
+          value = intVal;
+          stats.addIntValue(BigInteger.valueOf(intVal));
+          size = 4;
+          break;
+        case INT64:
+          long longValue = getInt64Value(value, columnMetadata.getScale(), logicalType);
+          value = longValue;
+          stats.addIntValue(BigInteger.valueOf(longValue));
+          size = 8;
+          break;
+        case DOUBLE:
+          double doubleValue = DataValidationUtil.validateAndParseReal(value);
+          value = doubleValue;
+          stats.addRealValue(doubleValue);
+          size = 8;
+          break;
+        case BINARY:
+          String str = getBinaryValue(value, stats, columnMetadata);
+          value = str;
+          size = str.getBytes().length;
+          break;
+        case FIXED_LEN_BYTE_ARRAY:
+          BigInteger intRep = getSb16Value(value, columnMetadata.getScale(), logicalType);
+          stats.addIntValue(intRep);
+          value = getSb16Bytes(intRep);
+          size += 16;
+          break;
+        default:
+          throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
+      }
+    } else {
+      if (!columnMetadata.getNullable()) {
+        throw new SFException(
+            ErrorCode.INVALID_ROW, columnMetadata.getName(), "Passed null to non nullable field");
+      }
+      stats.incCurrentNullCount();
+    }
+    return new ParquetBufferValue(value, size);
+  }
+
+  /**
+   * Parses an int32 value based on Snowflake logical type.
+   *
+   * @param value column value provided by user in a row
+   * @param scale data type scale
+   * @param logicalType Snowflake logical type
+   * @return parsed int32 value
+   */
+  private static int getInt32Value(
+      Object value, @Nullable Integer scale, AbstractRowBuffer.ColumnLogicalType logicalType) {
+    int intVal;
+    switch (logicalType) {
+      case DATE:
+        intVal = DataValidationUtil.validateAndParseDate(value);
+        break;
+      case TIME:
+        Utils.assertNotNull("Unexpected null scale for TIME data type", scale);
+        intVal =
+            DataValidationUtil.getTimeInScale(DataValidationUtil.getStringValue(value), scale)
+                .intValue();
+        break;
+      default:
+        intVal = DataValidationUtil.validateAndParseInteger(value);
+        break;
+    }
+    return intVal;
+  }
+
+  /**
+   * Parses an int64 value based on Snowflake logical type.
+   *
+   * @param value column value provided by user in a row
+   * @param scale data type scale
+   * @param logicalType Snowflake logical type
+   * @return parsed int64 value
+   */
+  private static long getInt64Value(
+      Object value, int scale, AbstractRowBuffer.ColumnLogicalType logicalType) {
+    long longValue;
+    switch (logicalType) {
+      case TIME:
+      case TIMESTAMP_LTZ:
+      case TIMESTAMP_NTZ:
+        longValue =
+            DataValidationUtil.getTimeInScale(DataValidationUtil.getStringValue(value), scale)
+                .longValue();
+        break;
+      case TIMESTAMP_TZ:
+        longValue =
+            DataValidationUtil.validateAndParseTimestampTz(value, scale)
+                .getSfTimestamp()
+                .orElseThrow(
+                    () ->
+                        new SFException(
+                            ErrorCode.INVALID_ROW,
+                            value,
+                            "Unable to parse timestamp for TIMESTAMP_TZ column"))
+                .toBinary(scale, true)
+                .longValue();
+        break;
+      default:
+        longValue = DataValidationUtil.validateAndParseLong(value);
+        break;
+    }
+    return longValue;
+  }
+
+  /**
+   * Parses an int128 value based on Snowflake logical type.
+   *
+   * @param value column value provided by user in a row
+   * @param scale data type scale
+   * @param logicalType Snowflake logical type
+   * @return parsed int64 value
+   */
+  private static BigInteger getSb16Value(
+      Object value, int scale, AbstractRowBuffer.ColumnLogicalType logicalType) {
+    switch (logicalType) {
+      case TIMESTAMP_TZ:
+        return DataValidationUtil.validateAndParseTimestampTz(value, scale)
+            .getSfTimestamp()
+            .orElseThrow(
+                () ->
+                    new SFException(
+                        ErrorCode.INVALID_ROW,
+                        value,
+                        "Unable to parse timestamp for TIMESTAMP_TZ column"))
+            .toBinary(scale, true);
+      case TIMESTAMP_LTZ:
+      case TIMESTAMP_NTZ:
+        return DataValidationUtil.validateAndParseTimestampNtzSb16(value, scale).getTimeInScale();
+      default:
+        BigDecimal bigDecimalValue = DataValidationUtil.validateAndParseBigDecimal(value);
+        // explicitly match the BigDecimal input scale with the Snowflake data type scale
+        bigDecimalValue = bigDecimalValue.setScale(scale, UNNECESSARY);
+        return bigDecimalValue.multiply(BigDecimal.valueOf(Power10.intTable[scale])).toBigInteger();
+    }
+  }
+
+  /**
+   * Converts an int128 value to its byte array representation.
+   *
+   * @param intRep int128 value
+   * @return byte array representation
+   */
+  private static byte[] getSb16Bytes(BigInteger intRep) {
+    byte[] bytes = intRep.toByteArray();
+    byte padByte = (byte) (bytes[0] < 0 ? -1 : 0);
+    byte[] bytesBE = new byte[16];
+    for (int i = 0; i < 16 - bytes.length; i++) {
+      bytesBE[i] = padByte;
+    }
+    System.arraycopy(bytes, 0, bytesBE, 16 - bytes.length, bytes.length);
+    return bytesBE;
+  }
+
+  /**
+   * Converts an object, string or binary value to its byte array representation.
+   *
+   * @param value value to parse
+   * @param stats column stats to update
+   * @param columnMetadata column metadata
+   * @return string (byte array) representation
+   */
+  private static String getBinaryValue(
+      Object value, RowBufferStats stats, ColumnMetadata columnMetadata) {
+    AbstractRowBuffer.ColumnLogicalType logicalType =
+        AbstractRowBuffer.ColumnLogicalType.valueOf(columnMetadata.getLogicalType());
+    String str;
+    if (logicalType.isObject()) {
+      str =
+          logicalType == AbstractRowBuffer.ColumnLogicalType.OBJECT
+              ? DataValidationUtil.validateAndParseObject(value)
+              : DataValidationUtil.validateAndParseVariant(value);
+    } else if (logicalType == AbstractRowBuffer.ColumnLogicalType.BINARY) {
+      String maxLengthString = columnMetadata.getLength().toString();
+      byte[] bytes =
+          DataValidationUtil.validateAndParseBinary(
+              value,
+              Optional.of(maxLengthString)
+                  .map(s -> DataValidationUtil.validateAndParseInteger(maxLengthString)));
+      str = new String(bytes, StandardCharsets.UTF_8);
+      stats.addStrValue(str);
+    } else {
+      String maxLengthString = columnMetadata.getLength().toString();
+      str =
+          DataValidationUtil.validateAndParseString(
+              value,
+              Optional.of(maxLengthString)
+                  .map(s -> DataValidationUtil.validateAndParseInteger(maxLengthString)));
+      stats.addStrValue(str);
+    }
+    return str;
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
@@ -152,7 +152,7 @@ class ParquetValueParser {
       case FIXED:
         BigDecimal bigDecimalValue = DataValidationUtil.validateAndParseBigDecimal(value);
         bigDecimalValue = bigDecimalValue.setScale(scale, RoundingMode.HALF_UP);
-        checkValueInRange(bigDecimalValue, scale, precision);
+        DataValidationUtil.checkValueInRange(bigDecimalValue, scale, precision);
         intVal = bigDecimalValue.intValue();
         break;
       default:
@@ -207,7 +207,7 @@ class ParquetValueParser {
       case FIXED:
         BigDecimal bigDecimalValue = DataValidationUtil.validateAndParseBigDecimal(value);
         bigDecimalValue = bigDecimalValue.setScale(scale, RoundingMode.HALF_UP);
-        checkValueInRange(bigDecimalValue, scale, precision);
+        DataValidationUtil.checkValueInRange(bigDecimalValue, scale, precision);
         longValue = bigDecimalValue.longValue();
         break;
       default:
@@ -252,21 +252,10 @@ class ParquetValueParser {
         BigDecimal bigDecimalValue = DataValidationUtil.validateAndParseBigDecimal(value);
         // explicitly match the BigDecimal input scale with the Snowflake data type scale
         bigDecimalValue = bigDecimalValue.setScale(scale, RoundingMode.HALF_UP);
-        checkValueInRange(bigDecimalValue, scale, precision);
+        DataValidationUtil.checkValueInRange(bigDecimalValue, scale, precision);
         return bigDecimalValue.unscaledValue();
       default:
         throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
-    }
-  }
-
-  private static void checkValueInRange(BigDecimal bigDecimalValue, int scale, int precision) {
-    if (bigDecimalValue.abs().compareTo(BigDecimal.TEN.pow(precision - scale)) >= 0) {
-      throw new SFException(
-          ErrorCode.INVALID_ROW,
-          bigDecimalValue,
-          String.format(
-              "Number out of representable exclusive range of (-1e%s..1e%s)",
-              precision - scale, precision - scale));
     }
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
@@ -272,7 +272,7 @@ class ParquetValueParser {
    * @param intRep int128 value
    * @return byte array representation
    */
-  private static byte[] getSb16Bytes(BigInteger intRep) {
+  static byte[] getSb16Bytes(BigInteger intRep) {
     byte[] bytes = intRep.toByteArray();
     byte padByte = (byte) (bytes[0] < 0 ? -1 : 0);
     byte[] bytesBE = new byte[16];
@@ -297,10 +297,20 @@ class ParquetValueParser {
         AbstractRowBuffer.ColumnLogicalType.valueOf(columnMetadata.getLogicalType());
     String str;
     if (logicalType.isObject()) {
-      str =
-          logicalType == AbstractRowBuffer.ColumnLogicalType.OBJECT
-              ? DataValidationUtil.validateAndParseObject(value)
-              : DataValidationUtil.validateAndParseVariant(value);
+      switch (logicalType) {
+        case OBJECT:
+          str = DataValidationUtil.validateAndParseObject(value);
+          break;
+        case VARIANT:
+          str = DataValidationUtil.validateAndParseVariant(value);
+          break;
+        case ARRAY:
+          str = DataValidationUtil.validateAndParseArray(value);
+          break;
+        default:
+          throw new SFException(
+              ErrorCode.UNKNOWN_DATA_TYPE, logicalType, columnMetadata.getPhysicalType());
+      }
     } else if (logicalType == AbstractRowBuffer.ColumnLogicalType.BINARY) {
       String maxLengthString = columnMetadata.getLength().toString();
       byte[] bytes =

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
@@ -25,7 +25,8 @@ import net.snowflake.ingest.utils.Utils;
  * Register one or more blobs to the targeted Snowflake table, it will be done using the dedicated
  * thread in order to maintain ordering per channel
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 class RegisterService<T> {
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBuffer.java
@@ -13,7 +13,8 @@ import net.snowflake.ingest.utils.Constants;
  * Interface for the buffer in the Streaming Ingest channel that holds the un-flushed rows, these
  * rows will be converted to the underlying format implementation for faster processing
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 interface RowBuffer<T> {
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -30,7 +30,8 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 /**
  * The first version of implementation for SnowflakeStreamingIngestChannel
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIngestChannel {
 
@@ -148,9 +149,20 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
     // TODO: The circular dependency SnowflakeStreamingIngestChannelInternal <-> RowBuffer
     // (SNOW-657667)
     // can be probably reconsidered
-    //noinspection unchecked
-    return (RowBuffer<T>)
-        new ArrowRowBuffer((SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot>) this);
+    switch (bdecVersion) {
+      case ONE:
+      case TWO:
+        //noinspection unchecked
+        return (RowBuffer<T>)
+            new ArrowRowBuffer((SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot>) this);
+      case THREE:
+        //noinspection unchecked
+        return (RowBuffer<T>)
+            new ParquetRowBuffer((SnowflakeStreamingIngestChannelInternal<ParquetChunkData>) this);
+      default:
+        throw new SFException(
+            ErrorCode.INTERNAL_ERROR, "Unsupported BDEC format version: " + bdecVersion);
+    }
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -82,7 +82,8 @@ import org.apache.arrow.memory.RootAllocator;
  * <li>the channel cache, which contains all the channels that belong to this account
  * <li>the flush service, which schedules and coordinates the flush to Snowflake tables
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStreamingIngestClient {
 
@@ -550,7 +551,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
                   .collect(Collectors.toList());
           if (!relevantChunks.isEmpty()) {
             retryBlobs.add(
-                new BlobMetadata(
+                BlobMetadata.createBlobMetadata(
                     blobMetadata.getPath(),
                     blobMetadata.getMD5(),
                     blobMetadata.getVersion(),

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -87,8 +87,8 @@ public class Constants {
 
     /**
      * Uses Parquet to generate BDEC chunks with {@link
-     * net.snowflake.ingest.streaming.internal.ParquetRowBuffer}. This version is experimental and
-     * WIP at the moment.
+     * net.snowflake.ingest.streaming.internal.ParquetRowBuffer} (page-level compression). This
+     * version is experimental and WIP at the moment.
      */
     THREE(3);
 

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -83,7 +83,14 @@ public class Constants {
     ONE(1),
 
     /** Uses Arrow to generate BDEC chunks with {@link ArrowBatchWriteMode#FILE}. */
-    TWO(2);
+    TWO(2),
+
+    /**
+     * Uses Parquet to generate BDEC chunks with {@link
+     * net.snowflake.ingest.streaming.internal.ParquetRowBuffer}. This version is experimental and
+     * WIP at the moment.
+     */
+    THREE(3);
 
     private final byte version;
 

--- a/src/test/java/net/snowflake/ingest/TestUtils.java
+++ b/src/test/java/net/snowflake/ingest/TestUtils.java
@@ -14,7 +14,6 @@ import static net.snowflake.ingest.utils.Constants.SSL;
 import static net.snowflake.ingest.utils.Constants.USER;
 import static net.snowflake.ingest.utils.Constants.WAREHOUSE;
 import static net.snowflake.ingest.utils.ParameterProvider.BLOB_FORMAT_VERSION;
-import static net.snowflake.ingest.utils.ParameterProvider.BLOB_FORMAT_VERSION_DEFAULT;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -35,6 +34,7 @@ import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMappe
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.Utils;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Assert;
@@ -180,7 +180,7 @@ public class TestUtils {
     return keyPair;
   }
 
-  public static Properties getProperties() throws Exception {
+  public static Properties getProperties(Constants.BdecVersion bdecVersion) throws Exception {
     if (profile == null) {
       init();
     }
@@ -195,14 +195,8 @@ public class TestUtils {
     props.put(PRIVATE_KEY, privateKeyPem);
     props.put(ROLE, role);
     props.put(ACCOUNT_URL, getAccountURL());
-    props.put(BLOB_FORMAT_VERSION, getBlobFormatVersion());
+    props.put(BLOB_FORMAT_VERSION, bdecVersion.toByte());
     return props;
-  }
-
-  private static byte getBlobFormatVersion() {
-    return profile.has(BLOB_FORMAT_VERSION)
-        ? (byte) profile.get(BLOB_FORMAT_VERSION).asInt()
-        : BLOB_FORMAT_VERSION_DEFAULT.toByte();
   }
 
   /**

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
@@ -57,15 +57,13 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldFixedSB1() {
     // FIXED, SB1
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB1");
-    testCol.setNullable(true);
-    testCol.setLogicalType("FIXED");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB1")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -80,15 +78,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldFixedSB2() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB2");
-    testCol.setNullable(false);
-    testCol.setLogicalType("FIXED");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB2")
+            .nullable(false)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -103,15 +99,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldFixedSB4() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB4");
-    testCol.setNullable(true);
-    testCol.setLogicalType("FIXED");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB4")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -125,15 +119,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldFixedSB8() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB8");
-    testCol.setNullable(true);
-    testCol.setLogicalType("FIXED");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -147,15 +139,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldFixedSB16() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB16");
-    testCol.setNullable(true);
-    testCol.setLogicalType("FIXED");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     ArrowType expectedType =
@@ -172,15 +162,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldLobVariant() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("LOB");
-    testCol.setNullable(true);
-    testCol.setLogicalType("VARIANT");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("VARIANT")
+            .physicalType("LOB")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -194,15 +182,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldTimestampNtzSB8() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB8");
-    testCol.setNullable(true);
-    testCol.setLogicalType("TIMESTAMP_NTZ");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -216,15 +202,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldTimestampNtzSB16() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB16");
-    testCol.setNullable(true);
-    testCol.setLogicalType("TIMESTAMP_NTZ");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -242,15 +226,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldTimestampTzSB8() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB8");
-    testCol.setNullable(true);
-    testCol.setLogicalType("TIMESTAMP_TZ");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_TZ")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -268,15 +250,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldTimestampTzSB16() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB16");
-    testCol.setNullable(true);
-    testCol.setLogicalType("TIMESTAMP_TZ");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_TZ")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -295,16 +275,14 @@ public class ArrowBufferTest {
   }
 
   @Test
-  public void buildFieldDate() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB8");
-    testCol.setNullable(true);
-    testCol.setLogicalType("DATE");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+  public void buildFieldTimestampDate() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("DATE")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -318,15 +296,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldTimeSB4() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB4");
-    testCol.setNullable(true);
-    testCol.setLogicalType("TIME");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB4")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -340,15 +316,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldTimeSB8() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB8");
-    testCol.setNullable(true);
-    testCol.setLogicalType("TIME");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -362,15 +336,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldBoolean() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("BINARY");
-    testCol.setNullable(true);
-    testCol.setLogicalType("BOOLEAN");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("BOOLEAN")
+            .physicalType("BINARY")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -384,15 +356,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldRealSB16() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB16");
-    testCol.setNullable(true);
-    testCol.setLogicalType("REAL");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("REAL")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ColumnMetadataBuilder.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ColumnMetadataBuilder.java
@@ -1,0 +1,160 @@
+package net.snowflake.ingest.streaming.internal;
+
+/** Helper class to build ColumnMetadata */
+public class ColumnMetadataBuilder {
+  private String name;
+  private String type;
+  private String logicalType;
+  private String physicalType;
+  private Integer precision;
+  private Integer scale;
+  private Integer byteLength;
+  private Integer length;
+  private boolean nullable;
+  private String collation;
+
+  /**
+   * Returns a new ColumnMetadata builder
+   *
+   * @return builder
+   */
+  public static ColumnMetadataBuilder newBuilder() {
+    ColumnMetadataBuilder mb = new ColumnMetadataBuilder();
+    mb.name = "testCol";
+    mb.byteLength = 14;
+    mb.length = 11;
+    mb.scale = 0;
+    mb.precision = 4;
+    return mb;
+  }
+
+  /**
+   * Set name
+   *
+   * @param name column name
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Set type
+   *
+   * @param type type (as defined in ColumnMetadata)
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder type(String type) {
+    this.type = type;
+    return this;
+  }
+
+  /**
+   * Set column logical type
+   *
+   * @param logicalType logical type
+   * @return columnMetadata object
+   */
+  public ColumnMetadataBuilder logicalType(String logicalType) {
+    this.logicalType = logicalType;
+    return this;
+  }
+
+  /**
+   * Set column physical type
+   *
+   * @param physicalType physical type
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder physicalType(String physicalType) {
+    this.physicalType = physicalType;
+    return this;
+  }
+
+  /**
+   * Set column precision
+   *
+   * @param precision precision
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder precision(int precision) {
+    this.precision = precision;
+    return this;
+  }
+
+  /**
+   * Set column scale
+   *
+   * @param scale scale
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder scale(int scale) {
+    this.scale = scale;
+    return this;
+  }
+
+  /**
+   * Set column length in bytes
+   *
+   * @param byteLength length in bytes
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder byteLength(int byteLength) {
+    this.byteLength = byteLength;
+    return this;
+  }
+
+  /**
+   * Set column length (in chars)
+   *
+   * @param length length
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder length(int length) {
+    this.length = length;
+    return this;
+  }
+
+  /**
+   * Set column nullability
+   *
+   * @param nullable nullable
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder nullable(boolean nullable) {
+    this.nullable = nullable;
+    return this;
+  }
+
+  /**
+   * Set column collation
+   *
+   * @param collation collation
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder collation(String collation) {
+    this.collation = collation;
+    return this;
+  }
+
+  /**
+   * Build a columnMetadata object from the set values
+   *
+   * @return columnMetadata object
+   */
+  public ColumnMetadata build() {
+    ColumnMetadata colMetadata = new ColumnMetadata();
+    colMetadata.setName(name);
+    colMetadata.setType(type);
+    colMetadata.setPhysicalType(physicalType);
+    colMetadata.setNullable(nullable);
+    colMetadata.setLogicalType(logicalType);
+    colMetadata.setByteLength(byteLength);
+    colMetadata.setLength(length);
+    colMetadata.setScale(scale);
+    colMetadata.setPrecision(precision);
+    colMetadata.setCollation(collation);
+    return colMetadata;
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ColumnMetadataBuilder.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ColumnMetadataBuilder.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal;
 
 /** Helper class to build ColumnMetadata */

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -183,11 +183,6 @@ public class FlushServiceTest {
         return this;
       }
 
-      ChannelBuilder setOnErrorOption(OpenChannelRequest.OnErrorOption onErrorOption) {
-        this.onErrorOption = onErrorOption;
-        return this;
-      }
-
       SnowflakeStreamingIngestChannelInternal<T> buildAndAdd() {
         SnowflakeStreamingIngestChannelInternal<T> channel =
             createChannel(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -55,7 +55,8 @@ import org.mockito.Mockito;
 public class FlushServiceTest {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> testContextFactory() {
-    return Arrays.asList(new Object[][] {{ArrowTestContext.createFactory()}});
+    return Arrays.asList(
+        new Object[][] {{ArrowTestContext.createFactory()}, {ParquetTestContext.createFactory()}});
   }
 
   public FlushServiceTest(TestContextFactory<?> testContextFactory) {
@@ -280,6 +281,48 @@ public class FlushServiceTest {
         @Override
         TestContext<VectorSchemaRoot> create() {
           return new ArrowTestContext();
+        }
+      };
+    }
+  }
+
+  private static class ParquetTestContext extends TestContext<List<List<Object>>> {
+
+    SnowflakeStreamingIngestChannelInternal<List<List<Object>>> createChannel(
+        String name,
+        String dbName,
+        String schemaName,
+        String tableName,
+        String offsetToken,
+        Long channelSequencer,
+        Long rowSequencer,
+        String encryptionKey,
+        Long encryptionKeyId,
+        OpenChannelRequest.OnErrorOption onErrorOption) {
+      return new SnowflakeStreamingIngestChannelInternal<>(
+          name,
+          dbName,
+          schemaName,
+          tableName,
+          offsetToken,
+          channelSequencer,
+          rowSequencer,
+          client,
+          encryptionKey,
+          encryptionKeyId,
+          onErrorOption,
+          Constants.BdecVersion.THREE,
+          null);
+    }
+
+    @Override
+    public void close() {}
+
+    static TestContextFactory<List<List<Object>>> createFactory() {
+      return new TestContextFactory<List<List<Object>>>("Parquet") {
+        @Override
+        TestContext<List<List<Object>>> create() {
+          return new ParquetTestContext();
         }
       };
     }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetTypeGeneratorTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetTypeGeneratorTest.java
@@ -1,0 +1,480 @@
+package net.snowflake.ingest.streaming.internal;
+
+import java.util.Map;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ParquetTypeGeneratorTest {
+
+  @Test
+  public void buildFieldFixedSB1() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB1")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(4)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
+        .expectedLogicalTypeAnnotation(
+            LogicalTypeAnnotation.decimalType(testCol.getScale(), testCol.getPrecision()))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.FIXED.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB1.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldFixedSB2() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB2")
+            .nullable(false)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(4)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
+        .expectedLogicalTypeAnnotation(
+            LogicalTypeAnnotation.decimalType(testCol.getScale(), testCol.getPrecision()))
+        .expectedRepetition(Type.Repetition.REQUIRED)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.FIXED.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB2.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldFixedSB4() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB4")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(4)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
+        .expectedLogicalTypeAnnotation(
+            LogicalTypeAnnotation.decimalType(testCol.getScale(), testCol.getPrecision()))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.FIXED.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB4.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldFixedSB8() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(8)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
+        .expectedLogicalTypeAnnotation(
+            LogicalTypeAnnotation.decimalType(testCol.getScale(), testCol.getPrecision()))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.FIXED.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB8.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldFixedSB16() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(16)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+        .expectedLogicalTypeAnnotation(
+            LogicalTypeAnnotation.decimalType(testCol.getScale(), testCol.getPrecision()))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.FIXED.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB16.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldLobVariant() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("VARIANT")
+            .physicalType("LOB")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(0)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.BINARY)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.stringType())
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.VARIANT.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.LOB.getOrdinal())
+        .assertMatches();
+
+    Assert.assertEquals("1", typeInfo.getMetadata().get(0 + ":obj_enc"));
+  }
+
+  @Test
+  public void buildFieldTimestampNtzSB8() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(8)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 18))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.TIMESTAMP_NTZ.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB8.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldTimestampNtzSB16() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(16)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 38))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.TIMESTAMP_NTZ.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB16.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldTimestampTzSB8() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_TZ")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(8)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 18))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.TIMESTAMP_TZ.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB8.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldTimestampTzSB16() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_TZ")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(16)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 38))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.TIMESTAMP_TZ.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB16.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldDate() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("DATE")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(0)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.dateType())
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.DATE.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB8.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldTimeSB4() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB4")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(4)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 9))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.TIME.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB4.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldTimeSB8() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(8)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 18))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.TIME.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB8.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldBoolean() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("BOOLEAN")
+            .physicalType("BINARY")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(0)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.BOOLEAN)
+        .expectedLogicalTypeAnnotation(null)
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.BOOLEAN.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.BINARY.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldRealSB16() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("REAL")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(0)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.DOUBLE)
+        .expectedLogicalTypeAnnotation(null)
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.REAL.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB16.getOrdinal())
+        .assertMatches();
+  }
+
+  /** Builder that helps to assert parquet type info */
+  private static class ParquetTypeInfoAssertionBuilder {
+    private String fieldName;
+    private int fieldId;
+    private PrimitiveType.PrimitiveTypeName primitiveTypeName;
+    private LogicalTypeAnnotation logicalTypeAnnotation;
+    private Type.Repetition repetition;
+    private int typeLength;
+    private String colMetadata;
+    private ParquetTypeGenerator.ParquetTypeInfo typeInfo;
+
+    static ParquetTypeInfoAssertionBuilder newBuilder() {
+      ParquetTypeInfoAssertionBuilder builder = new ParquetTypeInfoAssertionBuilder();
+      return builder;
+    }
+
+    ParquetTypeInfoAssertionBuilder typeInfo(ParquetTypeGenerator.ParquetTypeInfo typeInfo) {
+      this.typeInfo = typeInfo;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedFieldName(String fieldName) {
+      this.fieldName = fieldName;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedFieldId(int fieldId) {
+      this.fieldId = fieldId;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedPrimitiveTypeName(
+        PrimitiveType.PrimitiveTypeName primitiveTypeName) {
+      this.primitiveTypeName = primitiveTypeName;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedLogicalTypeAnnotation(
+        LogicalTypeAnnotation logicalTypeAnnotation) {
+      this.logicalTypeAnnotation = logicalTypeAnnotation;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedRepetition(Type.Repetition repetition) {
+      this.repetition = repetition;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedTypeLength(int typeLength) {
+      this.typeLength = typeLength;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedColMetaData(String colMetaData) {
+      this.colMetadata = colMetaData;
+      return this;
+    }
+
+    void assertMatches() {
+      Type type = typeInfo.getParquetType();
+      Map<String, String> metadata = typeInfo.getMetadata();
+      Assert.assertEquals(fieldName, type.getName());
+      Assert.assertEquals(typeLength, type.asPrimitiveType().getTypeLength());
+      Assert.assertEquals(fieldId, type.asPrimitiveType().getId().intValue());
+
+      Assert.assertEquals(primitiveTypeName, type.asPrimitiveType().getPrimitiveTypeName());
+      Assert.assertEquals(logicalTypeAnnotation, type.getLogicalTypeAnnotation());
+      Assert.assertEquals(repetition, type.getRepetition());
+      Assert.assertEquals(colMetadata, metadata.get(type.getId().toString()));
+    }
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
@@ -2,8 +2,8 @@ package net.snowflake.ingest.streaming.internal;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.schema.PrimitiveType;
 import org.junit.Assert;
@@ -31,6 +31,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
+        .expectedParsedValue(12)
         .expectedSize(4.0f)
         .expectedMinMax(BigInteger.valueOf(12))
         .assertMatches();
@@ -56,6 +57,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
+        .expectedParsedValue(1234)
         .expectedSize(4.0f)
         .expectedMinMax(BigInteger.valueOf(1234))
         .assertMatches();
@@ -81,6 +83,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
+        .expectedParsedValue(123456789)
         .expectedSize(4.0f)
         .expectedMinMax(BigInteger.valueOf(123456789))
         .assertMatches();
@@ -106,6 +109,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Long.class)
+        .expectedParsedValue(123456789987654321L)
         .expectedSize(8.0f)
         .expectedMinMax(BigInteger.valueOf(123456789987654321L))
         .assertMatches();
@@ -134,6 +138,9 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(byte[].class)
+        .expectedParsedValue(
+            ParquetValueParser.getSb16Bytes(
+                new BigInteger("91234567899876543219876543211234567891")))
         .expectedSize(16.0f)
         .expectedMinMax(new BigInteger("91234567899876543219876543211234567891"))
         .assertMatches();
@@ -162,6 +169,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Double.class)
+        .expectedParsedValue(Double.valueOf("12345.54321"))
         .expectedSize(8.0f)
         .expectedMinMax(Double.valueOf("12345.54321"))
         .assertMatches();
@@ -185,6 +193,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Double.class)
+        .expectedParsedValue(Double.valueOf(12345.54321))
         .expectedSize(8.0f)
         .expectedMinMax(Double.valueOf(12345.54321))
         .assertMatches();
@@ -208,6 +217,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Boolean.class)
+        .expectedParsedValue(true)
         .expectedSize(1.0f)
         .expectedMinMax(BigInteger.valueOf(1))
         .assertMatches();
@@ -231,6 +241,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(String.class)
+        .expectedParsedValue("Length7")
         .expectedSize(7.0f)
         .expectedMinMax("Length7")
         .assertMatches();
@@ -266,6 +277,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(String.class)
+        .expectedParsedValue(var)
         .expectedSize(var.getBytes().length)
         .expectedMinMax(null)
         .assertMatches();
@@ -280,18 +292,23 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    List<String> arr = Arrays.asList("{ \"a\": 1}", "{ \"b\": 2 }", "{ \"c\": 3 }");
+    Map<String, String> input = new HashMap<>();
+    input.put("a", "1");
+    input.put("b", "2");
+    input.put("c", "3");
+
     RowBufferStats rowBufferStats = new RowBufferStats();
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            arr, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
+            input, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
 
-    String resultArray = "[{ \"a\": 1}, { \"b\": 2 }, { \"c\": 3 }]";
+    String resultArray = "[{\"a\":\"1\",\"b\":\"2\",\"c\":\"3\"}]";
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(String.class)
+        .expectedParsedValue(resultArray)
         .expectedSize(resultArray.length())
         .expectedMinMax(null)
         .assertMatches();
@@ -345,6 +362,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Long.class)
+        .expectedParsedValue(1367182621000L)
         .expectedSize(8.0f)
         .expectedMinMax(BigInteger.valueOf(1367182621000L))
         .assertMatches();
@@ -372,6 +390,8 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(byte[].class)
+        .expectedParsedValue(
+            ParquetValueParser.getSb16Bytes(BigInteger.valueOf(1663538707123456789L)))
         .expectedSize(16.0f)
         .expectedMinMax(BigInteger.valueOf(1663538707123456789L))
         .assertMatches();
@@ -396,6 +416,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
+        .expectedParsedValue(Integer.valueOf(18628))
         .expectedSize(4.0f)
         .expectedMinMax(BigInteger.valueOf(18628))
         .assertMatches();
@@ -420,6 +441,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
+        .expectedParsedValue(3600)
         .expectedSize(4.0f)
         .expectedMinMax(BigInteger.valueOf(3600))
         .assertMatches();
@@ -444,6 +466,7 @@ public class ParquetValueParserTest {
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Long.class)
+        .expectedParsedValue(3600123L)
         .expectedSize(8.0f)
         .expectedMinMax(BigInteger.valueOf(3600123))
         .assertMatches();
@@ -478,6 +501,7 @@ public class ParquetValueParserTest {
     private ParquetValueParser.ParquetBufferValue parquetBufferValue;
     private RowBufferStats rowBufferStats;
     private Class valueClass;
+    private Object value;
     private float size;
     private Object minMaxStat;
 
@@ -502,6 +526,11 @@ public class ParquetValueParserTest {
       return this;
     }
 
+    ParquetValueParserAssertionBuilder expectedParsedValue(Object value) {
+      this.value = value;
+      return this;
+    }
+
     ParquetValueParserAssertionBuilder expectedSize(float size) {
       this.size = size;
       return this;
@@ -514,6 +543,12 @@ public class ParquetValueParserTest {
 
     void assertMatches() {
       Assert.assertEquals(valueClass, parquetBufferValue.getValue().getClass());
+      System.out.println("parquetBufferValue = " + parquetBufferValue.getValue().toString());
+      if (valueClass.equals(byte[].class)) {
+        Assert.assertArrayEquals((byte[]) value, (byte[]) parquetBufferValue.getValue());
+      } else {
+        Assert.assertEquals(value, parquetBufferValue.getValue());
+      }
       Assert.assertEquals(size, parquetBufferValue.getSize(), 0);
       if (minMaxStat instanceof BigInteger) {
         Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMinIntValue());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
@@ -1,0 +1,534 @@
+package net.snowflake.ingest.streaming.internal;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.parquet.schema.PrimitiveType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ParquetValueParserTest {
+
+  @Test
+  public void parseValueFixedSB1ToInt32() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB1")
+            .scale(0)
+            .precision(2)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            12, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Integer.class)
+        .expectedSize(4.0f)
+        .expectedMinMax(BigInteger.valueOf(12))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueFixedSB2ToInt32() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB2")
+            .scale(0)
+            .precision(4)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            1234, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Integer.class)
+        .expectedSize(4.0f)
+        .expectedMinMax(BigInteger.valueOf(1234))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueFixedSB4ToInt32() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB4")
+            .scale(0)
+            .precision(9)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            123456789, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Integer.class)
+        .expectedSize(4.0f)
+        .expectedMinMax(BigInteger.valueOf(123456789))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueFixedSB8ToInt64() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB8")
+            .scale(0)
+            .precision(18)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            123456789987654321L, testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Long.class)
+        .expectedSize(8.0f)
+        .expectedMinMax(BigInteger.valueOf(123456789987654321L))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueFixedSB16ToByteArray() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB16")
+            .scale(0)
+            .precision(38)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            new BigDecimal("91234567899876543219876543211234567891"),
+            testCol,
+            PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+            rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(byte[].class)
+        .expectedSize(16.0f)
+        .expectedMinMax(new BigInteger("91234567899876543219876543211234567891"))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueFixedDecimalToInt32() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB8")
+            .scale(5)
+            .precision(10)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            new BigDecimal("12345.54321"),
+            testCol,
+            PrimitiveType.PrimitiveTypeName.DOUBLE,
+            rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Double.class)
+        .expectedSize(8.0f)
+        .expectedMinMax(Double.valueOf("12345.54321"))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueDouble() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("REAL")
+            .physicalType("DOUBLE")
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            12345.54321d, testCol, PrimitiveType.PrimitiveTypeName.DOUBLE, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Double.class)
+        .expectedSize(8.0f)
+        .expectedMinMax(Double.valueOf(12345.54321))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueBoolean() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("BOOLEAN")
+            .physicalType("SB1")
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            true, testCol, PrimitiveType.PrimitiveTypeName.BOOLEAN, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Boolean.class)
+        .expectedSize(1.0f)
+        .expectedMinMax(BigInteger.valueOf(1))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueBinary() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("BINARY")
+            .physicalType("LOB")
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "Length7".getBytes(), testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(String.class)
+        .expectedSize(7.0f)
+        .expectedMinMax("Length7")
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueVariantToBinary() {
+    testJsonWithLogicalType("VARIANT");
+  }
+
+  @Test
+  public void parseValueObjectToBinary() {
+    testJsonWithLogicalType("OBJECT");
+  }
+
+  private void testJsonWithLogicalType(String logicalType) {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType(logicalType)
+            .physicalType("BINARY")
+            .nullable(true)
+            .build();
+
+    String var =
+        "{\"key1\":-879869596,\"key2\":\"value2\",\"key3\":null,"
+            + "\"key4\":{\"key41\":0.032437,\"key42\":\"value42\",\"key43\":null}}";
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(String.class)
+        .expectedSize(var.getBytes().length)
+        .expectedMinMax(null)
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueArrayToBinary() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("ARRAY")
+            .physicalType("BINARY")
+            .nullable(true)
+            .build();
+
+    List<String> arr = Arrays.asList("{ \"a\": 1}", "{ \"b\": 2 }", "{ \"c\": 3 }");
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            arr, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
+
+    String resultArray = "[{ \"a\": 1}, { \"b\": 2 }, { \"c\": 3 }]";
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(String.class)
+        .expectedSize(resultArray.length())
+        .expectedMinMax(null)
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueTimestampNtzSB4ToINT64() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB4")
+            .scale(0) // seconds
+            .precision(9)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "1663531507", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Integer.class)
+        .expectedSize(4.0f)
+        .expectedMinMax(BigInteger.valueOf(1663531507L))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueTimestampNtzSB8ToINT64() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB8")
+            .scale(3) // millis
+            .precision(18)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "1663531507000", testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Long.class)
+        .expectedSize(8.0f)
+        .expectedMinMax(BigInteger.valueOf(1663531507000000L))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueTimestampNtzSB16ToByteArray() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB16")
+            .nullable(true)
+            .scale(9) // nanos
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "1663531507.801809412",
+            testCol,
+            PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+            rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(byte[].class)
+        .expectedSize(16.0f)
+        .expectedMinMax(BigInteger.valueOf(1663531507801809412L))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueDateToInt32() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("DATE")
+            .physicalType("SB4")
+            .scale(0) // seconds
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "2021-01-01", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Integer.class)
+        .expectedSize(4.0f)
+        .expectedMinMax(BigInteger.valueOf(18628))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueTimeSB4ToInt32() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB4")
+            .scale(0) // seconds
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "01:00:00", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Integer.class)
+        .expectedSize(4.0f)
+        .expectedMinMax(BigInteger.valueOf(3600))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueTimeSB8ToInt64() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB8")
+            .scale(3) // milliseconds
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "01:00:00.123", testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Long.class)
+        .expectedSize(8.0f)
+        .expectedMinMax(BigInteger.valueOf(3600123))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueTimeSB16ToByteArray() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB16")
+            .scale(9) // nanos
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "36000.12345678",
+            testCol,
+            PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+            rowBufferStats); // todo specifying string "11:00:00.12345678" doesn't work
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(byte[].class)
+        .expectedSize(16.0f)
+        .expectedMinMax(BigInteger.valueOf(36000123456780L))
+        .assertMatches();
+  }
+
+  /** Builder that helps to assert parsing of values to parquet types */
+  private static class ParquetValueParserAssertionBuilder {
+    private ParquetValueParser.ParquetBufferValue parquetBufferValue;
+    private RowBufferStats rowBufferStats;
+    private Class valueClass;
+    private float size;
+    private Object minMaxStat;
+
+    static ParquetValueParserAssertionBuilder newBuilder() {
+      ParquetValueParserAssertionBuilder builder = new ParquetValueParserAssertionBuilder();
+      return builder;
+    }
+
+    ParquetValueParserAssertionBuilder parquetBufferValue(
+        ParquetValueParser.ParquetBufferValue parquetBufferValue) {
+      this.parquetBufferValue = parquetBufferValue;
+      return this;
+    }
+
+    ParquetValueParserAssertionBuilder rowBufferStats(RowBufferStats rowBufferStats) {
+      this.rowBufferStats = rowBufferStats;
+      return this;
+    }
+
+    ParquetValueParserAssertionBuilder expectedValueClass(Class valueClass) {
+      this.valueClass = valueClass;
+      return this;
+    }
+
+    ParquetValueParserAssertionBuilder expectedSize(float size) {
+      this.size = size;
+      return this;
+    }
+
+    public ParquetValueParserAssertionBuilder expectedMinMax(Object minMaxStat) {
+      this.minMaxStat = minMaxStat;
+      return this;
+    }
+
+    void assertMatches() {
+      Assert.assertEquals(valueClass, parquetBufferValue.getValue().getClass());
+      Assert.assertEquals(size, parquetBufferValue.getSize(), 0);
+      if (minMaxStat instanceof BigInteger) {
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMinIntValue());
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMaxIntValue());
+        return;
+      } else if (minMaxStat instanceof String || valueClass.equals(String.class)) {
+        // String can have null min/max stats for variant data types
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMinColStrValue());
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMaxColStrValue());
+        return;
+      } else if (minMaxStat instanceof Double || minMaxStat instanceof BigDecimal) {
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMinRealValue());
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMaxRealValue());
+        return;
+      }
+      throw new IllegalArgumentException("Unknown data type for min stat");
+    }
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -26,7 +26,11 @@ import org.junit.runners.Parameterized;
 public class RowBufferTest {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> bdecVersion() {
-    return Arrays.asList(new Object[][] {{"Arrow", Constants.BdecVersion.ONE}});
+    return Arrays.asList(
+        new Object[][] {
+          {"Arrow", Constants.BdecVersion.ONE},
+          {"Parquet", Constants.BdecVersion.THREE}
+        });
   }
 
   private final Constants.BdecVersion bdecVersion;
@@ -1029,6 +1033,7 @@ public class RowBufferTest {
     colBinary.setPhysicalType("LOB");
     colBinary.setNullable(true);
     colBinary.setLogicalType("BINARY");
+    colBinary.setLength(32);
     colBinary.setScale(0);
 
     innerBuffer.setupSchema(Collections.singletonList(colBinary));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
@@ -38,9 +40,21 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 /** Example streaming ingest sdk integration test */
+@RunWith(Parameterized.class)
 public class StreamingIngestIT {
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> bdecVersion() {
+    return Arrays.asList(
+        new Object[][] {
+          {"Arrow", Constants.BdecVersion.ONE},
+          {"Parquet", Constants.BdecVersion.THREE}
+        });
+  }
+
   private static final String TEST_TABLE = "STREAMING_INGEST_TEST_TABLE";
   private static final String TEST_DB_PREFIX = "STREAMING_INGEST_TEST_DB";
   private static final String TEST_SCHEMA = "STREAMING_INGEST_TEST_SCHEMA";
@@ -54,6 +68,13 @@ public class StreamingIngestIT {
   private SnowflakeStreamingIngestClientInternal<?> client;
   private Connection jdbcConnection;
   private String testDb;
+
+  private final Constants.BdecVersion bdecVersion;
+
+  public StreamingIngestIT(
+      @SuppressWarnings("unused") String name, Constants.BdecVersion bdecVersion) {
+    this.bdecVersion = bdecVersion;
+  }
 
   @Before
   public void beforeAll() throws Exception {
@@ -78,7 +99,7 @@ public class StreamingIngestIT {
         .createStatement()
         .execute(String.format("use warehouse %s", TestUtils.getWarehouse()));
 
-    prop = TestUtils.getProperties();
+    prop = TestUtils.getProperties(bdecVersion);
     if (prop.getProperty(ROLE).equals("DEFAULT_ROLE")) {
       prop.setProperty(ROLE, "ACCOUNTADMIN");
     }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -1318,56 +1318,6 @@ public class StreamingIngestIT {
     Assert.assertEquals(row.get("bl"), result.getBoolean("BL"));
   }
 
-  private static Map<String, Object> getRandomRow(Random r) {
-    Map<String, Object> row = new HashMap<>();
-    row.put("num", r.nextInt());
-    row.put("num_10_5", nextFloat(r));
-    row.put(
-        "num_38_0",
-        new BigDecimal("" + nextLongOfPrecision(r, 18) + Math.abs(nextLongOfPrecision(r, 18))));
-    row.put("num_2_0", r.nextInt(100));
-    row.put("num_4_0", r.nextInt(10000));
-    row.put("num_9_0", r.nextInt(1000000000));
-    row.put("num_18_0", nextLongOfPrecision(r, 18));
-    row.put("num_float", nextFloat(r));
-    row.put("str_varchar", nextString(r));
-    row.put("bin", nextBytes(r));
-    row.put("bl", r.nextBoolean());
-    row.put("var", nextJson(r));
-    row.put("obj", nextJson(r));
-    row.put("arr", Arrays.asList(r.nextInt(100), r.nextInt(100), r.nextInt(100)));
-    row.put(
-        "epochdays",
-        String.valueOf(Math.abs(r.nextInt()) % (18963 * 24 * 60 * 60))); // DATE, 02.12.2021
-    row.put(
-        "timesec",
-        String.valueOf(
-            (r.nextInt(11) * 60 * 60 + r.nextInt(59) * 60 + r.nextInt(59)) * 10000
-                + r.nextInt(9999))); // TIME(4), 05:12:43.4536
-    row.put(
-        "timenano",
-        String.valueOf(
-            (14 * 60 * 60 + 26 * 60 + 34) * 1000000000L
-                + 437582643)); // TIME(9), 14:26:34.437582643
-    row.put(
-        "epochsec",
-        String.valueOf(
-            Math.abs(r.nextLong()) % 1638459438)); // TIMESTAMP_LTZ(0), 02.12.2021 15:37:18
-    row.put(
-        "epochnano",
-        String.format(
-            "%d%d",
-            Math.abs(r.nextInt()) % 1999999999,
-            100000000
-                + Math.abs(
-                    r.nextInt(899999999)))); // TIMESTAMP_LTZ(9), 18.05.2033 03:33:19.999999999
-    return row;
-  }
-
-  private static long nextLongOfPrecision(Random r, int precision) {
-    return r.nextLong() % Math.round(Math.pow(10, precision));
-  }
-
   private static String nextString(Random r) {
     return new String(nextBytes(r));
   }
@@ -1379,26 +1329,5 @@ public class StreamingIngestIT {
       bin[i] = (byte) (Math.abs(bin[i]) % 25 + 97); // ascii letters
     }
     return bin;
-  }
-
-  private static double nextFloat(Random r) {
-    return (r.nextLong() % Math.round(Math.pow(10, 10))) / 100000d;
-  }
-
-  private static String nextJson(Random r) {
-    return String.format(
-        "{ \"%s\": %d, \"%s\": \"%s\", \"%s\": null, \"%s\": { \"%s\": %f, \"%s\": \"%s\", \"%s\":"
-            + " null } }",
-        nextString(r),
-        r.nextInt(),
-        nextString(r),
-        nextString(r),
-        nextString(r),
-        nextString(r),
-        nextString(r),
-        r.nextFloat(),
-        nextString(r),
-        nextString(r),
-        nextString(r));
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -9,6 +9,7 @@ import java.math.BigInteger;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -1068,7 +1069,7 @@ public class StreamingIngestIT {
   }
 
   @Test
-  public void testDataTypes() {
+  public void testDataTypes() throws SQLException, ParseException {
     String tableName = "t_data_types";
     try {
       jdbcConnection
@@ -1106,11 +1107,215 @@ public class StreamingIngestIT {
 
     SnowflakeStreamingIngestChannel channel = openChannel(tableName, "CHANNEL");
 
-    Random r = new Random();
-    for (int val = 0; val < 10000; val++) {
-      verifyInsertValidationResponse(channel.insertRow(getRandomRow(r), Integer.toString(val)));
-    }
-    waitChannelFlushed(channel, 10000);
+    Map<String, Object> negRow = getNegRow();
+    verifyInsertValidationResponse(channel.insertRow(negRow, Integer.toString(0)));
+
+    Map<String, Object> nullRow = getNullRow();
+    verifyInsertValidationResponse(channel.insertRow(nullRow, Integer.toString(1)));
+
+    Map<String, Object> posRow = getPosRow();
+    verifyInsertValidationResponse(channel.insertRow(posRow, Integer.toString(2)));
+
+    waitChannelFlushed(channel, 3);
+    verifyTableRowCount(3, tableName);
+
+    ResultSet result =
+        jdbcConnection
+            .createStatement()
+            .executeQuery(
+                String.format(
+                    "select * from %s.%s.%s order by num", testDb, TEST_SCHEMA, tableName));
+
+    result.next(); // negRow
+    assertNegRow(negRow, result);
+
+    result.next(); // nullRow
+    assertNullRow(nullRow, result);
+
+    result.next(); // posRow
+    assertPosRow(posRow, result);
+  }
+
+  private Map<String, Object> getNegRow() {
+    Map<String, Object> negRow = new HashMap<>();
+    negRow.put("num", -123);
+    negRow.put("num_10_5", new BigDecimal("-12345.54321"));
+    negRow.put("num_38_0", new BigDecimal("-91234567899876543219876543211234567891"));
+    negRow.put("num_2_0", -12);
+    negRow.put("num_4_0", -1234);
+    negRow.put("num_9_0", -123456789);
+    negRow.put("num_18_0", -123456789987654321L);
+    negRow.put("num_float", -12345.54321f);
+    negRow.put("str_varchar", "zxccvbnm,.");
+    negRow.put("bin", new byte[] {1, 2, 3});
+    negRow.put("bl", true);
+    negRow.put("var", "{}");
+    negRow.put("obj", "{}");
+    negRow.put("arr", Arrays.asList());
+    negRow.put("epochdays", 0);
+    negRow.put("epochsec", 0);
+    negRow.put("epochnano", new BigDecimal("0"));
+    negRow.put("timesec", 0);
+    negRow.put("timenano", 0);
+
+    return negRow;
+  }
+
+  private Map<String, Object> getNullRow() {
+    Map<String, Object> nullRow = new HashMap<>();
+    nullRow.put("num", 0);
+    nullRow.put("num_10_5", new BigDecimal("0.00000"));
+    nullRow.put("num_38_0", new BigDecimal("0"));
+    nullRow.put("num_2_0", 0);
+    nullRow.put("num_4_0", 0);
+    nullRow.put("num_9_0", 0);
+    nullRow.put("num_18_0", 0L);
+    nullRow.put("num_float", 0.0f);
+    nullRow.put("str_varchar", null);
+    nullRow.put("bin", null);
+    nullRow.put("bl", false);
+    nullRow.put("var", null);
+    nullRow.put("obj", null);
+    nullRow.put("arr", null);
+    nullRow.put("epochdays", null);
+    nullRow.put("epochsec", null);
+    nullRow.put("epochnano", null);
+    nullRow.put("timesec", null);
+    nullRow.put("timenano", null);
+
+    return nullRow;
+  }
+
+  private Map<String, Object> getPosRow() {
+    Map<String, Object> posRow = new HashMap<>();
+    posRow.put("num", 123);
+    posRow.put("num_10_5", new BigDecimal("12345.54321"));
+    posRow.put("num_38_0", new BigDecimal("91234567899876543219876543211234567891"));
+    posRow.put("num_2_0", 12);
+    posRow.put("num_4_0", 1234);
+    posRow.put("num_9_0", 123456789);
+    posRow.put("num_18_0", 123456789987654321L);
+    posRow.put("num_float", 12345.54321f);
+    posRow.put("str_varchar", "abcd123456.");
+    posRow.put("bin", new byte[] {4, 5, 6});
+    posRow.put("bl", true);
+    posRow.put(
+        "var",
+        "{ \"a\": 1, \"b\": \"qwerty\", \"c\": null, \"d\": { \"e\": 2, \"f\": \"asdf\", \"g\":"
+            + " null } }");
+    posRow.put(
+        "obj",
+        "{ \"a\": 1, \"b\": \"qwerty\", \"c\": null, \"d\": { \"e\": 2, \"f\": \"asdf\", \"g\":"
+            + " null } }");
+    posRow.put("arr", Arrays.asList("{ \"a\": 1}", "{ \"b\": 2 }", "{ \"c\": 3 }"));
+    posRow.put("epochdays", 738781); // DATE, 18.09.2022
+    posRow.put("epochsec", 1663531507); // TIMESTAMP_NTZ(0), 18.09.2022 20:05:07 GMT
+    posRow.put(
+        "epochnano",
+        new BigDecimal(
+            "1663531507.801809412")); // TIMESTAMP_NTZ(9) 18.09.2022 20:05:07.801809412 GMT
+    posRow.put("timesec", 79507); // TIME(0), 20:05:07 GMT
+    posRow.put("timenano", 79507.671940142); // TIME(9), 20:05:07.671940142 GMT
+
+    return posRow;
+  }
+
+  private void assertNegRow(Map<String, Object> expectedNegRow, ResultSet actualResult)
+      throws SQLException {
+    assertNonTimeAndVarFields(expectedNegRow, actualResult);
+    Assert.assertEquals("{}", actualResult.getString("VAR"));
+    Assert.assertEquals("{}", actualResult.getString("OBJ"));
+    Assert.assertEquals("[]", actualResult.getString("ARR"));
+    Assert.assertEquals(0, actualResult.getDate("EPOCHDAYS").getTime());
+    Assert.assertEquals(0, actualResult.getTimestamp("EPOCHSEC").getTime());
+    Assert.assertEquals(0, actualResult.getTimestamp("EPOCHNANO").getNanos());
+    Assert.assertEquals(0, actualResult.getTimestamp("EPOCHNANO").getTime());
+    Assert.assertEquals(0, actualResult.getTimestamp("TIMESEC").getTime());
+    Assert.assertEquals(0, actualResult.getTimestamp("TIMENANO").getNanos());
+    Assert.assertEquals(0, actualResult.getTimestamp("TIMENANO").getTime());
+  }
+
+  private void assertNullRow(Map<String, Object> expectedNullRow, ResultSet actualResult)
+      throws SQLException {
+    Assert.assertNotNull(actualResult);
+    assertNonTimeAndVarFields(expectedNullRow, actualResult);
+    Assert.assertEquals(null, actualResult.getString("VAR"));
+    Assert.assertEquals(null, actualResult.getString("OBJ"));
+    Assert.assertEquals(null, actualResult.getString("ARR"));
+    Assert.assertEquals(null, actualResult.getDate("EPOCHDAYS"));
+    Assert.assertEquals(null, actualResult.getTimestamp("EPOCHSEC"));
+    Assert.assertEquals(null, actualResult.getTimestamp("EPOCHNANO"));
+    Assert.assertEquals(null, actualResult.getTimestamp("TIMESEC"));
+    Assert.assertEquals(null, actualResult.getTimestamp("TIMENANO"));
+  }
+
+  private void assertPosRow(Map<String, Object> expectedPosRow, ResultSet actualResult)
+      throws SQLException {
+    String formattedJSON =
+        "{\n"
+            + "  \"a\": 1,\n"
+            + "  \"b\": \"qwerty\",\n"
+            + "  \"c\": null,\n"
+            + "  \"d\": {\n"
+            + "    \"e\": 2,\n"
+            + "    \"f\": \"asdf\",\n"
+            + "    \"g\": null\n"
+            + "  }\n"
+            + "}";
+
+    String formattedArrayForParquet =
+        "[\n"
+            + "  {\n"
+            + "    \"a\": 1\n"
+            + "  },\n"
+            + "  {\n"
+            + "    \"b\": 2\n"
+            + "  },\n"
+            + "  {\n"
+            + "    \"c\": 3\n"
+            + "  }\n"
+            + "]";
+    String formattedArrayForArrow =
+        "[\n"
+            + "  \"{ \\\"a\\\": 1}\",\n"
+            + "  \"{ \\\"b\\\": 2 }\",\n"
+            + "  \"{ \\\"c\\\": 3 }\"\n"
+            + "]";
+    Assert.assertNotNull(actualResult);
+    assertNonTimeAndVarFields(expectedPosRow, actualResult);
+    Assert.assertEquals(formattedJSON, actualResult.getString("VAR"));
+    Assert.assertEquals(formattedJSON, actualResult.getString("OBJ"));
+    Assert.assertEquals(
+        (bdecVersion == Constants.BdecVersion.THREE
+            ? formattedArrayForParquet
+            : formattedArrayForArrow),
+        actualResult.getString("ARR"));
+    Assert.assertEquals(
+        63830678400000l, actualResult.getDate("EPOCHDAYS").getTime()); // in ms, 18.09.2022 00:00:00
+    Assert.assertEquals(1663531507000L, actualResult.getTimestamp("EPOCHSEC").getTime());
+    Assert.assertEquals(801809412L, actualResult.getTimestamp("EPOCHNANO").getNanos());
+    // 1663531507000 ms + 801 ms (from ns)
+    Assert.assertEquals(1663531507801L, actualResult.getTimestamp("EPOCHNANO").getTime());
+    Assert.assertEquals(79507000, actualResult.getTimestamp("TIMESEC").getTime());
+    Assert.assertEquals(671940142, actualResult.getTimestamp("TIMENANO").getNanos());
+    // 79507000 ms + 671 ms (from ns)
+    Assert.assertEquals(79507671, actualResult.getTimestamp("TIMENANO").getTime());
+  }
+
+  private void assertNonTimeAndVarFields(Map<String, Object> row, ResultSet result)
+      throws SQLException {
+    Assert.assertNotNull(result);
+    Assert.assertEquals(row.get("num"), result.getInt("NUM"));
+    Assert.assertEquals(row.get("num_10_5"), result.getBigDecimal("NUM_10_5"));
+    Assert.assertEquals(row.get("num_38_0"), result.getBigDecimal("NUM_38_0"));
+    Assert.assertEquals(row.get("num_2_0"), result.getInt("NUM_2_0"));
+    Assert.assertEquals(row.get("num_4_0"), result.getInt("NUM_4_0"));
+    Assert.assertEquals(row.get("num_9_0"), result.getInt("NUM_9_0"));
+    Assert.assertEquals((long) row.get("num_18_0"), result.getLong("NUM_18_0"));
+    Assert.assertEquals((float) row.get("num_float"), result.getFloat("NUM_FLOAT"), 0);
+    Assert.assertEquals(row.get("str_varchar"), result.getString("STR_VARCHAR"));
+    Assert.assertArrayEquals((byte[]) row.get("bin"), result.getBytes("BIN"));
+    Assert.assertEquals(row.get("bl"), result.getBoolean("BL"));
   }
 
   private static Map<String, Object> getRandomRow(Random r) {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -81,6 +81,11 @@ public class StreamingIngestIT {
     testDb = TEST_DB_PREFIX + "_" + UUID.randomUUID().toString().substring(0, 4);
     // Create a streaming ingest client
     jdbcConnection = TestUtils.getConnection(true);
+    if (bdecVersion == Constants.BdecVersion.THREE) {
+      // TODO: encryption and interleaved mode are not yet supported by server side's Parquet
+      // scanner if local file cache is enabled (SNOW-656500)
+      jdbcConnection.createStatement().execute("alter session set disable_parquet_cache=true;");
+    }
     jdbcConnection
         .createStatement()
         .execute(String.format("create or replace database %s;", testDb));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -51,7 +51,7 @@ public class StreamingIngestIT {
     return Arrays.asList(
         new Object[][] {
           {"Arrow", Constants.BdecVersion.ONE},
-          {"Parquet", Constants.BdecVersion.THREE}
+          // {"Parquet", Constants.BdecVersion.THREE}
         });
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -1261,19 +1261,7 @@ public class StreamingIngestIT {
             + "  }\n"
             + "}";
 
-    String formattedArrayForParquet =
-        "[\n"
-            + "  {\n"
-            + "    \"a\": 1\n"
-            + "  },\n"
-            + "  {\n"
-            + "    \"b\": 2\n"
-            + "  },\n"
-            + "  {\n"
-            + "    \"c\": 3\n"
-            + "  }\n"
-            + "]";
-    String formattedArrayForArrow =
+    String formattedArray =
         "[\n"
             + "  \"{ \\\"a\\\": 1}\",\n"
             + "  \"{ \\\"b\\\": 2 }\",\n"
@@ -1283,11 +1271,7 @@ public class StreamingIngestIT {
     assertNonTimeAndVarFields(expectedPosRow, actualResult);
     Assert.assertEquals(formattedJSON, actualResult.getString("VAR"));
     Assert.assertEquals(formattedJSON, actualResult.getString("OBJ"));
-    Assert.assertEquals(
-        (bdecVersion == Constants.BdecVersion.THREE
-            ? formattedArrayForParquet
-            : formattedArrayForArrow),
-        actualResult.getString("ARR"));
+    Assert.assertEquals(formattedArray, actualResult.getString("ARR"));
     Assert.assertEquals(
         1663459200000l, actualResult.getDate("EPOCHDAYS").getTime()); // in ms, 18.09.2022 00:00:00
     Assert.assertEquals(1663531507000L, actualResult.getTimestamp("EPOCHSEC").getTime());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -1152,11 +1151,11 @@ public class StreamingIngestIT {
     negRow.put("var", "{}");
     negRow.put("obj", "{}");
     negRow.put("arr", Arrays.asList());
-    negRow.put("epochdays", 0);
-    negRow.put("epochsec", 0);
-    negRow.put("epochnano", new BigDecimal("0"));
-    negRow.put("timesec", 0);
-    negRow.put("timenano", 0);
+    negRow.put("epochdays", "0");
+    negRow.put("epochsec", "0");
+    negRow.put("epochnano", "0");
+    negRow.put("timesec", "0");
+    negRow.put("timenano", "0");
 
     return negRow;
   }
@@ -1208,14 +1207,11 @@ public class StreamingIngestIT {
         "{ \"a\": 1, \"b\": \"qwerty\", \"c\": null, \"d\": { \"e\": 2, \"f\": \"asdf\", \"g\":"
             + " null } }");
     posRow.put("arr", Arrays.asList("{ \"a\": 1}", "{ \"b\": 2 }", "{ \"c\": 3 }"));
-    posRow.put("epochdays", 738781); // DATE, 18.09.2022
-    posRow.put("epochsec", 1663531507); // TIMESTAMP_NTZ(0), 18.09.2022 20:05:07 GMT
-    posRow.put(
-        "epochnano",
-        new BigDecimal(
-            "1663531507.801809412")); // TIMESTAMP_NTZ(9) 18.09.2022 20:05:07.801809412 GMT
-    posRow.put("timesec", 79507); // TIME(0), 20:05:07 GMT
-    posRow.put("timenano", 79507.671940142); // TIME(9), 20:05:07.671940142 GMT
+    posRow.put("epochdays", "2022-09-18 20:05:07"); // DATE, 18.09.2022
+    posRow.put("epochsec", "2022-09-18 20:05:07"); // TIMESTAMP_NTZ(0)
+    posRow.put("epochnano", "2022-09-18 20:05:07.999999999"); // TIMESTAMP_NTZ(9)
+    posRow.put("timesec", "01:00:01.999999999"); // TIME(0)
+    posRow.put("timenano", "01:00:01.999999999"); // TIME(9)
 
     return posRow;
   }
@@ -1291,15 +1287,15 @@ public class StreamingIngestIT {
             : formattedArrayForArrow),
         actualResult.getString("ARR"));
     Assert.assertEquals(
-        63830678400000l, actualResult.getDate("EPOCHDAYS").getTime()); // in ms, 18.09.2022 00:00:00
+        1663459200000l, actualResult.getDate("EPOCHDAYS").getTime()); // in ms, 18.09.2022 00:00:00
     Assert.assertEquals(1663531507000L, actualResult.getTimestamp("EPOCHSEC").getTime());
-    Assert.assertEquals(801809412L, actualResult.getTimestamp("EPOCHNANO").getNanos());
-    // 1663531507000 ms + 801 ms (from ns)
-    Assert.assertEquals(1663531507801L, actualResult.getTimestamp("EPOCHNANO").getTime());
-    Assert.assertEquals(79507000, actualResult.getTimestamp("TIMESEC").getTime());
-    Assert.assertEquals(671940142, actualResult.getTimestamp("TIMENANO").getNanos());
-    // 79507000 ms + 671 ms (from ns)
-    Assert.assertEquals(79507671, actualResult.getTimestamp("TIMENANO").getTime());
+    Assert.assertEquals(999999999L, actualResult.getTimestamp("EPOCHNANO").getNanos());
+    // 1663531507000 ms + 999 ms (from ns)
+    Assert.assertEquals(1663531507999L, actualResult.getTimestamp("EPOCHNANO").getTime());
+    Assert.assertEquals(3601000, actualResult.getTimestamp("TIMESEC").getTime()); // 1h + 1s in ms
+    Assert.assertEquals(999999999, actualResult.getTimestamp("TIMENANO").getNanos());
+    // 1h + 1s + 999 ms (from ns)
+    Assert.assertEquals(3601999, actualResult.getTimestamp("TIMENANO").getTime());
   }
 
   private void assertNonTimeAndVarFields(Map<String, Object> row, ResultSet result)
@@ -1316,18 +1312,5 @@ public class StreamingIngestIT {
     Assert.assertEquals(row.get("str_varchar"), result.getString("STR_VARCHAR"));
     Assert.assertArrayEquals((byte[]) row.get("bin"), result.getBytes("BIN"));
     Assert.assertEquals(row.get("bl"), result.getBoolean("BL"));
-  }
-
-  private static String nextString(Random r) {
-    return new String(nextBytes(r));
-  }
-
-  private static byte[] nextBytes(Random r) {
-    byte[] bin = new byte[128];
-    r.nextBytes(bin);
-    for (int i = 0; i < bin.length; i++) {
-      bin[i] = (byte) (Math.abs(bin[i]) % 25 + 97); // ascii letters
-    }
-    return bin;
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -51,6 +51,8 @@ public class StreamingIngestIT {
     return Arrays.asList(
         new Object[][] {
           {"Arrow", Constants.BdecVersion.ONE},
+          // TODO: uncomment once SNOW-659721 is deployed and we set the parameter
+          // DISABLE_PARQUET_CACHE to true for the test account
           // {"Parquet", Constants.BdecVersion.THREE}
         });
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractDataTypeTest {
     return Arrays.asList(
         new Object[][] {
           {"Arrow", Constants.BdecVersion.ONE},
-          {"Parquet", Constants.BdecVersion.THREE}
+          // {"Parquet", Constants.BdecVersion.THREE}
         });
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -36,6 +36,8 @@ public abstract class AbstractDataTypeTest {
     return Arrays.asList(
         new Object[][] {
           {"Arrow", Constants.BdecVersion.ONE},
+          // TODO: uncomment once SNOW-659721 is deployed and we set the parameter
+          // DISABLE_PARQUET_CACHE to true for the test account
           // {"Parquet", Constants.BdecVersion.THREE}
         });
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/BinaryIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/BinaryIT.java
@@ -1,9 +1,14 @@
 package net.snowflake.ingest.streaming.internal.datatypes;
 
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Ignore;
 import org.junit.Test;
 
 public class BinaryIT extends AbstractDataTypeTest {
+
+  public BinaryIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
 
   @Test
   public void testBinarySimple() throws Exception {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
@@ -8,6 +8,7 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -16,6 +17,10 @@ import org.junit.Test;
  * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats
  */
 public class DateTimeIT extends AbstractDataTypeTest {
+
+  public DateTimeIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
 
   @Test
   public void testTimestampWithTimeZone() throws Exception {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/LogicalTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/LogicalTypesIT.java
@@ -2,9 +2,15 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Test;
 
 public class LogicalTypesIT extends AbstractDataTypeTest {
+
+  public LogicalTypesIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
+
   @Test
   public void testLogicalTypes() throws Exception {
     // Test booleans

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NullIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NullIT.java
@@ -1,9 +1,15 @@
 package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.util.Arrays;
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Test;
 
 public class NullIT extends AbstractDataTypeTest {
+
+  public NullIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
+
   @Test
   public void testNullIngestion() throws Exception {
     for (String type :

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NumericTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NumericTypesIT.java
@@ -2,9 +2,15 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Test;
 
 public class NumericTypesIT extends AbstractDataTypeTest {
+
+  public NumericTypesIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
+
   @Test
   public void testIntegers() throws Exception {
     // test bytes

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -23,6 +24,10 @@ public class SemiStructuredIT extends AbstractDataTypeTest {
   // TODO SNOW-664249: There is a few-byte mismatch between the value sent by the user and its
   // server-side representation. Validation leaves a small buffer for this difference.
   private static final int MAX_ALLOWED_LENGTH = 16 * 1024 * 1024 - 64;
+
+  public SemiStructuredIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
 
   @Test
   public void testVariant() throws Exception {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
@@ -2,10 +2,16 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Ignore;
 import org.junit.Test;
 
 public class StringsIT extends AbstractDataTypeTest {
+
+  public StringsIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
+
   @Test
   public void testStrings() throws Exception {
     testJdbcTypeCompatibility("VARCHAR", "", new StringProvider());


### PR DESCRIPTION
This PR is the first implementation of Parquet file generator for Streaming Ingest along with Arrow.
Parquet is a native format for Iceberg tables. This is the first step to support Iceberg for Streaming Ingest.

This Parquet implementation buffers the rows in `ParquetRowBuffer`. The `ParquetFlusher` uses classical simple Parquet file generation approach (as in official examples) that writes rows one-by-one. Nonetheless, small research shows that internally it relies on Parquet column buffers that can be used later for the sake of performance if needed for the price for the implementation complication.

@test run `StreamingIngestIT` (except timestamp tests).

The PR is based on a refactoring in #202 that prepares the code base to plugin other format implementations along the existing Arrow one.

@tests in #224

There are still some things that are not supported and planned as separate PRs:
- Scanner file caching (with encryption) is not supported by server side yet: [SNOW-656500](https://snowflakecomputing.atlassian.net/browse/SNOW-656500)
- Parquet V2 is not supported by server side yet: [SNOW-657238](https://snowflakecomputing.atlassian.net/browse/SNOW-657238)
- further optimisation:
    - use fixed len array for SF sb number types for non-Iceberg case
    - use lower level internal Parquet column buffers