### PR TITLE
@snow SNOW-633432 Refactor RowBuffer and Flusher API

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestClientFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestClientFactory.java
@@ -49,7 +49,7 @@ public class SnowflakeStreamingIngestClientFactory {
       Properties prop = Utils.createProperties(this.prop);
       SnowflakeURL accountURL = new SnowflakeURL(prop.getProperty(Constants.ACCOUNT_URL));
 
-      return new SnowflakeStreamingIngestClientInternal(
+      return new SnowflakeStreamingIngestClientInternal<>(
           this.name, accountURL, prop, this.parameterOverrides);
     }
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import net.snowflake.ingest.streaming.InsertValidationResponse;
+import net.snowflake.ingest.streaming.OpenChannelRequest;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.Logging;
+import net.snowflake.ingest.utils.SFException;
+import net.snowflake.ingest.utils.Utils;
+import org.apache.arrow.util.VisibleForTesting;
+
+/**
+ * The abstract implementation of the buffer in the Streaming Ingest channel that holds the
+ * un-flushed rows, these rows will be converted to the underlying format implementation for faster
+ * processing
+ *
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot}
+ */
+abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
+  private static final Logging logger = new Logging(AbstractRowBuffer.class);
+  // these types cannot be packed into the data chunk because they are not readable by the server
+  // side scanner
+  private static final int INVALID_SERVER_SIDE_DATA_TYPE_ORDINAL = -1;
+
+  // Snowflake table column logical type
+  enum ColumnLogicalType {
+    ANY,
+    BOOLEAN(1),
+    ROWINDEX,
+    NULL(15),
+    REAL(8),
+    FIXED(2),
+    TEXT(9),
+    CHAR,
+    BINARY(10),
+    DATE(7),
+    TIME(6),
+    TIMESTAMP_LTZ(3),
+    TIMESTAMP_NTZ(4),
+    TIMESTAMP_TZ(5),
+    INTERVAL,
+    RAW,
+    ARRAY(13, true),
+    OBJECT(12, true),
+    VARIANT(11, true),
+    ROW,
+    SEQUENCE,
+    FUNCTION,
+    USER_DEFINED_TYPE,
+    ;
+
+    // ordinal should be in sync with the server side scanner
+    private final int ordinal;
+    // whether it is a composite data type: array, object or variant
+    private final boolean object;
+
+    ColumnLogicalType() {
+      // no valid server side ordinal by default
+      this(INVALID_SERVER_SIDE_DATA_TYPE_ORDINAL);
+    }
+
+    ColumnLogicalType(int ordinal) {
+      this(ordinal, false);
+    }
+
+    ColumnLogicalType(int ordinal, boolean object) {
+      this.ordinal = ordinal;
+      this.object = object;
+    }
+
+    /**
+     * Ordinal to encode the data type for the server side scanner
+     *
+     * <p>currently used for Parquet format
+     */
+    public int getOrdinal() {
+      return ordinal;
+    }
+
+    /** Whether the data type is a composite type: OBJECT, VARIANT, ARRAY. */
+    public boolean isObject() {
+      return object;
+    }
+  }
+
+  // Snowflake table column physical type
+  enum ColumnPhysicalType {
+    ROWINDEX(9),
+    DOUBLE(7),
+    SB1(1),
+    SB2(2),
+    SB4(3),
+    SB8(4),
+    SB16(5),
+    LOB(8),
+    BINARY,
+    ROW(10),
+    ;
+
+    // ordinal should be in sync with the server side scanner
+    private final int ordinal;
+
+    ColumnPhysicalType() {
+      // no valid server side ordinal by default
+      this(INVALID_SERVER_SIDE_DATA_TYPE_ORDINAL);
+    }
+
+    ColumnPhysicalType(int ordinal) {
+      this.ordinal = ordinal;
+    }
+
+    /**
+     * Ordinal to encode the data type for the server side scanner
+     *
+     * <p>currently used for Parquet format
+     */
+    public int getOrdinal() {
+      return ordinal;
+    }
+  }
+
+  // Map the column name to the stats
+  @VisibleForTesting Map<String, RowBufferStats> statsMap;
+
+  // Temp stats map to use until all the rows are validated
+  @VisibleForTesting Map<String, RowBufferStats> tempStatsMap;
+
+  // Lock used to protect the buffers from concurrent read/write
+  private final Lock flushLock;
+
+  // Current row count
+  @VisibleForTesting volatile int rowCount;
+
+  // Current buffer size
+  private volatile float bufferSize;
+
+  // Reference to the Streaming Ingest channel that owns this buffer
+  @VisibleForTesting final SnowflakeStreamingIngestChannelInternal<T> owningChannel;
+
+  // Names of non-nullable columns
+  private final Set<String> nonNullableFieldNames;
+
+  AbstractRowBuffer(SnowflakeStreamingIngestChannelInternal<T> channel) {
+    this.owningChannel = channel;
+    this.nonNullableFieldNames = new HashSet<>();
+    this.flushLock = new ReentrantLock();
+    this.rowCount = 0;
+    this.bufferSize = 0F;
+
+    // Initialize empty stats
+    this.statsMap = new HashMap<>();
+    this.tempStatsMap = new HashMap<>();
+  }
+
+  /**
+   * Adds non-nullable filed name.
+   *
+   * @param nonNullableFieldName non-nullable filed name
+   */
+  void addNonNullableFieldName(String nonNullableFieldName) {
+    nonNullableFieldNames.add(nonNullableFieldName);
+  }
+
+  /**
+   * Get the current buffer size
+   *
+   * @return the current buffer size
+   */
+  @Override
+  public float getSize() {
+    return bufferSize;
+  }
+
+  /**
+   * Verify that the input row columns are all valid.
+   *
+   * <p>Checks that the columns, specified in the row, are present in the table and values for all
+   * non-nullable columns are specified.
+   *
+   * @param row the input row
+   * @param error the insert error that we return to the customer
+   * @return the set of input column names
+   */
+  Set<String> verifyInputColumns(
+      Map<String, Object> row, InsertValidationResponse.InsertError error) {
+    Map<String, String> inputColNamesMap =
+        row.keySet().stream()
+            .collect(Collectors.toMap(AbstractRowBuffer::formatColumnName, value -> value));
+
+    // Check for extra columns in the row
+    List<String> extraCols = new ArrayList<>();
+    for (String columnName : inputColNamesMap.keySet()) {
+      if (!hasColumn(columnName)) {
+        extraCols.add(inputColNamesMap.get(columnName));
+      }
+    }
+
+    if (!extraCols.isEmpty()) {
+      if (error != null) {
+        error.setExtraColNames(extraCols);
+      }
+      throw new SFException(
+          ErrorCode.INVALID_ROW,
+          "Extra columns: " + extraCols,
+          "Columns not present in the table shouldn't be specified.");
+    }
+
+    // Check for missing columns in the row
+    List<String> missingCols = new ArrayList<>();
+    for (String columnName : this.nonNullableFieldNames) {
+      if (!inputColNamesMap.containsKey(columnName)) {
+        missingCols.add(columnName);
+      }
+    }
+
+    if (!missingCols.isEmpty()) {
+      if (error != null) {
+        error.setMissingNotNullColNames(missingCols);
+      }
+      throw new SFException(
+          ErrorCode.INVALID_ROW,
+          "Missing columns: " + missingCols,
+          "Values for all non-nullable columns must be specified.");
+    }
+
+    return inputColNamesMap.keySet();
+  }
+
+  /**
+   * Insert a batch of rows into the row buffer
+   *
+   * @param rows input row
+   * @param offsetToken offset token of the latest row in the batch
+   * @return insert response that possibly contains errors because of insertion failures
+   */
+  @Override
+  public InsertValidationResponse insertRows(
+      Iterable<Map<String, Object>> rows, String offsetToken) {
+    float rowSize = 0F;
+    if (!hasColumns()) {
+      throw new SFException(ErrorCode.INTERNAL_ERROR, "Empty column fields");
+    }
+    InsertValidationResponse response = new InsertValidationResponse();
+    this.flushLock.lock();
+    try {
+      if (this.owningChannel.getOnErrorOption() == OpenChannelRequest.OnErrorOption.CONTINUE) {
+        // Used to map incoming row(nth row) to InsertError(for nth row) in response
+        long rowIndex = 0;
+        for (Map<String, Object> row : rows) {
+          InsertValidationResponse.InsertError error =
+              new InsertValidationResponse.InsertError(row, rowIndex);
+          try {
+            Set<String> inputColumnNames = verifyInputColumns(row, error);
+            rowSize += addRow(row, this.rowCount, this.statsMap, inputColumnNames);
+            this.rowCount++;
+            this.bufferSize += rowSize;
+          } catch (SFException e) {
+            error.setException(e);
+            response.addError(error);
+          } catch (Throwable e) {
+            logger.logWarn("Unexpected error happens during insertRows: {}", e.getMessage());
+            error.setException(new SFException(e, ErrorCode.INTERNAL_ERROR, e.getMessage()));
+            response.addError(error);
+          }
+          rowIndex++;
+          if (this.rowCount == Integer.MAX_VALUE) {
+            throw new SFException(ErrorCode.INTERNAL_ERROR, "Row count reaches MAX value");
+          }
+        }
+      } else {
+        // If the on_error option is ABORT, simply throw the first exception
+        float tempRowSize = 0F;
+        int tempRowCount = 0;
+        for (Map<String, Object> row : rows) {
+          Set<String> inputColumnNames = verifyInputColumns(row, null);
+          tempRowSize += addTempRow(row, tempRowCount, this.tempStatsMap, inputColumnNames);
+          tempRowCount++;
+        }
+
+        moveTempRowsToActualBuffer(tempRowCount);
+
+        rowSize = tempRowSize;
+        if ((long) this.rowCount + tempRowCount >= Integer.MAX_VALUE) {
+          throw new SFException(ErrorCode.INTERNAL_ERROR, "Row count reaches MAX value");
+        }
+        this.rowCount += tempRowCount;
+        this.bufferSize += rowSize;
+        this.statsMap.forEach(
+            (colName, stats) ->
+                this.statsMap.put(
+                    colName,
+                    RowBufferStats.getCombinedStats(stats, this.tempStatsMap.get(colName))));
+      }
+
+      this.owningChannel.setOffsetToken(offsetToken);
+      this.owningChannel.collectRowSize(rowSize);
+    } finally {
+      this.tempStatsMap.values().forEach(RowBufferStats::reset);
+      clearTempRows();
+      this.flushLock.unlock();
+    }
+
+    return response;
+  }
+
+  /**
+   * Flush the data in the row buffer by taking the ownership of the old vectors and pass all the
+   * required info back to the flush service to build the blob
+   *
+   * @return A ChannelData object that contains the info needed by the flush service to build a blob
+   */
+  @Override
+  public ChannelData<T> flush() {
+    logger.logDebug("Start get data for channel={}", this.owningChannel.getFullyQualifiedName());
+    if (this.rowCount > 0) {
+      Optional<T> oldData = Optional.empty();
+      int oldRowCount = 0;
+      float oldBufferSize = 0F;
+      long oldRowSequencer = 0;
+      String oldOffsetToken = null;
+      Map<String, RowBufferStats> oldColumnEps = null;
+
+      logger.logDebug(
+          "Arrow buffer flush about to take lock on channel={}",
+          this.owningChannel.getFullyQualifiedName());
+
+      this.flushLock.lock();
+      try {
+        if (this.rowCount > 0) {
+          // Transfer the ownership of the vectors
+          oldData = getSnapshot();
+          oldRowCount = this.rowCount;
+          oldBufferSize = this.bufferSize;
+          oldRowSequencer = this.owningChannel.incrementAndGetRowSequencer();
+          oldOffsetToken = this.owningChannel.getOffsetToken();
+          oldColumnEps = new HashMap<>(this.statsMap);
+          // Reset everything in the buffer once we save all the info
+          reset();
+        }
+      } finally {
+        this.flushLock.unlock();
+      }
+
+      logger.logDebug(
+          "Arrow buffer flush released lock on channel={}, rowCount={}, bufferSize={}",
+          this.owningChannel.getFullyQualifiedName(),
+          rowCount,
+          bufferSize);
+
+      if (oldData.isPresent()) {
+        ChannelData<T> data = new ChannelData<>();
+        data.setVectors(oldData.get());
+        data.setRowCount(oldRowCount);
+        data.setBufferSize(oldBufferSize);
+        data.setChannel(owningChannel);
+        data.setRowSequencer(oldRowSequencer);
+        data.setOffsetToken(oldOffsetToken);
+        data.setColumnEps(oldColumnEps);
+        return data;
+      }
+    }
+    return null;
+  }
+
+  /** Whether row has a column with a given name. */
+  abstract boolean hasColumn(String name);
+
+  /**
+   * Add an input row to the buffer.
+   *
+   * @param row input row
+   * @param curRowIndex current row index to use
+   * @param statsMap column stats map
+   * @param formattedInputColumnNames list of input column names after formatting
+   * @return row size
+   */
+  abstract float addRow(
+      Map<String, Object> row,
+      int curRowIndex,
+      Map<String, RowBufferStats> statsMap,
+      Set<String> formattedInputColumnNames);
+
+  /**
+   * Add an input row to the temporary row buffer.
+   *
+   * <p>The temporary row buffer is used to add rows before validating all of them. Once all the
+   * rows to add have been validated, the temporary row buffer is moved to the actual one.
+   *
+   * @param row input row
+   * @param curRowIndex current row index to use
+   * @param statsMap column stats map
+   * @param formattedInputColumnNames list of input column names after formatting
+   * @return row size
+   */
+  abstract float addTempRow(
+      Map<String, Object> row,
+      int curRowIndex,
+      Map<String, RowBufferStats> statsMap,
+      Set<String> formattedInputColumnNames);
+
+  /** Move rows from the temporary buffer to the current row buffer. */
+  abstract void moveTempRowsToActualBuffer(int tempRowCount);
+
+  /** Clear the temporary row buffer. */
+  abstract void clearTempRows();
+
+  /** If row has any column. */
+  abstract boolean hasColumns();
+
+  /** Reset the variables after each flush. Note that the caller needs to handle synchronization. */
+  void reset() {
+    this.rowCount = 0;
+    this.bufferSize = 0F;
+    this.statsMap.replaceAll(
+        (key, value) -> new RowBufferStats(value.getCollationDefinitionString()));
+  }
+
+  /** Get buffered data snapshot for later flushing. */
+  abstract Optional<T> getSnapshot();
+
+  /** Normalize the column name, given with the inserted row, to send to server side. */
+  static String formatColumnName(String columnName) {
+    Utils.assertStringNotNullOrEmpty("invalid column name", columnName);
+    return (columnName.charAt(0) == '"' && columnName.charAt(columnName.length() - 1) == '"')
+        ? columnName
+        : columnName.toUpperCase();
+  }
+
+  /**
+   * Given a set of col names to stats, build the right ep info
+   *
+   * @param rowCount: count of rows in the given arrow buffer
+   * @param colStats: map of column name to RowBufferStats
+   * @return the EPs built from column stats
+   */
+  static EpInfo buildEpInfoFromStats(long rowCount, Map<String, RowBufferStats> colStats) {
+    EpInfo epInfo = new EpInfo(rowCount, new HashMap<>());
+    for (Map.Entry<String, RowBufferStats> colStat : colStats.entrySet()) {
+      RowBufferStats stat = colStat.getValue();
+      FileColumnProperties dto = new FileColumnProperties(stat);
+
+      String colName = colStat.getKey();
+      epInfo.getColumnEps().put(colName, dto);
+    }
+    return epInfo;
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowFlusher.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import net.snowflake.ingest.utils.Constants;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.Logging;
+import net.snowflake.ingest.utils.SFException;
+import org.apache.arrow.vector.VectorLoader;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.VectorUnloader;
+import org.apache.arrow.vector.compression.CompressionUtil;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.ipc.ArrowWriter;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+
+/**
+ * Converts {@link ChannelData} buffered in {@link RowBuffer} to the Arrow format for faster
+ * processing.
+ */
+public class ArrowFlusher implements Flusher<VectorSchemaRoot> {
+  private static final Logging logger = new Logging(ArrowFlusher.class);
+
+  private final Constants.BdecVersion bdecVersion;
+
+  public ArrowFlusher(Constants.BdecVersion bdecVersion) {
+    this.bdecVersion = bdecVersion;
+  }
+
+  @Override
+  public Flusher.SerializationResult serialize(
+      List<ChannelData<VectorSchemaRoot>> channelsDataPerTable,
+      ByteArrayOutputStream chunkData,
+      String filePath)
+      throws IOException {
+    List<ChannelMetadata> channelsMetadataList = new ArrayList<>();
+    long rowCount = 0L;
+    VectorSchemaRoot root = null;
+    ArrowWriter arrowWriter = null;
+    VectorLoader loader = null;
+    SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> firstChannel = null;
+    Map<String, RowBufferStats> columnEpStatsMapCombined = null;
+
+    try {
+      for (ChannelData<VectorSchemaRoot> data : channelsDataPerTable) {
+        // Create channel metadata
+        ChannelMetadata channelMetadata =
+            ChannelMetadata.builder()
+                .setOwningChannel(data.getChannel())
+                .setRowSequencer(data.getRowSequencer())
+                .setOffsetToken(data.getOffsetToken())
+                .build();
+        // Add channel metadata to the metadata list
+        channelsMetadataList.add(channelMetadata);
+
+        logger.logDebug(
+            "Start building channel={}, rowCount={}, bufferSize={} in blob={}",
+            data.getChannel().getFullyQualifiedName(),
+            data.getRowCount(),
+            data.getBufferSize(),
+            filePath);
+
+        if (root == null) {
+          columnEpStatsMapCombined = data.getColumnEps();
+          root = data.getVectors();
+          arrowWriter =
+              getArrowBatchWriteMode() == Constants.ArrowBatchWriteMode.STREAM
+                  ? new ArrowStreamWriter(root, null, chunkData)
+                  : new ArrowFileWriterWithCompression(
+                      root,
+                      Channels.newChannel(chunkData),
+                      new CustomCompressionCodec(CompressionUtil.CodecType.ZSTD));
+          loader = new VectorLoader(root);
+          firstChannel = data.getChannel();
+          arrowWriter.start();
+        } else {
+          // This method assumes that channelsDataPerTable is grouped by table. We double check
+          // here and throw an error if the assumption is violated
+          if (!data.getChannel()
+              .getFullyQualifiedTableName()
+              .equals(firstChannel.getFullyQualifiedTableName())) {
+            throw new SFException(ErrorCode.INVALID_DATA_IN_CHUNK);
+          }
+
+          columnEpStatsMapCombined =
+              ChannelData.getCombinedColumnStatsMap(columnEpStatsMapCombined, data.getColumnEps());
+
+          VectorUnloader unloader = new VectorUnloader(data.getVectors());
+          ArrowRecordBatch recordBatch = unloader.getRecordBatch();
+          loader.load(recordBatch);
+          recordBatch.close();
+          data.getVectors().close();
+        }
+
+        // Write channel data using the stream writer
+        arrowWriter.writeBatch();
+        rowCount += data.getRowCount();
+
+        logger.logDebug(
+            "Finish building channel={}, rowCount={}, bufferSize={} in blob={}",
+            data.getChannel().getFullyQualifiedName(),
+            data.getRowCount(),
+            data.getBufferSize(),
+            filePath);
+      }
+    } finally {
+      if (arrowWriter != null) {
+        arrowWriter.close();
+        root.close();
+      }
+    }
+    return new Flusher.SerializationResult(
+        channelsMetadataList, columnEpStatsMapCombined, rowCount);
+  }
+
+  private Constants.ArrowBatchWriteMode getArrowBatchWriteMode() {
+    switch (bdecVersion) {
+      case ONE:
+        return Constants.ArrowBatchWriteMode.STREAM;
+      case TWO:
+        return Constants.ArrowBatchWriteMode.FILE;
+      default:
+        throw new SFException(
+            ErrorCode.INTERNAL_ERROR, "Unsupported BLOB_FORMAT_VERSION: " + bdecVersion);
+    }
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -9,18 +9,14 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 import net.snowflake.client.jdbc.internal.google.common.collect.Sets;
 import net.snowflake.client.jdbc.internal.snowflake.common.util.Power10;
-import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.SFException;
@@ -53,49 +49,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * The buffer in the Streaming Ingest channel that holds the un-flushed rows, these rows will be
  * converted to Arrow format for faster processing
  */
-class ArrowRowBuffer {
-
-  // Snowflake table column logical type
-  private static enum ColumnLogicalType {
-    ANY,
-    BOOLEAN,
-    ROWINDEX,
-    NULL,
-    REAL,
-    FIXED,
-    TEXT,
-    CHAR,
-    BINARY,
-    DATE,
-    TIME,
-    TIMESTAMP_LTZ,
-    TIMESTAMP_NTZ,
-    TIMESTAMP_TZ,
-    INTERVAL,
-    RAW,
-    ARRAY,
-    OBJECT,
-    VARIANT,
-    ROW,
-    SEQUENCE,
-    FUNCTION,
-    USER_DEFINED_TYPE,
-  }
-
-  // Snowflake table column physical type
-  private static enum ColumnPhysicalType {
-    ROWINDEX,
-    DOUBLE,
-    SB1,
-    SB2,
-    SB4,
-    SB8,
-    SB16,
-    LOB,
-    BINARY,
-    ROW,
-  }
-
+class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
   private static final Logging logger = new Logging(ArrowRowBuffer.class);
 
   // Constants for column fields
@@ -124,66 +78,18 @@ class ArrowRowBuffer {
   // Map the column name to Arrow column field
   private final Map<String, Field> fields;
 
-  // Map the column name to the stats
-  @VisibleForTesting Map<String, RowBufferStats> statsMap;
-
-  // Temp stats map to use until all the rows are validated
-  @VisibleForTesting Map<String, RowBufferStats> tempStatsMap;
-
-  // Lock used to protect the buffers from concurrent read/write
-  private final Lock flushLock;
-
-  // Current row count
-  @VisibleForTesting volatile int rowCount;
-
   // Allocator used to allocate the buffers
   private final BufferAllocator allocator;
-
-  // Current buffer size
-  private volatile float bufferSize;
-
-  // Reference to the Streaming Ingest channel that owns this buffer
-  @VisibleForTesting final SnowflakeStreamingIngestChannelInternal owningChannel;
-
-  // Names of non-nullable columns
-  private final Set<String> nonNullableFieldNames;
-
-  /**
-   * Given a set of col names to stats, build the right ep info
-   *
-   * @param rowCount: count of rows in the given arrow buffer
-   * @param colStats: map of column name to RowBufferStats
-   * @return the EPs built from column stats
-   */
-  static EpInfo buildEpInfoFromStats(long rowCount, Map<String, RowBufferStats> colStats) {
-    EpInfo epInfo = new EpInfo(rowCount, new HashMap<>());
-    for (Map.Entry<String, RowBufferStats> colStat : colStats.entrySet()) {
-      RowBufferStats stat = colStat.getValue();
-      FileColumnProperties dto = new FileColumnProperties(stat);
-
-      String colName = colStat.getKey();
-      epInfo.getColumnEps().put(colName, dto);
-    }
-    return epInfo;
-  }
 
   /**
    * Construct a ArrowRowBuffer object
    *
-   * @param channel
+   * @param channel client channel
    */
-  ArrowRowBuffer(SnowflakeStreamingIngestChannelInternal channel) {
-    this.owningChannel = channel;
+  ArrowRowBuffer(SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel) {
+    super(channel);
     this.allocator = channel.getAllocator();
     this.fields = new HashMap<>();
-    this.nonNullableFieldNames = new HashSet<>();
-    this.flushLock = new ReentrantLock();
-    this.rowCount = 0;
-    this.bufferSize = 0F;
-
-    // Initialize empty stats
-    this.statsMap = new HashMap<>();
-    this.tempStatsMap = new HashMap<>();
   }
 
   /**
@@ -191,7 +97,8 @@ class ArrowRowBuffer {
    *
    * @param columns list of column metadata
    */
-  void setupSchema(List<ColumnMetadata> columns) {
+  @Override
+  public void setupSchema(List<ColumnMetadata> columns) {
     List<FieldVector> vectors = new ArrayList<>();
     List<FieldVector> tempVectors = new ArrayList<>();
 
@@ -199,7 +106,7 @@ class ArrowRowBuffer {
       Field field = buildField(column);
       FieldVector vector = field.createVector(this.allocator);
       if (!field.isNullable()) {
-        this.nonNullableFieldNames.add(field.getName());
+        addNonNullableFieldName(field.getName());
       }
       this.fields.put(column.getName(), field);
       vectors.add(vector);
@@ -220,7 +127,8 @@ class ArrowRowBuffer {
    * Close the row buffer and release resources. Note that the caller needs to handle
    * synchronization
    */
-  void close(String name) {
+  @Override
+  public void close(String name) {
     long allocatedBeforeRelease = this.allocator.getAllocatedMemory();
     if (this.vectorsRoot != null) {
       this.vectorsRoot.close();
@@ -249,197 +157,10 @@ class ArrowRowBuffer {
   }
 
   /** Reset the variables after each flush. Note that the caller needs to handle synchronization */
+  @Override
   void reset() {
+    super.reset();
     this.vectorsRoot.clear();
-    this.rowCount = 0;
-    this.bufferSize = 0F;
-    this.statsMap.replaceAll(
-        (key, value) -> new RowBufferStats(value.getCollationDefinitionString()));
-  }
-
-  /**
-   * Get the current buffer size
-   *
-   * @return the current buffer size
-   */
-  float getSize() {
-    return this.bufferSize;
-  }
-
-  /**
-   * Insert a batch of rows into the row buffer
-   *
-   * @param rows input row
-   * @param offsetToken offset token of the latest row in the batch
-   * @return insert response that possibly contains errors because of insertion failures
-   */
-  InsertValidationResponse insertRows(Iterable<Map<String, Object>> rows, String offsetToken) {
-    float rowSize = 0F;
-    if (this.fields.isEmpty()) {
-      throw new SFException(ErrorCode.INTERNAL_ERROR, "Empty column fields");
-    }
-
-    InsertValidationResponse response = new InsertValidationResponse();
-    this.flushLock.lock();
-    try {
-      if (this.owningChannel.getOnErrorOption() == OpenChannelRequest.OnErrorOption.CONTINUE) {
-        // Used to map incoming row(nth row) to InsertError(for nth row) in response
-        long rowIndex = 0;
-        for (Map<String, Object> row : rows) {
-          InsertValidationResponse.InsertError error =
-              new InsertValidationResponse.InsertError(row, rowIndex);
-          try {
-            Set<String> inputColumnNames = verifyInputColumns(row, error);
-            rowSize +=
-                convertRowToArrow(
-                    row, this.vectorsRoot, this.rowCount, this.statsMap, inputColumnNames);
-            this.rowCount++;
-            this.bufferSize += rowSize;
-          } catch (SFException e) {
-            error.setException(e);
-            response.addError(error);
-          } catch (Throwable e) {
-            logger.logWarn("Unexpected error happens during insertRows: {}", e.getMessage());
-            error.setException(new SFException(e, ErrorCode.INTERNAL_ERROR, e.getMessage()));
-            response.addError(error);
-          }
-          rowIndex++;
-          if (this.rowCount == Integer.MAX_VALUE) {
-            throw new SFException(ErrorCode.INTERNAL_ERROR, "Row count reaches MAX value");
-          }
-        }
-      } else {
-        // If the on_error option is ABORT, simply throw the first exception
-        float tempRowSize = 0F;
-        int tempRowCount = 0;
-        for (Map<String, Object> row : rows) {
-          Set<String> inputColumnNames = verifyInputColumns(row, null);
-          tempRowSize +=
-              convertRowToArrow(
-                  row, this.tempVectorsRoot, tempRowCount, this.tempStatsMap, inputColumnNames);
-          tempRowCount++;
-        }
-
-        // If all the rows are inserted successfully, transfer the rows from temp vectors to
-        // the final vectors and update the row size and row count
-        // TODO: switch to VectorSchemaRootAppender once it works for all vector types
-        for (Field field : fields.values()) {
-          FieldVector from = this.tempVectorsRoot.getVector(field);
-          FieldVector to = this.vectorsRoot.getVector(field);
-          for (int rowIdx = 0; rowIdx < tempRowCount; rowIdx++) {
-            to.copyFromSafe(rowIdx, this.rowCount + rowIdx, from);
-          }
-        }
-        rowSize = tempRowSize;
-        if ((long) this.rowCount + tempRowCount >= Integer.MAX_VALUE) {
-          throw new SFException(ErrorCode.INTERNAL_ERROR, "Row count reaches MAX value");
-        }
-        this.rowCount += tempRowCount;
-        this.bufferSize += rowSize;
-        this.statsMap.forEach(
-            (colName, stats) -> {
-              this.statsMap.put(
-                  colName, RowBufferStats.getCombinedStats(stats, this.tempStatsMap.get(colName)));
-            });
-      }
-
-      this.owningChannel.setOffsetToken(offsetToken);
-      this.owningChannel.collectRowSize(rowSize);
-    } finally {
-      this.tempStatsMap.values().forEach(RowBufferStats::reset);
-      this.tempVectorsRoot.clear();
-      this.flushLock.unlock();
-    }
-
-    return response;
-  }
-
-  /**
-   * Flush the data in the row buffer by taking the ownership of the old vectors and pass all the
-   * required info back to the flush service to build the blob
-   *
-   * @return A ChannelData object that contains the info needed by the flush service to build a blob
-   */
-  ChannelData flush() {
-    logger.logDebug("Start get data for channel={}", this.owningChannel.getFullyQualifiedName());
-    if (this.rowCount > 0) {
-      List<FieldVector> oldVectors = new ArrayList<>();
-      int oldRowCount = 0;
-      float oldBufferSize = 0F;
-      long oldRowSequencer = 0;
-      String oldOffsetToken = null;
-      Map<String, RowBufferStats> oldColumnEps = null;
-
-      logger.logDebug(
-          "Arrow buffer flush about to take lock on channel={}",
-          this.owningChannel.getFullyQualifiedName());
-
-      this.flushLock.lock();
-      try {
-        if (this.rowCount > 0) {
-          // Transfer the ownership of the vectors
-          for (FieldVector vector : this.vectorsRoot.getFieldVectors()) {
-            vector.setValueCount(this.rowCount);
-            if (vector instanceof DecimalVector) {
-              // DecimalVectors do not transfer FieldType metadata when using
-              // vector.getTransferPair. We need to explicitly create the new vector to transfer to
-              // in order to keep the metadata.
-              ArrowType arrowType =
-                  new ArrowType.Decimal(
-                      ((DecimalVector) vector).getPrecision(),
-                      ((DecimalVector) vector).getScale(),
-                      DECIMAL_BIT_WIDTH);
-              FieldType fieldType =
-                  new FieldType(
-                      vector.getField().isNullable(),
-                      arrowType,
-                      null,
-                      vector.getField().getMetadata());
-              Field f = new Field(vector.getName(), fieldType, null);
-              DecimalVector newVector = new DecimalVector(f, this.allocator);
-              TransferPair t = vector.makeTransferPair(newVector);
-              t.transfer();
-              oldVectors.add((FieldVector) t.getTo());
-            } else {
-              TransferPair t = vector.getTransferPair(this.allocator);
-              t.transfer();
-              oldVectors.add((FieldVector) t.getTo());
-            }
-          }
-
-          oldRowCount = this.rowCount;
-          oldBufferSize = this.bufferSize;
-          oldRowSequencer = this.owningChannel.incrementAndGetRowSequencer();
-          oldOffsetToken = this.owningChannel.getOffsetToken();
-          oldColumnEps = new HashMap<>(this.statsMap);
-          // Reset everything in the buffer once we save all the info
-          reset();
-        }
-      } finally {
-        this.flushLock.unlock();
-      }
-
-      logger.logDebug(
-          "Arrow buffer flush released lock on channel={}, rowCount={}, bufferSize={}",
-          this.owningChannel.getFullyQualifiedName(),
-          rowCount,
-          bufferSize);
-
-      if (!oldVectors.isEmpty()) {
-        ChannelData data = new ChannelData();
-        VectorSchemaRoot vectors = new VectorSchemaRoot(oldVectors);
-        vectors.setRowCount(oldRowCount);
-        data.setVectors(vectors);
-        data.setBufferSize(oldBufferSize);
-        data.setChannel(this.owningChannel);
-        data.setRowSequencer(oldRowSequencer);
-        data.setOffsetToken(oldOffsetToken);
-        data.setColumnEps(oldColumnEps);
-
-        return data;
-      }
-    }
-    return null;
   }
 
   /**
@@ -621,62 +342,85 @@ class ArrowRowBuffer {
     return new Field(column.getName(), fieldType, children);
   }
 
-  private String formatColumnName(String columnName) {
-    Utils.assertStringNotNullOrEmpty("invalid column name", columnName);
-    return (columnName.charAt(0) == '"' && columnName.charAt(columnName.length() - 1) == '"')
-        ? columnName
-        : columnName.toUpperCase();
+  @Override
+  void moveTempRowsToActualBuffer(int tempRowCount) {
+    // If all the rows are inserted successfully, transfer the rows from temp vectors to
+    // the final vectors and update the row size and row count
+    // TODO: switch to VectorSchemaRootAppender once it works for all vector types
+    for (Field field : fields.values()) {
+      FieldVector from = this.tempVectorsRoot.getVector(field);
+      FieldVector to = this.vectorsRoot.getVector(field);
+      for (int rowIdx = 0; rowIdx < tempRowCount; rowIdx++) {
+        to.copyFromSafe(rowIdx, this.rowCount + rowIdx, from);
+      }
+    }
   }
 
-  /**
-   * Verify that the input row columns are all valid
-   *
-   * @param row the input row
-   * @param error the insert error that we return to the customer
-   * @return the set of input column names
-   */
-  private Set<String> verifyInputColumns(
-      Map<String, Object> row, InsertValidationResponse.InsertError error) {
-    Map<String, String> inputColNamesMap =
-        row.keySet().stream().collect(Collectors.toMap(this::formatColumnName, value -> value));
+  @Override
+  void clearTempRows() {
+    tempVectorsRoot.clear();
+  }
 
-    // Check for extra columns in the row
-    List<String> extraCols = new ArrayList<>();
-    for (String columnName : inputColNamesMap.keySet()) {
-      if (!this.fields.containsKey(columnName)) {
-        extraCols.add(inputColNamesMap.get(columnName));
+  @Override
+  boolean hasColumns() {
+    return !fields.isEmpty();
+  }
+
+  @Override
+  Optional<VectorSchemaRoot> getSnapshot() {
+    List<FieldVector> oldVectors = new ArrayList<>();
+    for (FieldVector vector : this.vectorsRoot.getFieldVectors()) {
+      vector.setValueCount(this.rowCount);
+      if (vector instanceof DecimalVector) {
+        // DecimalVectors do not transfer FieldType metadata when using
+        // vector.getTransferPair. We need to explicitly create the new vector to transfer to
+        // in order to keep the metadata.
+        ArrowType arrowType =
+            new ArrowType.Decimal(
+                ((DecimalVector) vector).getPrecision(),
+                ((DecimalVector) vector).getScale(),
+                DECIMAL_BIT_WIDTH);
+        FieldType fieldType =
+            new FieldType(
+                vector.getField().isNullable(), arrowType, null, vector.getField().getMetadata());
+        Field f = new Field(vector.getName(), fieldType, null);
+        DecimalVector newVector = new DecimalVector(f, this.allocator);
+        TransferPair t = vector.makeTransferPair(newVector);
+        t.transfer();
+        oldVectors.add((FieldVector) t.getTo());
+      } else {
+        TransferPair t = vector.getTransferPair(this.allocator);
+        t.transfer();
+        oldVectors.add((FieldVector) t.getTo());
       }
     }
+    VectorSchemaRoot root = new VectorSchemaRoot(oldVectors);
+    root.setRowCount(this.rowCount);
+    return oldVectors.isEmpty() ? Optional.empty() : Optional.of(root);
+  }
 
-    if (!extraCols.isEmpty()) {
-      if (error != null) {
-        error.setExtraColNames(extraCols);
-      }
-      throw new SFException(
-          ErrorCode.INVALID_ROW,
-          "Extra columns: " + extraCols,
-          "Columns not present in the table shouldn't be specified.");
-    }
+  @Override
+  boolean hasColumn(String name) {
+    return this.fields.get(name) != null;
+  }
 
-    // Check for missing columns in the row
-    List<String> missingCols = new ArrayList<>();
-    for (String columnName : this.nonNullableFieldNames) {
-      if (!inputColNamesMap.containsKey(columnName)) {
-        missingCols.add(columnName);
-      }
-    }
+  @Override
+  float addRow(
+      Map<String, Object> row,
+      int curRowIndex,
+      Map<String, RowBufferStats> statsMap,
+      Set<String> formattedInputColumnNames) {
+    return convertRowToArrow(row, vectorsRoot, curRowIndex, statsMap, formattedInputColumnNames);
+  }
 
-    if (!missingCols.isEmpty()) {
-      if (error != null) {
-        error.setMissingNotNullColNames(missingCols);
-      }
-      throw new SFException(
-          ErrorCode.INVALID_ROW,
-          "Missing columns: " + missingCols,
-          "Values for all non-nullable columns must be specified.");
-    }
-
-    return inputColNamesMap.keySet();
+  @Override
+  float addTempRow(
+      Map<String, Object> row,
+      int curRowIndex,
+      Map<String, RowBufferStats> statsMap,
+      Set<String> formattedInputColumnNames) {
+    return convertRowToArrow(
+        row, tempVectorsRoot, curRowIndex, statsMap, formattedInputColumnNames);
   }
 
   /**
@@ -699,7 +443,7 @@ class ArrowRowBuffer {
     float rowBufferSize = 0F;
     for (Map.Entry<String, Object> entry : row.entrySet()) {
       rowBufferSize += 0.125; // 1/8 for null value bitmap
-      String columnName = this.formatColumnName(entry.getKey());
+      String columnName = formatColumnName(entry.getKey());
       Object value = entry.getValue();
       Field field = this.fields.get(columnName);
       Utils.assertNotNull("Arrow column field", field);
@@ -1022,5 +766,10 @@ class ArrowRowBuffer {
       throw new SFException(ErrorCode.INTERNAL_ERROR, "Unexpected FieldType");
     }
     stats.incCurrentNullCount();
+  }
+
+  @Override
+  public Flusher<VectorSchemaRoot> createFlusher(Constants.BdecVersion bdecVersion) {
+    return new ArrowFlusher(bdecVersion);
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
@@ -102,16 +102,13 @@ class BlobBuilder {
    * @param filePath blob file full path
    * @param chunkData uncompressed chunk data
    * @param blockSizeToAlignTo block size to align to for encryption
-   * @param arrowBatchWriteMode Arrow format write mode
+   * @param compress whether to compress the chunk
    * @return padded compressed chunk data, aligned to blockSizeToAlignTo, and actual length of
    *     compressed data before padding at the end
    * @throws IOException
    */
   static Pair<byte[], Integer> compressIfNeededAndPadChunk(
-      String filePath,
-      ByteArrayOutputStream chunkData,
-      int blockSizeToAlignTo,
-      Constants.ArrowBatchWriteMode arrowBatchWriteMode)
+      String filePath, ByteArrayOutputStream chunkData, int blockSizeToAlignTo, boolean compress)
       throws IOException {
     // Encryption needs padding to the ENCRYPTION_ALGORITHM_BLOCK_SIZE_BYTES
     // to align with decryption on the Snowflake query path starting from this chunk offset.
@@ -119,7 +116,7 @@ class BlobBuilder {
     // Hence, the actual chunk size is smaller by the padding size.
     // The compression on the Snowflake query path needs the correct size of the compressed
     // data.
-    if (arrowBatchWriteMode == Constants.ArrowBatchWriteMode.STREAM) {
+    if (compress) {
       // Stream write mode does not support column level compression.
       // Compress the chunk data and pad it for encryption.
       return BlobBuilder.compress(filePath, chunkData, blockSizeToAlignTo);
@@ -147,7 +144,7 @@ class BlobBuilder {
       List<byte[]> chunksDataList,
       long chunksChecksum,
       long chunksDataSize,
-      Constants.BdecVerion bdecVersion)
+      Constants.BdecVersion bdecVersion)
       throws IOException {
     byte[] chunkMetadataListInBytes = MAPPER.writeValueAsBytes(chunksMetadataList);
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadata.java
@@ -14,7 +14,7 @@ import net.snowflake.ingest.utils.ParameterProvider;
 class BlobMetadata {
   private final String path;
   private final String md5;
-  private final Constants.BdecVerion bdecVersion;
+  private final Constants.BdecVersion bdecVersion;
   private final List<ChunkMetadata> chunks;
 
   BlobMetadata(String path, String md5, List<ChunkMetadata> chunks) {
@@ -22,7 +22,7 @@ class BlobMetadata {
   }
 
   BlobMetadata(
-      String path, String md5, Constants.BdecVerion bdecVersion, List<ChunkMetadata> chunks) {
+      String path, String md5, Constants.BdecVersion bdecVersion, List<ChunkMetadata> chunks) {
     this.path = path;
     this.md5 = md5;
     this.bdecVersion = bdecVersion;
@@ -30,7 +30,7 @@ class BlobMetadata {
   }
 
   @JsonIgnore
-  Constants.BdecVerion getVersion() {
+  Constants.BdecVersion getVersion() {
     return bdecVersion;
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
@@ -13,12 +13,14 @@ import java.util.concurrent.ConcurrentHashMap;
  * channels belong to the same table will be stored together in order to combine the channel data
  * during flush. The key is a fully qualified table name and the value is a set of channels that
  * belongs to this table
+ *
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
  */
-class ChannelCache {
+class ChannelCache<T> {
   // Cache to hold all the valid channels, the key for the outer map is FullyQualifiedTableName and
   // the key for the inner map is ChannelName
   private ConcurrentHashMap<
-          String, ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal>>
+          String, ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<T>>>
       cache = new ConcurrentHashMap<>();
 
   /**
@@ -26,12 +28,13 @@ class ChannelCache {
    *
    * @param channel
    */
-  void addChannel(SnowflakeStreamingIngestChannelInternal channel) {
-    ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal> channels =
+  void addChannel(SnowflakeStreamingIngestChannelInternal<T> channel) {
+    ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<T>> channels =
         this.cache.computeIfAbsent(
             channel.getFullyQualifiedTableName(), v -> new ConcurrentHashMap<>());
 
-    SnowflakeStreamingIngestChannelInternal oldChannel = channels.put(channel.getName(), channel);
+    SnowflakeStreamingIngestChannelInternal<T> oldChannel =
+        channels.put(channel.getName(), channel);
     // Invalidate old channel if it exits to block new inserts and return error to users earlier
     if (oldChannel != null) {
       oldChannel.invalidate();
@@ -43,7 +46,7 @@ class ChannelCache {
    *
    * @return
    */
-  Iterator<Map.Entry<String, ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal>>>
+  Iterator<Map.Entry<String, ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<T>>>>
       iterator() {
     return this.cache.entrySet().iterator();
   }
@@ -57,11 +60,11 @@ class ChannelCache {
 
   /** Remove a channel in the channel cache if the channel sequencer matches */
   // TODO: background cleaner to cleanup old stale channels that are not closed?
-  void removeChannelIfSequencersMatch(SnowflakeStreamingIngestChannelInternal channel) {
+  void removeChannelIfSequencersMatch(SnowflakeStreamingIngestChannelInternal<T> channel) {
     cache.computeIfPresent(
         channel.getFullyQualifiedTableName(),
         (k, v) -> {
-          SnowflakeStreamingIngestChannelInternal channelInCache = v.get(channel.getName());
+          SnowflakeStreamingIngestChannelInternal<T> channelInCache = v.get(channel.getName());
           // We need to compare the channel sequencer in case the old channel was already been
           // removed
           return channelInCache != null
@@ -81,10 +84,10 @@ class ChannelCache {
       String channelName,
       Long channelSequencer) {
     String fullyQualifiedTableName = String.format("%s.%s.%s", dbName, schemaName, tableName);
-    ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal> channelsMapPerTable =
+    ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<T>> channelsMapPerTable =
         cache.get(fullyQualifiedTableName);
     if (channelsMapPerTable != null) {
-      SnowflakeStreamingIngestChannelInternal channel = channelsMapPerTable.get(channelName);
+      SnowflakeStreamingIngestChannelInternal<T> channel = channelsMapPerTable.get(channelName);
       if (channel != null && channel.getChannelSequencer().equals(channelSequencer)) {
         channel.invalidate();
       }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelData.java
@@ -8,18 +8,20 @@ import java.util.HashMap;
 import java.util.Map;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
-import org.apache.arrow.vector.VectorSchemaRoot;
 
 /**
  * Contains the data and metadata returned for each channel flush, which will be used to build the
  * blob and register blob request
+ *
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot}
  */
-class ChannelData {
+class ChannelData<T> {
   private Long rowSequencer;
   private String offsetToken;
-  private VectorSchemaRoot vectors;
+  private T vectors;
   private float bufferSize;
-  private SnowflakeStreamingIngestChannelInternal channel;
+  private int rowCount;
+  private SnowflakeStreamingIngestChannelInternal<T> channel;
   private Map<String, RowBufferStats> columnEps;
 
   // TODO performance test this vs in place update
@@ -78,16 +80,20 @@ class ChannelData {
     this.offsetToken = offsetToken;
   }
 
-  VectorSchemaRoot getVectors() {
+  T getVectors() {
     return this.vectors;
   }
 
-  void setVectors(VectorSchemaRoot vectors) {
+  void setVectors(T vectors) {
     this.vectors = vectors;
   }
 
   int getRowCount() {
-    return this.vectors.getRowCount();
+    return this.rowCount;
+  }
+
+  void setRowCount(int rowCount) {
+    this.rowCount = rowCount;
   }
 
   float getBufferSize() {
@@ -98,11 +104,11 @@ class ChannelData {
     this.bufferSize = bufferSize;
   }
 
-  SnowflakeStreamingIngestChannelInternal getChannel() {
+  SnowflakeStreamingIngestChannelInternal<T> getChannel() {
     return this.channel;
   }
 
-  void setChannel(SnowflakeStreamingIngestChannelInternal channel) {
+  void setChannel(SnowflakeStreamingIngestChannelInternal<T> channel) {
     this.channel = channel;
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -126,8 +126,21 @@ class DataValidationUtil {
    */
   static TimestampWrapper validateAndParseTimestampNtzSb16(
       Object input, Map<String, String> metadata) {
+    int scale = Integer.parseInt(metadata.get(ArrowRowBuffer.COLUMN_SCALE));
+    return validateAndParseTimestampNtzSb16(input, scale);
+  }
+
+  /**
+   * Validates and parses input for TIMESTAMP_NTZ Snowflake type
+   *
+   * @param input String date in valid format or seconds past the epoch. Accepts fractional seconds
+   *     with precision up to the column's scale
+   * @param scale decimal scale of timestamp 16 byte integer
+   * @return TimestampWrapper with epoch seconds, fractional seconds, and epoch time in the column
+   *     scale
+   */
+  static TimestampWrapper validateAndParseTimestampNtzSb16(Object input, int scale) {
     try {
-      int scale = Integer.parseInt(metadata.get(ArrowRowBuffer.COLUMN_SCALE));
       String valueString = getStringValue(input);
 
       long epoch;
@@ -194,10 +207,22 @@ class DataValidationUtil {
    *     scale
    */
   static TimestampWrapper validateAndParseTimestampTz(Object input, Map<String, String> metadata) {
+    int scale = Integer.parseInt(metadata.get(ArrowRowBuffer.COLUMN_SCALE));
+    return validateAndParseTimestampTz(input, scale);
+  }
+
+  /**
+   * Validates and parses input for TIMESTAMP_TZ Snowflake type
+   *
+   * @param input TIMESTAMP_TZ in "2021-01-01 01:00:00 +0100" format
+   * @param scale decimal scale of timestamp 16 byte integer
+   * @return TimestampWrapper with epoch seconds, fractional seconds, and epoch time in the column
+   *     scale
+   */
+  static TimestampWrapper validateAndParseTimestampTz(Object input, int scale) {
     try {
       if (input instanceof String) {
         String stringInput = (String) input;
-        int scale = Integer.parseInt(metadata.get(ArrowRowBuffer.COLUMN_SCALE));
         SFTimestamp timestamp = snowflakeDateTimeFormatter.parse(stringInput);
         if (timestamp == null) {
           throw new SFException(

--- a/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface to convert {@link ChannelData} buffered in {@link RowBuffer} to the underlying format
+ * implementation for faster processing.
+ *
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ */
+public interface Flusher<T> {
+  /**
+   * Serialize buffered rows into the underlying format.
+   *
+   * @param channelsDataPerTable buffered rows
+   * @param chunkData output
+   * @param filePath file path
+   * @return {@link SerializationResult}
+   * @throws IOException
+   */
+  SerializationResult serialize(
+      List<ChannelData<T>> channelsDataPerTable, ByteArrayOutputStream chunkData, String filePath)
+      throws IOException;
+
+  /** Holds result of the buffered rows conversion: channel metadata and stats. */
+  class SerializationResult {
+    final List<ChannelMetadata> channelsMetadataList;
+    final Map<String, RowBufferStats> columnEpStatsMapCombined;
+    final long rowCount;
+
+    public SerializationResult(
+        List<ChannelMetadata> channelsMetadataList,
+        Map<String, RowBufferStats> columnEpStatsMapCombined,
+        long rowCount) {
+      this.channelsMetadataList = channelsMetadataList;
+      this.columnEpStatsMapCombined = columnEpStatsMapCombined;
+      this.rowCount = rowCount;
+    }
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBuffer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import java.util.List;
+import java.util.Map;
+import net.snowflake.ingest.streaming.InsertValidationResponse;
+import net.snowflake.ingest.utils.Constants;
+
+/**
+ * Interface for the buffer in the Streaming Ingest channel that holds the un-flushed rows, these
+ * rows will be converted to the underlying format implementation for faster processing
+ *
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ */
+interface RowBuffer<T> {
+  /**
+   * Setup the column fields and vectors using the column metadata from the server
+   *
+   * @param columns list of column metadata
+   */
+  void setupSchema(List<ColumnMetadata> columns);
+
+  /**
+   * Insert a batch of rows into the row buffer
+   *
+   * @param rows input row
+   * @param offsetToken offset token of the latest row in the batch
+   * @return insert response that possibly contains errors because of insertion failures
+   */
+  InsertValidationResponse insertRows(Iterable<Map<String, Object>> rows, String offsetToken);
+
+  /**
+   * Flush the data in the row buffer by taking the ownership of the old vectors and pass all the
+   * required info back to the flush service to build the blob
+   *
+   * @return A ChannelData object that contains the info needed by the flush service to build a blob
+   */
+  ChannelData<T> flush();
+
+  /**
+   * Close the row buffer and release resources. Note that the caller needs to handle
+   * synchronization
+   */
+  void close(String name);
+
+  /**
+   * Get the current buffer size
+   *
+   * @return the current buffer size
+   */
+  float getSize();
+
+  /**
+   * Create {@link Flusher} implementation to flush the buffered rows to the underlying format
+   * implementation for faster processing.
+   *
+   * @param bdecVersion version of the BDEC file format to generate
+   * @return flusher
+   */
+  Flusher<T> createFlusher(Constants.BdecVersion bdecVersion);
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelFactory.java
@@ -9,12 +9,12 @@ import net.snowflake.ingest.utils.Utils;
 
 /** Builds a Streaming Ingest channel for a specific Streaming Ingest client */
 class SnowflakeStreamingIngestChannelFactory {
-  static SnowflakeStreamingIngestChannelBuilder builder(String name) {
-    return new SnowflakeStreamingIngestChannelBuilder(name);
+  static <T> SnowflakeStreamingIngestChannelBuilder<T> builder(String name) {
+    return new SnowflakeStreamingIngestChannelBuilder<>(name);
   }
 
   // Builder class to build a SnowflakeStreamingIngestChannel
-  static class SnowflakeStreamingIngestChannelBuilder {
+  static class SnowflakeStreamingIngestChannelBuilder<T> {
     private String name;
     private String dbName;
     private String schemaName;
@@ -22,7 +22,7 @@ class SnowflakeStreamingIngestChannelFactory {
     private String offsetToken;
     private Long channelSequencer;
     private Long rowSequencer;
-    private SnowflakeStreamingIngestClientInternal owningClient;
+    private SnowflakeStreamingIngestClientInternal<T> owningClient;
     private String encryptionKey;
     private Long encryptionKeyId;
     private OpenChannelRequest.OnErrorOption onErrorOption;
@@ -31,59 +31,59 @@ class SnowflakeStreamingIngestChannelFactory {
       this.name = name;
     }
 
-    SnowflakeStreamingIngestChannelBuilder setDBName(String dbName) {
+    SnowflakeStreamingIngestChannelBuilder<T> setDBName(String dbName) {
       this.dbName = dbName;
       return this;
     }
 
-    SnowflakeStreamingIngestChannelBuilder setSchemaName(String schemaName) {
+    SnowflakeStreamingIngestChannelBuilder<T> setSchemaName(String schemaName) {
       this.schemaName = schemaName;
       return this;
     }
 
-    SnowflakeStreamingIngestChannelBuilder setTableName(String tableName) {
+    SnowflakeStreamingIngestChannelBuilder<T> setTableName(String tableName) {
       this.tableName = tableName;
       return this;
     }
 
-    SnowflakeStreamingIngestChannelBuilder setOffsetToken(String offsetToken) {
+    SnowflakeStreamingIngestChannelBuilder<T> setOffsetToken(String offsetToken) {
       this.offsetToken = offsetToken;
       return this;
     }
 
-    SnowflakeStreamingIngestChannelBuilder setChannelSequencer(Long sequencer) {
+    SnowflakeStreamingIngestChannelBuilder<T> setChannelSequencer(Long sequencer) {
       this.channelSequencer = sequencer;
       return this;
     }
 
-    SnowflakeStreamingIngestChannelBuilder setRowSequencer(Long sequencer) {
+    SnowflakeStreamingIngestChannelBuilder<T> setRowSequencer(Long sequencer) {
       this.rowSequencer = sequencer;
       return this;
     }
 
-    SnowflakeStreamingIngestChannelBuilder setEncryptionKey(String encryptionKey) {
+    SnowflakeStreamingIngestChannelBuilder<T> setEncryptionKey(String encryptionKey) {
       this.encryptionKey = encryptionKey;
       return this;
     }
 
-    SnowflakeStreamingIngestChannelBuilder setEncryptionKeyId(Long encryptionKeyId) {
+    SnowflakeStreamingIngestChannelBuilder<T> setEncryptionKeyId(Long encryptionKeyId) {
       this.encryptionKeyId = encryptionKeyId;
       return this;
     }
 
-    SnowflakeStreamingIngestChannelBuilder setOnErrorOption(
+    SnowflakeStreamingIngestChannelBuilder<T> setOnErrorOption(
         OpenChannelRequest.OnErrorOption onErrorOption) {
       this.onErrorOption = onErrorOption;
       return this;
     }
 
-    SnowflakeStreamingIngestChannelBuilder setOwningClient(
-        SnowflakeStreamingIngestClientInternal client) {
+    SnowflakeStreamingIngestChannelBuilder<T> setOwningClient(
+        SnowflakeStreamingIngestClientInternal<T> client) {
       this.owningClient = client;
       return this;
     }
 
-    SnowflakeStreamingIngestChannelInternal build() {
+    SnowflakeStreamingIngestChannelInternal<T> build() {
       Utils.assertStringNotNullOrEmpty("channel name", this.name);
       Utils.assertStringNotNullOrEmpty("table name", this.tableName);
       Utils.assertStringNotNullOrEmpty("schema name", this.schemaName);
@@ -94,7 +94,7 @@ class SnowflakeStreamingIngestChannelFactory {
       Utils.assertStringNotNullOrEmpty("encryption key", this.encryptionKey);
       Utils.assertNotNull("encryption key_id", this.encryptionKeyId);
       Utils.assertNotNull("on_error option", this.onErrorOption);
-      return new SnowflakeStreamingIngestChannelInternal(
+      return new SnowflakeStreamingIngestChannelInternal<>(
           this.name,
           this.dbName,
           this.schemaName,

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -79,7 +79,7 @@ public class Constants {
   }
 
   /** The write mode to generate Arrow BDEC file. */
-  public enum BdecVerion {
+  public enum BdecVersion {
     /** Uses Arrow to generate BDEC chunks with {@link ArrowBatchWriteMode#STREAM}. */
     ONE(1),
 
@@ -88,7 +88,7 @@ public class Constants {
 
     private final byte version;
 
-    BdecVerion(int version) {
+    BdecVersion(int version) {
       if (version > Byte.MAX_VALUE || version < Byte.MIN_VALUE) {
         throw new IllegalArgumentException("Version does not fit into the byte data type");
       }
@@ -99,12 +99,12 @@ public class Constants {
       return version;
     }
 
-    public static BdecVerion fromInt(int val) {
+    public static BdecVersion fromInt(int val) {
       if (val > Byte.MAX_VALUE || val < Byte.MIN_VALUE) {
         throw new IllegalArgumentException("Version does not fit into the byte data type");
       }
       byte version = (byte) val;
-      for (BdecVerion eversion : BdecVerion.values()) {
+      for (BdecVersion eversion : BdecVersion.values()) {
         if (eversion.version == version) {
           return eversion;
         }
@@ -112,7 +112,7 @@ public class Constants {
       throw new IllegalArgumentException(
           String.format(
               "Unsupported BLOB_FORMAT_VERSION = '%d', allowed values are %s",
-              version, Arrays.asList(BdecVerion.values())));
+              version, Arrays.asList(BdecVersion.values())));
     }
   }
 

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -26,7 +26,7 @@ public class ParameterProvider {
   public static final long INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_DEFAULT = 10;
   public static final boolean SNOWPIPE_STREAMING_METRICS_DEFAULT = false;
 
-  public static final Constants.BdecVerion BLOB_FORMAT_VERSION_DEFAULT = Constants.BdecVerion.ONE;
+  public static final Constants.BdecVersion BLOB_FORMAT_VERSION_DEFAULT = Constants.BdecVersion.ONE;
 
   /** Map of parameter name to parameter value. This will be set by client/configure API Call. */
   private final Map<String, Object> parameterMap = new HashMap<>();
@@ -138,10 +138,10 @@ public class ParameterProvider {
   }
 
   /** @return Blob format version: 1 (arrow stream write mode), 2 (arrow file write mode) etc */
-  public Constants.BdecVerion getBlobFormatVersion() {
+  public Constants.BdecVersion getBlobFormatVersion() {
     Object val = this.parameterMap.getOrDefault(BLOB_FORMAT_VERSION, BLOB_FORMAT_VERSION_DEFAULT);
-    if (val instanceof Constants.BdecVerion) {
-      return (Constants.BdecVerion) val;
+    if (val instanceof Constants.BdecVersion) {
+      return (Constants.BdecVersion) val;
     }
     if (val instanceof String) {
       try {
@@ -151,7 +151,7 @@ public class ParameterProvider {
             String.format("Failed to parse BLOB_FORMAT_VERSION = '%s'", val), t);
       }
     }
-    return Constants.BdecVerion.fromInt((int) val);
+    return Constants.BdecVersion.fromInt((int) val);
   }
 
   @Override

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
@@ -4,16 +4,17 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class ChannelCacheTest {
-  ChannelCache cache;
-  SnowflakeStreamingIngestClientInternal client;
-  SnowflakeStreamingIngestChannelInternal channel1;
-  SnowflakeStreamingIngestChannelInternal channel2;
-  SnowflakeStreamingIngestChannelInternal channel3;
+  ChannelCache<VectorSchemaRoot> cache;
+  SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client;
+  SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel1;
+  SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel2;
+  SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel3;
   String dbName = "db";
   String schemaName = "schema";
   String table1Name = "table1";
@@ -21,10 +22,10 @@ public class ChannelCacheTest {
 
   @Before
   public void setup() {
-    cache = new ChannelCache();
-    client = new SnowflakeStreamingIngestClientInternal("client");
+    cache = new ChannelCache<>();
+    client = new SnowflakeStreamingIngestClientInternal<>("client");
     channel1 =
-        new SnowflakeStreamingIngestChannelInternal(
+        new SnowflakeStreamingIngestChannelInternal<>(
             "channel1",
             dbName,
             schemaName,
@@ -38,7 +39,7 @@ public class ChannelCacheTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             true);
     channel2 =
-        new SnowflakeStreamingIngestChannelInternal(
+        new SnowflakeStreamingIngestChannelInternal<>(
             "channel2",
             dbName,
             schemaName,
@@ -52,7 +53,7 @@ public class ChannelCacheTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             true);
     channel3 =
-        new SnowflakeStreamingIngestChannelInternal(
+        new SnowflakeStreamingIngestChannelInternal<>(
             "channel3",
             dbName,
             schemaName,
@@ -75,10 +76,10 @@ public class ChannelCacheTest {
     String channelName = "channel";
     String tableName = "table";
 
-    ChannelCache cache = new ChannelCache();
+    ChannelCache<VectorSchemaRoot> cache = new ChannelCache<>();
     Assert.assertEquals(0, cache.getSize());
-    SnowflakeStreamingIngestChannelInternal channel =
-        new SnowflakeStreamingIngestChannelInternal(
+    SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel =
+        new SnowflakeStreamingIngestChannelInternal<>(
             channelName,
             dbName,
             schemaName,
@@ -95,8 +96,8 @@ public class ChannelCacheTest {
     Assert.assertEquals(1, cache.getSize());
     Assert.assertTrue(channel == cache.iterator().next().getValue().get(channelName));
 
-    SnowflakeStreamingIngestChannelInternal channelDup =
-        new SnowflakeStreamingIngestChannelInternal(
+    SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channelDup =
+        new SnowflakeStreamingIngestChannelInternal<>(
             channelName,
             dbName,
             schemaName,
@@ -114,7 +115,7 @@ public class ChannelCacheTest {
     Assert.assertTrue(!channel.isValid());
     Assert.assertTrue(channelDup.isValid());
     Assert.assertEquals(1, cache.getSize());
-    ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal> channels =
+    ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot>> channels =
         cache.iterator().next().getValue();
     Assert.assertEquals(1, channels.size());
     Assert.assertTrue(channelDup == channels.get(channelName));
@@ -124,11 +125,19 @@ public class ChannelCacheTest {
   @Test
   public void testIterator() {
     Assert.assertEquals(2, cache.getSize());
-    Iterator<Map.Entry<String, ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal>>>
+    Iterator<
+            Map.Entry<
+                String,
+                ConcurrentHashMap<
+                    String, SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot>>>>
         iter = cache.iterator();
-    Map.Entry<String, ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal>>
+    Map.Entry<
+            String,
+            ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot>>>
         firstTable = iter.next();
-    Map.Entry<String, ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal>>
+    Map.Entry<
+            String,
+            ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot>>>
         secondTable = iter.next();
     Assert.assertFalse(iter.hasNext());
     if (firstTable.getKey().equals(channel1.getFullyQualifiedTableName())) {
@@ -147,10 +156,14 @@ public class ChannelCacheTest {
   @Test
   public void testCloseAllChannels() {
     cache.closeAllChannels();
-    Iterator<Map.Entry<String, ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal>>>
+    Iterator<
+            Map.Entry<
+                String,
+                ConcurrentHashMap<
+                    String, SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot>>>>
         iter = cache.iterator();
     while (iter.hasNext()) {
-      for (SnowflakeStreamingIngestChannelInternal channel : iter.next().getValue().values()) {
+      for (SnowflakeStreamingIngestChannelInternal<?> channel : iter.next().getValue().values()) {
         Assert.assertTrue(channel.isClosed());
       }
     }
@@ -166,8 +179,8 @@ public class ChannelCacheTest {
     cache.removeChannelIfSequencersMatch(channel2);
     Assert.assertEquals(1, cache.getSize());
 
-    SnowflakeStreamingIngestChannelInternal channel3Dup =
-        new SnowflakeStreamingIngestChannelInternal(
+    SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel3Dup =
+        new SnowflakeStreamingIngestChannelInternal<>(
             "channel3",
             dbName,
             schemaName,

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import net.snowflake.ingest.utils.Pair;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -18,15 +19,15 @@ public class RegisterServiceTest {
 
   @Test
   public void testRegisterService() throws Exception {
-    RegisterService rs = new RegisterService(null, true);
+    RegisterService<VectorSchemaRoot> rs = new RegisterService<>(null, true);
 
-    Pair<FlushService.BlobData, CompletableFuture<BlobMetadata>> blobFuture =
+    Pair<FlushService.BlobData<VectorSchemaRoot>, CompletableFuture<BlobMetadata>> blobFuture =
         new Pair<>(
-            new FlushService.BlobData("test", null),
+            new FlushService.BlobData<>("test", null),
             CompletableFuture.completedFuture(new BlobMetadata("path", "md5", null)));
     rs.addBlobs(Collections.singletonList(blobFuture));
     Assert.assertEquals(1, rs.getBlobsList().size());
-    List<FlushService.BlobData> errorBlobs = rs.registerBlobs(null);
+    List<FlushService.BlobData<VectorSchemaRoot>> errorBlobs = rs.registerBlobs(null);
     Assert.assertEquals(0, rs.getBlobsList().size());
     Assert.assertEquals(0, errorBlobs.size());
   }
@@ -42,22 +43,22 @@ public class RegisterServiceTest {
    */
   @Test
   public void testRegisterServiceTimeoutException() throws Exception {
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal("client");
-    RegisterService rs = new RegisterService(client, true);
+    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+        new SnowflakeStreamingIngestClientInternal<>("client");
+    RegisterService<VectorSchemaRoot> rs = new RegisterService<>(client, true);
 
-    Pair<FlushService.BlobData, CompletableFuture<BlobMetadata>> blobFuture1 =
+    Pair<FlushService.BlobData<VectorSchemaRoot>, CompletableFuture<BlobMetadata>> blobFuture1 =
         new Pair<>(
-            new FlushService.BlobData("success", new ArrayList<>()),
+            new FlushService.BlobData<>("success", new ArrayList<>()),
             CompletableFuture.completedFuture(new BlobMetadata("path", "md5", null)));
     CompletableFuture future = new CompletableFuture();
     future.completeExceptionally(new TimeoutException());
-    Pair<FlushService.BlobData, CompletableFuture<BlobMetadata>> blobFuture2 =
-        new Pair<>(new FlushService.BlobData("fail", new ArrayList<>()), future);
+    Pair<FlushService.BlobData<VectorSchemaRoot>, CompletableFuture<BlobMetadata>> blobFuture2 =
+        new Pair<>(new FlushService.BlobData<VectorSchemaRoot>("fail", new ArrayList<>()), future);
     rs.addBlobs(Arrays.asList(blobFuture1, blobFuture2));
     Assert.assertEquals(2, rs.getBlobsList().size());
     try {
-      List<FlushService.BlobData> errorBlobs = rs.registerBlobs(null);
+      List<FlushService.BlobData<VectorSchemaRoot>> errorBlobs = rs.registerBlobs(null);
       Assert.assertEquals(0, rs.getBlobsList().size());
       Assert.assertEquals(1, errorBlobs.size());
       Assert.assertEquals("fail", errorBlobs.get(0).getFilePath());
@@ -70,13 +71,13 @@ public class RegisterServiceTest {
   @Ignore
   @Test
   public void testRegisterServiceTimeoutException_testRetries() throws Exception {
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal("client");
-    RegisterService rs = new RegisterService(client, true);
+    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+        new SnowflakeStreamingIngestClientInternal<>("client");
+    RegisterService<VectorSchemaRoot> rs = new RegisterService<>(client, true);
 
-    Pair<FlushService.BlobData, CompletableFuture<BlobMetadata>> blobFuture1 =
+    Pair<FlushService.BlobData<VectorSchemaRoot>, CompletableFuture<BlobMetadata>> blobFuture1 =
         new Pair<>(
-            new FlushService.BlobData("success", new ArrayList<>()),
+            new FlushService.BlobData<>("success", new ArrayList<>()),
             CompletableFuture.completedFuture(new BlobMetadata("path", "md5", null)));
     CompletableFuture future = new CompletableFuture();
     future.thenRunAsync(
@@ -88,12 +89,12 @@ public class RegisterServiceTest {
           }
           return;
         });
-    Pair<FlushService.BlobData, CompletableFuture<BlobMetadata>> blobFuture2 =
-        new Pair<>(new FlushService.BlobData("fail", new ArrayList<>()), future);
+    Pair<FlushService.BlobData<VectorSchemaRoot>, CompletableFuture<BlobMetadata>> blobFuture2 =
+        new Pair<>(new FlushService.BlobData<VectorSchemaRoot>("fail", new ArrayList<>()), future);
     rs.addBlobs(Arrays.asList(blobFuture1, blobFuture2));
     Assert.assertEquals(2, rs.getBlobsList().size());
     try {
-      List<FlushService.BlobData> errorBlobs = rs.registerBlobs(null);
+      List<FlushService.BlobData<VectorSchemaRoot>> errorBlobs = rs.registerBlobs(null);
       Assert.assertEquals(0, rs.getBlobsList().size());
       Assert.assertEquals(1, errorBlobs.size());
       Assert.assertEquals("fail", errorBlobs.get(0).getFilePath());
@@ -104,18 +105,18 @@ public class RegisterServiceTest {
 
   @Test
   public void testRegisterServiceNonTimeoutException() {
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal("client");
-    RegisterService rs = new RegisterService(client, true);
+    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+        new SnowflakeStreamingIngestClientInternal<>("client");
+    RegisterService<VectorSchemaRoot> rs = new RegisterService<>(client, true);
 
     CompletableFuture future = new CompletableFuture();
     future.completeExceptionally(new IndexOutOfBoundsException());
-    Pair<FlushService.BlobData, CompletableFuture<BlobMetadata>> blobFuture =
-        new Pair<>(new FlushService.BlobData("fail", new ArrayList<>()), future);
+    Pair<FlushService.BlobData<VectorSchemaRoot>, CompletableFuture<BlobMetadata>> blobFuture =
+        new Pair<>(new FlushService.BlobData<VectorSchemaRoot>("fail", new ArrayList<>()), future);
     rs.addBlobs(Collections.singletonList(blobFuture));
     Assert.assertEquals(1, rs.getBlobsList().size());
     try {
-      List<FlushService.BlobData> errorBlobs = rs.registerBlobs(null);
+      List<FlushService.BlobData<VectorSchemaRoot>> errorBlobs = rs.registerBlobs(null);
       Assert.assertEquals(0, rs.getBlobsList().size());
       Assert.assertEquals(1, errorBlobs.size());
       Assert.assertEquals("fail", errorBlobs.get(0).getFilePath());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -36,6 +36,7 @@ import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -50,8 +51,8 @@ public class SnowflakeStreamingIngestChannelTest {
     String tableName = "TABLE";
     Long channelSequencer = 0L;
     Long rowSequencer = 0L;
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal("client");
+    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+        new SnowflakeStreamingIngestClientInternal<>("client");
 
     Object[] fields =
         new Object[] {name, dbName, schemaName, tableName, channelSequencer, rowSequencer, client};
@@ -499,7 +500,7 @@ public class SnowflakeStreamingIngestChannelTest {
     row.put("col", 1);
 
     // Get data before insert to verify that there is no row (data should be null)
-    ChannelData data = channel.getData();
+    ChannelData<VectorSchemaRoot> data = channel.getData();
     Assert.assertNull(data);
 
     InsertValidationResponse response = channel.insertRow(row, "1");

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -56,6 +56,7 @@ import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -65,17 +66,17 @@ import org.mockito.Mockito;
 public class SnowflakeStreamingIngestClientTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
-  SnowflakeStreamingIngestChannelInternal channel1;
-  SnowflakeStreamingIngestChannelInternal channel2;
-  SnowflakeStreamingIngestChannelInternal channel3;
-  SnowflakeStreamingIngestChannelInternal channel4;
+  SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel1;
+  SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel2;
+  SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel3;
+  SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel4;
 
   @Before
   public void setup() {
     objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.ANY);
     objectMapper.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.ANY);
     channel1 =
-        new SnowflakeStreamingIngestChannelInternal(
+        new SnowflakeStreamingIngestChannelInternal<>(
             "channel1",
             "db",
             "schemaName",
@@ -89,7 +90,7 @@ public class SnowflakeStreamingIngestClientTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             true);
     channel2 =
-        new SnowflakeStreamingIngestChannelInternal(
+        new SnowflakeStreamingIngestChannelInternal<>(
             "channel2",
             "db",
             "schemaName",
@@ -103,7 +104,7 @@ public class SnowflakeStreamingIngestClientTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             true);
     channel3 =
-        new SnowflakeStreamingIngestChannelInternal(
+        new SnowflakeStreamingIngestChannelInternal<>(
             "channel3",
             "db",
             "schemaName",
@@ -117,7 +118,7 @@ public class SnowflakeStreamingIngestClientTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             true);
     channel4 =
-        new SnowflakeStreamingIngestChannelInternal(
+        new SnowflakeStreamingIngestChannelInternal<>(
             "channel4",
             "db",
             "schemaName",
@@ -145,8 +146,8 @@ public class SnowflakeStreamingIngestClientTest {
     Map<String, Object> parameterMap = new HashMap<>();
     parameterMap.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_MAP_KEY, 321);
 
-    SnowflakeStreamingIngestClientInternal client =
-        (SnowflakeStreamingIngestClientInternal)
+    SnowflakeStreamingIngestClientInternal<?> client =
+        (SnowflakeStreamingIngestClientInternal<?>)
             SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
 
     Assert.assertEquals("client", client.getName());
@@ -167,8 +168,8 @@ public class SnowflakeStreamingIngestClientTest {
     prop.put(PRIVATE_KEY, TestUtils.getPrivateKey());
     prop.put(ROLE, "role");
 
-    SnowflakeStreamingIngestClientInternal client =
-        (SnowflakeStreamingIngestClientInternal)
+    SnowflakeStreamingIngestClientInternal<?> client =
+        (SnowflakeStreamingIngestClientInternal<?>)
             SnowflakeStreamingIngestClientFactory.builder("client")
                 .setProperties(prop)
                 .setParameterOverrides(
@@ -323,8 +324,8 @@ public class SnowflakeStreamingIngestClientTest {
     RequestBuilder requestBuilder =
         Mockito.spy(
             new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair()));
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal(
+    SnowflakeStreamingIngestClientInternal<?> client =
+        new SnowflakeStreamingIngestClientInternal<>(
             "client",
             new SnowflakeURL("snowflake.dev.local:8082"),
             null,
@@ -333,8 +334,8 @@ public class SnowflakeStreamingIngestClientTest {
             requestBuilder,
             null);
 
-    SnowflakeStreamingIngestChannelInternal channel =
-        new SnowflakeStreamingIngestChannelInternal(
+    SnowflakeStreamingIngestChannelInternal<?> channel =
+        new SnowflakeStreamingIngestChannelInternal<>(
             "channel",
             "db",
             "schemaName",
@@ -381,8 +382,8 @@ public class SnowflakeStreamingIngestClientTest {
     RequestBuilder requestBuilder =
         Mockito.spy(
             new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair()));
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal(
+    SnowflakeStreamingIngestClientInternal<?> client =
+        new SnowflakeStreamingIngestClientInternal<>(
             "client",
             new SnowflakeURL("snowflake.dev.local:8082"),
             null,
@@ -391,8 +392,8 @@ public class SnowflakeStreamingIngestClientTest {
             requestBuilder,
             null);
 
-    SnowflakeStreamingIngestChannelInternal channel =
-        new SnowflakeStreamingIngestChannelInternal(
+    SnowflakeStreamingIngestChannelInternal<?> channel =
+        new SnowflakeStreamingIngestChannelInternal<>(
             "channel",
             "db",
             "schemaName",
@@ -429,8 +430,8 @@ public class SnowflakeStreamingIngestClientTest {
     RequestBuilder requestBuilder =
         new RequestBuilder(url, prop.get(USER).toString(), keyPair, null, null);
 
-    SnowflakeStreamingIngestChannelInternal channel =
-        new SnowflakeStreamingIngestChannelInternal(
+    SnowflakeStreamingIngestChannelInternal<?> channel =
+        new SnowflakeStreamingIngestChannelInternal<>(
             "channel",
             "db",
             "schemaName",
@@ -453,7 +454,7 @@ public class SnowflakeStreamingIngestClientTest {
 
     Map<String, RowBufferStats> columnEps = new HashMap<>();
     columnEps.put("column", new RowBufferStats());
-    EpInfo epInfo = ArrowRowBuffer.buildEpInfoFromStats(1, columnEps);
+    EpInfo epInfo = AbstractRowBuffer.buildEpInfoFromStats(1, columnEps);
 
     ChunkMetadata chunkMetadata =
         ChunkMetadata.builder()
@@ -495,7 +496,7 @@ public class SnowflakeStreamingIngestClientTest {
   private Pair<List<BlobMetadata>, Set<ChunkRegisterStatus>> getRetryBlobMetadata() {
     Map<String, RowBufferStats> columnEps = new HashMap<>();
     columnEps.put("column", new RowBufferStats());
-    EpInfo epInfo = ArrowRowBuffer.buildEpInfoFromStats(1, columnEps);
+    EpInfo epInfo = AbstractRowBuffer.buildEpInfoFromStats(1, columnEps);
 
     ChannelMetadata channelMetadata1 =
         ChannelMetadata.builder()
@@ -596,8 +597,8 @@ public class SnowflakeStreamingIngestClientTest {
     RequestBuilder requestBuilder =
         new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair());
 
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal(
+    SnowflakeStreamingIngestClientInternal<?> client =
+        new SnowflakeStreamingIngestClientInternal<>(
             "client",
             new SnowflakeURL("snowflake.dev.local:8082"),
             null,
@@ -637,8 +638,8 @@ public class SnowflakeStreamingIngestClientTest {
 
     RequestBuilder requestBuilder =
         new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair());
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal(
+    SnowflakeStreamingIngestClientInternal<?> client =
+        new SnowflakeStreamingIngestClientInternal<>(
             "client",
             new SnowflakeURL("snowflake.dev.local:8082"),
             null,
@@ -685,8 +686,8 @@ public class SnowflakeStreamingIngestClientTest {
 
     RequestBuilder requestBuilder =
         new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair());
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal(
+    SnowflakeStreamingIngestClientInternal<?> client =
+        new SnowflakeStreamingIngestClientInternal<>(
             "client",
             new SnowflakeURL("snowflake.dev.local:8082"),
             null,
@@ -742,8 +743,8 @@ public class SnowflakeStreamingIngestClientTest {
 
     RequestBuilder requestBuilder =
         new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair());
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal(
+    SnowflakeStreamingIngestClientInternal<?> client =
+        new SnowflakeStreamingIngestClientInternal<>(
             "client",
             new SnowflakeURL("snowflake.dev.local:8082"),
             null,
@@ -826,8 +827,8 @@ public class SnowflakeStreamingIngestClientTest {
     RequestBuilder requestBuilder =
         Mockito.spy(
             new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair()));
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal(
+    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+        new SnowflakeStreamingIngestClientInternal<>(
             "client",
             new SnowflakeURL("snowflake.dev.local:8082"),
             null,
@@ -941,8 +942,8 @@ public class SnowflakeStreamingIngestClientTest {
     RequestBuilder requestBuilder =
         Mockito.spy(
             new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair()));
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal(
+    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+        new SnowflakeStreamingIngestClientInternal<>(
             "client",
             new SnowflakeURL("snowflake.dev.local:8082"),
             null,

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -51,7 +51,7 @@ public class StreamingIngestIT {
 
   private Properties prop;
 
-  private SnowflakeStreamingIngestClientInternal client;
+  private SnowflakeStreamingIngestClientInternal<?> client;
   private Connection jdbcConnection;
   private String testDb;
 
@@ -83,7 +83,7 @@ public class StreamingIngestIT {
       prop.setProperty(ROLE, "ACCOUNTADMIN");
     }
     client =
-        (SnowflakeStreamingIngestClientInternal)
+        (SnowflakeStreamingIngestClientInternal<?>)
             SnowflakeStreamingIngestClientFactory.builder("client1").setProperties(prop).build();
   }
 
@@ -167,7 +167,7 @@ public class StreamingIngestIT {
     parameterMap.put(ParameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS_MAP_KEY, 1L);
     parameterMap.put(ParameterProvider.ENABLE_SNOWPIPE_STREAMING_METRICS_MAP_KEY, true);
     client =
-        (SnowflakeStreamingIngestClientInternal)
+        (SnowflakeStreamingIngestClientInternal<?>)
             SnowflakeStreamingIngestClientFactory.builder("testParameterOverridesClient")
                 .setProperties(prop)
                 .setParameterOverrides(parameterMap)
@@ -699,11 +699,11 @@ public class StreamingIngestIT {
    */
   @Test
   public void testTwoClientsOneChannel() throws Exception {
-    SnowflakeStreamingIngestClientInternal clientA =
-        (SnowflakeStreamingIngestClientInternal)
+    SnowflakeStreamingIngestClientInternal<?> clientA =
+        (SnowflakeStreamingIngestClientInternal<?>)
             SnowflakeStreamingIngestClientFactory.builder("clientA").setProperties(prop).build();
-    SnowflakeStreamingIngestClientInternal clientB =
-        (SnowflakeStreamingIngestClientInternal)
+    SnowflakeStreamingIngestClientInternal<?> clientB =
+        (SnowflakeStreamingIngestClientInternal<?>)
             SnowflakeStreamingIngestClientFactory.builder("clientB").setProperties(prop).build();
 
     OpenChannelRequest requestA =
@@ -956,7 +956,7 @@ public class StreamingIngestIT {
           .createStatement()
           .execute(
               String.format(
-                  "create or replace table %s (num NUMBER(38,0 ), str VARCHAR);", tableName));
+                  "create or replace table %s (num NUMBER(38,0), str VARCHAR);", tableName));
     } catch (SQLException e) {
       throw new RuntimeException("Cannot create table " + tableName, e);
     }


### PR DESCRIPTION
Now our client supports only flushing chunk in Arrow format.
This PR refactors buffering and flushing code to support plugins for other file formats.
It is a prerequisite for introducing support of Parquet file format in #200.

There are 2 major places that are made pluggable to support Parquet along with Arrow:
- `ArrowRowBuffer` is refactored to an abstract format-agnostic interface `RowBuffer`, common things are pulled into `AbstractRowBuffer`
- `FlushService` uses the `RowBuffer` to create an abstract format-agnostic interface `Flusher` to flush the rows into a chunk

`ChannelData` has been generified to hold either Arrow vectors or Parquet buffers in #200.
This triggered a lot of generification of other classes to avoid unsafe casts, better ideas are welcome.

@test tests are refactored in a separate PR #209.