### PR TITLE
SNOW-593873 SNOW-636695 Round timestamp to seconds when creating blob name

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -663,7 +663,7 @@ class FlushService {
     int day = calendar.get(Calendar.DAY_OF_MONTH);
     int hour = calendar.get(Calendar.HOUR_OF_DAY);
     int minute = calendar.get(Calendar.MINUTE);
-    long time = calendar.getTimeInMillis() / 1000;
+    long time = TimeUnit.MILLISECONDS.toSeconds(calendar.getTimeInMillis());
     long threadId = Thread.currentThread().getId();
     String fileName =
         Long.toString(time, 36)

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -663,7 +663,7 @@ class FlushService {
     int day = calendar.get(Calendar.DAY_OF_MONTH);
     int hour = calendar.get(Calendar.HOUR_OF_DAY);
     int minute = calendar.get(Calendar.MINUTE);
-    long time = calendar.getTimeInMillis();
+    long time = calendar.getTimeInMillis() / 1000;
     long threadId = Thread.currentThread().getId();
     String fileName =
         Long.toString(time, 36)


### PR DESCRIPTION
During investigation of the parent issue, we saw that bdec file shortnames look like `l5kkhkwc_HFDUCTv22sdxqQR6lW9nOq9dg5e2aiSnSgo5exuHUqACC_22_144.bdec` while fdn shortnames look like `reyy2e_316685135989106_1_001` . 

In the scenario where the two above files end up in the same EpFile , that EpFile will have `reyy2e_316685135989106_1_001` as its max fdn shortname and `l5kkhkwc_HFDUCTv22sdxqQR6lW9nOq9dg5e2aiSnSgo5exuHUqACC_22_144.bdec` as its min, as they are compared lexicographically. 

When computing the EpFileBucketIndex (e.g. during any pruning phase of any query or DML), we bucketize EpFiles based on their min/max fdnshortnames. To do this we extract the [base36 encoded timestamp](https://snowflakecomputing.atlassian.net/wiki/spaces/EN/pages/2352513187/File+ShortName+Format+and+Usage) in the beginning of each shortname and we compute the actual timestamp in ms. In the case above, we have  reyy2e = 1657731830 while l5kkhkwc = 1657775093772 which is greater. The reason for this is that the timestamp used in the FDN shortname creation in seconds and NOT in milliseconds, as is the case for BDEC’s. So the min shortname seems to have a bigger timestamp than the max shortname. 

This leads to such  EpFiles always been assigned to the bucket in the EpFileBucketIndex with index 0 and if, as in our bug, a deleted BDEC file is in a compacted EpFile that also has FDN files (so it ends up in index 0 of the index) but the BDEC file itself is assigned to another bucket, then the EpFile will not be scanned.