### PR TITLE
V0.10.8 release branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- Arifact name and version information -->
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-ingest-sdk</artifactId>
-    <version>0.10.7</version>
+    <version>0.10.8</version>
     <packaging>jar</packaging>
     <name>Snowflake Ingest SDK</name>
     <description>Snowflake Ingest SDK</description>

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -112,7 +112,7 @@ public final class RequestBuilder {
   // Don't change!
   public static final String CLIENT_NAME = "SnowpipeJavaSDK";
 
-  public static final String DEFAULT_VERSION = "0.10.7";
+  public static final String DEFAULT_VERSION = "0.10.8";
 
   public static final String JAVA_USER_AGENT = "JAVA";
 

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -8,6 +8,7 @@ import com.google.common.base.Strings;
 import java.security.Security;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import javax.net.ssl.SSLContext;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -52,6 +53,12 @@ public class HttpUtil {
   private static PoolingHttpClientConnectionManager connectionManager;
 
   private static IdleConnectionMonitorThread idleConnectionMonitorThread;
+
+  /**
+   * This lock is to synchronize on idleConnectionMonitorThread to avoid setting starting a thread
+   * which was already started. (To avoid {@link IllegalThreadStateException})
+   */
+  private static ReentrantLock idleConnectionMonitorThreadLock = new ReentrantLock(true);
 
   private static final int DEFAULT_CONNECTION_TIMEOUT_MINUTES = 1;
   private static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT_MINUTES = 5;
@@ -162,15 +169,22 @@ public class HttpUtil {
 
   /** Starts a daemon thread to monitor idle connections in http connection manager. */
   private static void initIdleConnectionMonitoringThread() {
-    // Start a new thread only if connectionManager was init before and
-    // daemon thread was not started before or was closed because of SimpleIngestManager close
-    if (connectionManager != null
-        && (idleConnectionMonitorThread == null || idleConnectionMonitorThread.isShutdown())) {
-      // Monitors in a separate thread where it closes any idle connections
-      // https://hc.apache.org/httpcomponents-client-4.5.x/current/tutorial/html/connmgmt.html
-      idleConnectionMonitorThread = new IdleConnectionMonitorThread(connectionManager);
-      idleConnectionMonitorThread.setDaemon(true);
-      idleConnectionMonitorThread.start();
+    idleConnectionMonitorThreadLock.lock();
+    try {
+      // Start a new thread only if connectionManager was init before and
+      // daemon thread was not started before or was closed because of SimpleIngestManager close
+      if (connectionManager != null
+          && (idleConnectionMonitorThread == null || idleConnectionMonitorThread.isShutdown())) {
+        // Monitors in a separate thread where it closes any idle connections
+        // https://hc.apache.org/httpcomponents-client-4.5.x/current/tutorial/html/connmgmt.html
+        idleConnectionMonitorThread = new IdleConnectionMonitorThread(connectionManager);
+        idleConnectionMonitorThread.setDaemon(true);
+        idleConnectionMonitorThread.start();
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Unable to start Daemon thread for Http Idle Connection Monitoring", e);
+    } finally {
+      idleConnectionMonitorThreadLock.unlock();
     }
   }
 


### PR DESCRIPTION
Why:
- Need this released for for Confluent trying to upgrade to 1.6.7

Context:
- We did a similar release in beta(https://github.com/snowflakedb/snowflake-ingest-java/releases/tag/v0.10.4-beta.3) for Snowpipe EOS APIs but that might not be rolled out in PuPr.
- New commit is just cherry picked here from other released [tag](https://github.com/snowflakedb/snowflake-ingest-java/releases/tag/v0.10.4-beta.3)
- We did a PoolingConnectionManager release in 0.10.7, so only one commit is required before KC can consume this. 


I will not merge this, I am just creating the diff for approval of release, will create the tag later. 

We will use branch [v0.10.8-release-branch for release. ](https://github.com/snowflakedb/snowflake-ingest-java/tree/v0.10.8-release-branch)