### PR TITLE
@snow SNOW-633432 Refactor tests to support various BDEC format versions

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -27,7 +27,7 @@ import org.apache.arrow.util.VisibleForTesting;
  * un-flushed rows, these rows will be converted to the underlying format implementation for faster
  * processing
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot}
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
  */
 abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
   private static final Logging logger = new Logging(AbstractRowBuffer.class);
@@ -430,6 +430,12 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
 
   /** Get buffered data snapshot for later flushing. */
   abstract Optional<T> getSnapshot();
+
+  @VisibleForTesting
+  abstract Object getVectorValueAt(String column, int index);
+
+  @VisibleForTesting
+  abstract int getTempRowCount();
 
   /** Normalize the column name, given with the inserted row, to send to server side. */
   static String formatColumnName(String columnName) {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -772,4 +772,16 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
   public Flusher<VectorSchemaRoot> createFlusher(Constants.BdecVersion bdecVersion) {
     return new ArrowFlusher(bdecVersion);
   }
+
+  @VisibleForTesting
+  @Override
+  Object getVectorValueAt(String column, int index) {
+    Object value = vectorsRoot.getVector(column).getObject(index);
+    return (value instanceof Text) ? new String(((Text) value).getBytes()) : value;
+  }
+
+  @VisibleForTesting
+  int getTempRowCount() {
+    return tempVectorsRoot.getRowCount();
+  }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelMetadata.java
@@ -29,7 +29,7 @@ class ChannelMetadata {
     private Long rowSequencer;
     @Nullable private String offsetToken; // offset token could be null
 
-    Builder setOwningChannel(SnowflakeStreamingIngestChannelInternal channel) {
+    Builder setOwningChannel(SnowflakeStreamingIngestChannelInternal<?> channel) {
       this.channelName = channel.getName();
       this.clientSequencer = channel.getChannelSequencer();
       return this;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -601,7 +601,7 @@ class FlushService<T> {
    *
    * @param blobData list of channels that belongs to the blob
    */
-  void invalidateAllChannelsInBlob(List<List<ChannelData<T>>> blobData) {
+  <CD> void invalidateAllChannelsInBlob(List<List<ChannelData<CD>>> blobData) {
     blobData.forEach(
         chunkData ->
             chunkData.forEach(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
@@ -1,0 +1,475 @@
+package net.snowflake.ingest.streaming.internal;
+
+import static net.snowflake.ingest.streaming.internal.ArrowRowBuffer.DECIMAL_BIT_WIDTH;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import net.snowflake.ingest.streaming.InsertValidationResponse;
+import net.snowflake.ingest.streaming.OpenChannelRequest;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ArrowBufferTest {
+  private ArrowRowBuffer rowBufferOnErrorContinue;
+
+  @Before
+  public void setupRowBuffer() {
+    this.rowBufferOnErrorContinue = createTestBuffer(OpenChannelRequest.OnErrorOption.CONTINUE);
+    this.rowBufferOnErrorContinue.setupSchema(RowBufferTest.createSchema());
+  }
+
+  ArrowRowBuffer createTestBuffer(OpenChannelRequest.OnErrorOption onErrorOption) {
+    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+        new SnowflakeStreamingIngestClientInternal<>("client");
+    SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel =
+        new SnowflakeStreamingIngestChannelInternal<>(
+            "channel", "db", "schema", "table", "0", 0L, 0L, client, "key", 1234L, onErrorOption);
+    return new ArrowRowBuffer(channel);
+  }
+
+  @Test
+  public void testFieldNumberAfterFlush() {
+    String offsetToken = "1";
+    Map<String, Object> row = new HashMap<>();
+    row.put("colTinyInt", (byte) 1);
+    row.put("\"colTinyInt\"", (byte) 1);
+    row.put("colSmallInt", (short) 2);
+    row.put("colInt", 3);
+    row.put("colBigInt", 4L);
+    row.put("colDecimal", 1.23);
+    row.put("colChar", "2");
+
+    InsertValidationResponse response =
+        rowBufferOnErrorContinue.insertRows(Collections.singletonList(row), offsetToken);
+    Assert.assertFalse(response.hasErrors());
+
+    ChannelData<VectorSchemaRoot> data = rowBufferOnErrorContinue.flush();
+    Assert.assertEquals(7, data.getVectors().getFieldVectors().size());
+  }
+
+  @Test
+  public void buildFieldFixedSB1() {
+    // FIXED, SB1
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB1");
+    testCol.setNullable(true);
+    testCol.setLogicalType("FIXED");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.TINYINT.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB1");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "FIXED");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("nullable"), "true");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 0);
+  }
+
+  @Test
+  public void buildFieldFixedSB2() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB2");
+    testCol.setNullable(false);
+    testCol.setLogicalType("FIXED");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.SMALLINT.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB2");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "FIXED");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("nullable"), "false");
+    Assert.assertFalse(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 0);
+  }
+
+  @Test
+  public void buildFieldFixedSB4() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB4");
+    testCol.setNullable(true);
+    testCol.setLogicalType("FIXED");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.INT.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB4");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "FIXED");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 0);
+  }
+
+  @Test
+  public void buildFieldFixedSB8() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB8");
+    testCol.setNullable(true);
+    testCol.setLogicalType("FIXED");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIGINT.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "FIXED");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 0);
+  }
+
+  @Test
+  public void buildFieldFixedSB16() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB16");
+    testCol.setNullable(true);
+    testCol.setLogicalType("FIXED");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    ArrowType expectedType =
+        new ArrowType.Decimal(testCol.getPrecision(), testCol.getScale(), DECIMAL_BIT_WIDTH);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), expectedType);
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "FIXED");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 0);
+  }
+
+  @Test
+  public void buildFieldLobVariant() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("LOB");
+    testCol.setNullable(true);
+    testCol.setLogicalType("VARIANT");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.VARCHAR.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "LOB");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "VARIANT");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 0);
+  }
+
+  @Test
+  public void buildFieldTimestampNtzSB8() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB8");
+    testCol.setNullable(true);
+    testCol.setLogicalType("TIMESTAMP_NTZ");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIGINT.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "TIMESTAMP_NTZ");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 0);
+  }
+
+  @Test
+  public void buildFieldTimestampNtzSB16() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB16");
+    testCol.setNullable(true);
+    testCol.setLogicalType("TIMESTAMP_NTZ");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.STRUCT.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "TIMESTAMP_NTZ");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 2);
+    Assert.assertEquals(
+        result.getChildren().get(0).getFieldType().getType(), Types.MinorType.BIGINT.getType());
+    Assert.assertEquals(
+        result.getChildren().get(1).getFieldType().getType(), Types.MinorType.INT.getType());
+  }
+
+  @Test
+  public void buildFieldTimestampTzSB8() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB8");
+    testCol.setNullable(true);
+    testCol.setLogicalType("TIMESTAMP_TZ");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.STRUCT.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "TIMESTAMP_TZ");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 2);
+    Assert.assertEquals(
+        result.getChildren().get(0).getFieldType().getType(), Types.MinorType.BIGINT.getType());
+    Assert.assertEquals(
+        result.getChildren().get(1).getFieldType().getType(), Types.MinorType.INT.getType());
+  }
+
+  @Test
+  public void buildFieldTimestampTzSB16() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB16");
+    testCol.setNullable(true);
+    testCol.setLogicalType("TIMESTAMP_TZ");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.STRUCT.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "TIMESTAMP_TZ");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 3);
+    Assert.assertEquals(
+        result.getChildren().get(0).getFieldType().getType(), Types.MinorType.BIGINT.getType());
+    Assert.assertEquals(
+        result.getChildren().get(1).getFieldType().getType(), Types.MinorType.INT.getType());
+    Assert.assertEquals(
+        result.getChildren().get(2).getFieldType().getType(), Types.MinorType.INT.getType());
+  }
+
+  @Test
+  public void buildFieldDate() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB8");
+    testCol.setNullable(true);
+    testCol.setLogicalType("DATE");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.DATEDAY.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "DATE");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 0);
+  }
+
+  @Test
+  public void buildFieldTimeSB4() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB4");
+    testCol.setNullable(true);
+    testCol.setLogicalType("TIME");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.INT.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB4");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "TIME");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 0);
+  }
+
+  @Test
+  public void buildFieldTimeSB8() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB8");
+    testCol.setNullable(true);
+    testCol.setLogicalType("TIME");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIGINT.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "TIME");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 0);
+  }
+
+  @Test
+  public void buildFieldBoolean() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("BINARY");
+    testCol.setNullable(true);
+    testCol.setLogicalType("BOOLEAN");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIT.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "BINARY");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "BOOLEAN");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 0);
+  }
+
+  @Test
+  public void buildFieldRealSB16() {
+    ColumnMetadata testCol = new ColumnMetadata();
+    testCol.setName("testCol");
+    testCol.setPhysicalType("SB16");
+    testCol.setNullable(true);
+    testCol.setLogicalType("REAL");
+    testCol.setByteLength(14);
+    testCol.setLength(11);
+    testCol.setScale(0);
+    testCol.setPrecision(4);
+    Field result = this.rowBufferOnErrorContinue.buildField(testCol);
+
+    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.FLOAT8.getType());
+    Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
+    Assert.assertEquals(result.getFieldType().getMetadata().get("logicalType"), "REAL");
+    Assert.assertTrue(result.getFieldType().isNullable());
+    Assert.assertEquals(result.getChildren().size(), 0);
+  }
+
+  @Test
+  public void testArrowE2ETimestampLTZ() {
+    testArrowE2ETimestampLTZHelper(OpenChannelRequest.OnErrorOption.ABORT);
+    testArrowE2ETimestampLTZHelper(OpenChannelRequest.OnErrorOption.CONTINUE);
+  }
+
+  private void testArrowE2ETimestampLTZHelper(OpenChannelRequest.OnErrorOption onErrorOption) {
+    ArrowRowBuffer innerBuffer = createTestBuffer(onErrorOption);
+
+    ColumnMetadata colTimestampLtzSB8 = new ColumnMetadata();
+    colTimestampLtzSB8.setName("COLTIMESTAMPLTZ_SB8");
+    colTimestampLtzSB8.setPhysicalType("SB8");
+    colTimestampLtzSB8.setNullable(false);
+    colTimestampLtzSB8.setLogicalType("TIMESTAMP_LTZ");
+    colTimestampLtzSB8.setScale(0);
+
+    ColumnMetadata colTimestampLtzSB16 = new ColumnMetadata();
+    colTimestampLtzSB16.setName("COLTIMESTAMPLTZ_SB16");
+    colTimestampLtzSB16.setPhysicalType("SB16");
+    colTimestampLtzSB16.setNullable(false);
+    colTimestampLtzSB16.setLogicalType("TIMESTAMP_LTZ");
+    colTimestampLtzSB16.setScale(9);
+
+    innerBuffer.setupSchema(Arrays.asList(colTimestampLtzSB8, colTimestampLtzSB16));
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COLTIMESTAMPLTZ_SB8", "1621899220");
+    row.put("COLTIMESTAMPLTZ_SB16", new BigDecimal("1621899220.123456789"));
+
+    InsertValidationResponse response =
+        innerBuffer.insertRows(Collections.singletonList(row), null);
+    Assert.assertFalse(response.hasErrors());
+    Assert.assertEquals(
+        1621899220L, innerBuffer.vectorsRoot.getVector("COLTIMESTAMPLTZ_SB8").getObject(0));
+    Assert.assertEquals(
+        "epoch",
+        innerBuffer
+            .vectorsRoot
+            .getVector("COLTIMESTAMPLTZ_SB16")
+            .getChildrenFromFields()
+            .get(0)
+            .getName());
+    Assert.assertEquals(
+        1621899220L,
+        innerBuffer
+            .vectorsRoot
+            .getVector("COLTIMESTAMPLTZ_SB16")
+            .getChildrenFromFields()
+            .get(0)
+            .getObject(0));
+    Assert.assertEquals(
+        "fraction",
+        innerBuffer
+            .vectorsRoot
+            .getVector("COLTIMESTAMPLTZ_SB16")
+            .getChildrenFromFields()
+            .get(1)
+            .getName());
+    Assert.assertEquals(
+        123456789,
+        innerBuffer
+            .vectorsRoot
+            .getVector("COLTIMESTAMPLTZ_SB16")
+            .getChildrenFromFields()
+            .get(1)
+            .getObject(0));
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -31,7 +33,6 @@ import java.util.TimeZone;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
-import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Constants;
@@ -41,93 +42,320 @@ import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.IntVector;
-import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.util.Text;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+@RunWith(Parameterized.class)
 public class FlushServiceTest {
-  private SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client;
-  private ChannelCache<VectorSchemaRoot> channelCache;
-  private SnowflakeConnectionV1 conn;
-  private SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel1;
-  private SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel2;
-  private SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel3;
-  private StreamingIngestStage stage;
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> testContextFactory() {
+    return Arrays.asList(new Object[][] {{ArrowTestContext.createFactory()}});
+  }
 
-  private final BufferAllocator allocator = new RootAllocator();
+  public FlushServiceTest(TestContextFactory<?> testContextFactory) {
+    this.testContextFactory = testContextFactory;
+  }
+
+  private abstract static class TestContextFactory<T> {
+    private final String name;
+
+    TestContextFactory(String name) {
+      this.name = name;
+    }
+
+    abstract TestContext<T> create();
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  private abstract static class TestContext<T> implements AutoCloseable {
+    SnowflakeStreamingIngestClientInternal<T> client;
+    ChannelCache<T> channelCache;
+    final Map<String, SnowflakeStreamingIngestChannelInternal<T>> channels = new HashMap<>();
+    FlushService<T> flushService;
+    StreamingIngestStage stage;
+    ParameterProvider parameterProvider;
+
+    final List<ChannelData<T>> channelData = new ArrayList<>();
+
+    TestContext() {
+      stage = Mockito.mock(StreamingIngestStage.class);
+      Mockito.when(stage.getClientPrefix()).thenReturn("client_prefix");
+      parameterProvider = new ParameterProvider();
+      client = Mockito.mock(SnowflakeStreamingIngestClientInternal.class);
+      Mockito.when(client.getParameterProvider()).thenReturn(parameterProvider);
+      channelCache = new ChannelCache<>();
+      Mockito.when(client.getChannelCache()).thenReturn(channelCache);
+      flushService = Mockito.spy(new FlushService<>(client, channelCache, stage, false));
+    }
+
+    ChannelData<T> flushChannel(String name) {
+      ChannelData<T> channelData = channels.get(name).getRowBuffer().flush();
+      this.channelData.add(channelData);
+      return channelData;
+    }
+
+    BlobMetadata buildAndUpload() throws Exception {
+      List<List<ChannelData<T>>> blobData = Collections.singletonList(channelData);
+      return flushService.buildAndUpload("file_name", blobData);
+    }
+
+    abstract SnowflakeStreamingIngestChannelInternal<T> createChannel(
+        String name,
+        String dbName,
+        String schemaName,
+        String tableName,
+        String offsetToken,
+        Long channelSequencer,
+        Long rowSequencer,
+        String encryptionKey,
+        Long encryptionKeyId,
+        OpenChannelRequest.OnErrorOption onErrorOption);
+
+    ChannelBuilder channelBuilder(String name) {
+      return new ChannelBuilder(name);
+    }
+
+    class ChannelBuilder {
+      private final String name;
+      private String dbName = "db1";
+      private String schemaName = "schema1";
+      private String tableName = "table1";
+      private String offsetToken = "offset1";
+      private Long channelSequencer = 0L;
+      private Long rowSequencer = 0L;
+      private String encryptionKey = "key";
+      private Long encryptionKeyId = 0L;
+      private OpenChannelRequest.OnErrorOption onErrorOption =
+          OpenChannelRequest.OnErrorOption.CONTINUE;
+
+      private ChannelBuilder(String name) {
+        this.name = name;
+      }
+
+      ChannelBuilder setDBName(String dbName) {
+        this.dbName = dbName;
+        return this;
+      }
+
+      ChannelBuilder setSchemaName(String schemaName) {
+        this.schemaName = schemaName;
+        return this;
+      }
+
+      ChannelBuilder setTableName(String tableName) {
+        this.tableName = tableName;
+        return this;
+      }
+
+      ChannelBuilder setOffsetToken(String offsetToken) {
+        this.offsetToken = offsetToken;
+        return this;
+      }
+
+      ChannelBuilder setChannelSequencer(Long sequencer) {
+        this.channelSequencer = sequencer;
+        return this;
+      }
+
+      ChannelBuilder setRowSequencer(Long sequencer) {
+        this.rowSequencer = sequencer;
+        return this;
+      }
+
+      ChannelBuilder setEncryptionKey(String encryptionKey) {
+        this.encryptionKey = encryptionKey;
+        return this;
+      }
+
+      ChannelBuilder setEncryptionKeyId(Long encryptionKeyId) {
+        this.encryptionKeyId = encryptionKeyId;
+        return this;
+      }
+
+      ChannelBuilder setOnErrorOption(OpenChannelRequest.OnErrorOption onErrorOption) {
+        this.onErrorOption = onErrorOption;
+        return this;
+      }
+
+      SnowflakeStreamingIngestChannelInternal<T> buildAndAdd() {
+        SnowflakeStreamingIngestChannelInternal<T> channel =
+            createChannel(
+                name,
+                dbName,
+                schemaName,
+                tableName,
+                offsetToken,
+                channelSequencer,
+                rowSequencer,
+                encryptionKey,
+                encryptionKeyId,
+                onErrorOption);
+        channels.put(name, channel);
+        channelCache.addChannel(channel);
+        return channel;
+      }
+    }
+  }
+
+  private static class RowSetBuilder {
+    private final List<Map<String, Object>> rows = new ArrayList<>();
+
+    private Map<String, Object> lastRow() {
+      return rows.get(rows.size() - 1);
+    }
+
+    RowSetBuilder addColumn(String column, Object value) {
+      lastRow().put(column, value);
+      return this;
+    }
+
+    RowSetBuilder newRow() {
+      if (rows.isEmpty() || !lastRow().isEmpty()) {
+        rows.add(new HashMap<>());
+      }
+      return this;
+    }
+
+    List<Map<String, Object>> build() {
+      return rows;
+    }
+
+    static RowSetBuilder newBuilder() {
+      return new RowSetBuilder().newRow();
+    }
+  }
+
+  private static class ArrowTestContext extends TestContext<VectorSchemaRoot> {
+    private final BufferAllocator allocator = new RootAllocator();
+
+    SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> createChannel(
+        String name,
+        String dbName,
+        String schemaName,
+        String tableName,
+        String offsetToken,
+        Long channelSequencer,
+        Long rowSequencer,
+        String encryptionKey,
+        Long encryptionKeyId,
+        OpenChannelRequest.OnErrorOption onErrorOption) {
+      return new SnowflakeStreamingIngestChannelInternal<>(
+          name,
+          dbName,
+          schemaName,
+          tableName,
+          offsetToken,
+          channelSequencer,
+          rowSequencer,
+          client,
+          encryptionKey,
+          encryptionKeyId,
+          onErrorOption,
+          Constants.BdecVersion.ONE,
+          allocator);
+    }
+
+    @Override
+    public void close() {
+      try {
+        // Close allocator to make sure no memory leak
+        allocator.close();
+      } catch (Exception e) {
+        Assert.fail(String.format("Allocator close failure. Caused by %s", e.getMessage()));
+      }
+    }
+
+    static TestContextFactory<VectorSchemaRoot> createFactory() {
+      return new TestContextFactory<VectorSchemaRoot>("Arrow") {
+        @Override
+        TestContext<VectorSchemaRoot> create() {
+          return new ArrowTestContext();
+        }
+      };
+    }
+  }
+
+  TestContextFactory<?> testContextFactory;
+  TestContext<?> testContext;
 
   @Before
   public void setup() {
     java.security.Security.addProvider(new BouncyCastleProvider());
+    testContext = testContextFactory.create();
+  }
 
-    ParameterProvider parameterProvider = new ParameterProvider();
-    client = Mockito.mock(SnowflakeStreamingIngestClientInternal.class);
-    Mockito.when(client.getParameterProvider()).thenReturn(parameterProvider);
-    stage = Mockito.mock(StreamingIngestStage.class);
-    Mockito.when(stage.getClientPrefix()).thenReturn("client_prefix");
-    channelCache = new ChannelCache<>();
-    Mockito.when(client.getChannelCache()).thenReturn(channelCache);
-    conn = Mockito.mock(SnowflakeConnectionV1.class);
-    channel1 =
-        new SnowflakeStreamingIngestChannelInternal<>(
-            "channel1",
-            "db1",
-            "schema1",
-            "table1",
-            "offset1",
-            0L,
-            0L,
-            client,
-            "key",
-            1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+  private SnowflakeStreamingIngestChannelInternal<?> addChannel1() {
+    return testContext
+        .channelBuilder("channel1")
+        .setDBName("db1")
+        .setSchemaName("schema1")
+        .setTableName("table1")
+        .setOffsetToken("offset1")
+        .setChannelSequencer(0L)
+        .setRowSequencer(0L)
+        .buildAndAdd();
+  }
 
-    channel2 =
-        new SnowflakeStreamingIngestChannelInternal<>(
-            "channel2",
-            "db1",
-            "schema1",
-            "table1",
-            "offset2",
-            10L,
-            100L,
-            client,
-            "key",
-            1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+  private SnowflakeStreamingIngestChannelInternal<?> addChannel2() {
+    return testContext
+        .channelBuilder("channel2")
+        .setDBName("db1")
+        .setSchemaName("schema1")
+        .setTableName("table1")
+        .setOffsetToken("offset2")
+        .setChannelSequencer(10L)
+        .setRowSequencer(100L)
+        .buildAndAdd();
+  }
 
-    channel3 =
-        new SnowflakeStreamingIngestChannelInternal<>(
-            "channel3",
-            "db2",
-            "schema1",
-            "table2",
-            "offset3",
-            0L,
-            0L,
-            client,
-            "key",
-            1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
-    channelCache.addChannel(channel1);
-    channelCache.addChannel(channel2);
-    channelCache.addChannel(channel3);
+  private SnowflakeStreamingIngestChannelInternal<?> addChannel3() {
+    return testContext
+        .channelBuilder("channel3")
+        .setDBName("db2")
+        .setSchemaName("schema1")
+        .setTableName("table2")
+        .setOffsetToken("offset3")
+        .setChannelSequencer(0L)
+        .setRowSequencer(0L)
+        .buildAndAdd();
+  }
+
+  private static ColumnMetadata createTestIntegerColumn() {
+    ColumnMetadata colInt = new ColumnMetadata();
+    colInt.setName("COLINT");
+    colInt.setPhysicalType("SB4");
+    colInt.setNullable(true);
+    colInt.setLogicalType("FIXED");
+    colInt.setScale(0);
+    return colInt;
+  }
+
+  private static ColumnMetadata createTestTextColumn() {
+    ColumnMetadata colChar = new ColumnMetadata();
+    colChar.setName("COLCHAR");
+    colChar.setPhysicalType("LOB");
+    colChar.setNullable(true);
+    colChar.setLogicalType("TEXT");
+    colChar.setByteLength(14);
+    colChar.setLength(11);
+    colChar.setScale(0);
+    colChar.setCollation("en-ci");
+    return colChar;
   }
 
   @Test
   public void testGetFilePath() {
-    FlushService<VectorSchemaRoot> flushService =
-        new FlushService<>(client, channelCache, stage, false);
+    FlushService<?> flushService = testContext.flushService;
     Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
     String clientPrefix = "honk";
     String outputString = flushService.getFilePath(calendar, clientPrefix);
@@ -160,8 +388,7 @@ public class FlushServiceTest {
 
   @Test
   public void testFlush() throws Exception {
-    FlushService<VectorSchemaRoot> flushService =
-        Mockito.spy(new FlushService<>(client, channelCache, stage, false));
+    FlushService<?> flushService = testContext.flushService;
 
     // Nothing to flush
     flushService.flush(false).get();
@@ -187,34 +414,29 @@ public class FlushServiceTest {
 
   @Test
   public void testBuildAndUpload() throws Exception {
-    FlushService<VectorSchemaRoot> flushService =
-        Mockito.spy(new FlushService<>(client, channelCache, stage, true));
+    SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1();
+    SnowflakeStreamingIngestChannelInternal<?> channel2 = addChannel2();
 
-    List<List<ChannelData<VectorSchemaRoot>>> blobData = new ArrayList<>();
-    List<ChannelData<VectorSchemaRoot>> chunkData = new ArrayList<>();
+    List<ColumnMetadata> schema = Arrays.asList(createTestIntegerColumn(), createTestTextColumn());
+    channel1.getRowBuffer().setupSchema(schema);
+    channel2.getRowBuffer().setupSchema(schema);
 
-    // Construct fields
-    ChannelData<VectorSchemaRoot> channel1Data = new ChannelData<>();
-    ChannelData<VectorSchemaRoot> channel2Data = new ChannelData<>();
+    List<Map<String, Object>> rows1 =
+        RowSetBuilder.newBuilder()
+            .addColumn("COLINT", 11)
+            .addColumn("COLCHAR", "bob")
+            .newRow()
+            .addColumn("COLINT", 22)
+            .addColumn("COLCHAR", "bob")
+            .build();
+    List<Map<String, Object>> rows2 =
+        RowSetBuilder.newBuilder().addColumn("COLINT", null).addColumn("COLCHAR", "toby").build();
 
-    FieldVector vector1 = new VarCharVector("vector1", allocator);
-    FieldVector vector2 = new IntVector("vector2", allocator);
-    FieldVector vector3 = new VarCharVector("vector3", allocator);
-    FieldVector vector4 = new IntVector("vector4", allocator);
-    List<FieldVector> vectorList1 = new ArrayList<>();
-    vectorList1.add(vector1);
-    vectorList1.add(vector2);
-    List<FieldVector> vectorList2 = new ArrayList<>();
-    vectorList2.add(vector3);
-    vectorList2.add(vector4);
+    channel1.insertRows(rows1, "offset1");
+    channel2.insertRows(rows2, "offset2");
 
-    VectorSchemaRoot vectorRoot1 = new VectorSchemaRoot(vectorList1);
-    vectorRoot1.setRowCount(2);
-    VectorSchemaRoot vectorRoot2 = new VectorSchemaRoot(vectorList2);
-    vectorRoot2.setRowCount(1);
-
-    channel1Data.setVectors(vectorRoot1);
-    channel2Data.setVectors(vectorRoot2);
+    ChannelData<?> channel1Data = testContext.flushChannel(channel1.getName());
+    ChannelData<?> channel2Data = testContext.flushChannel(channel2.getName());
 
     Map<String, RowBufferStats> eps1 = new HashMap<>();
     Map<String, RowBufferStats> eps2 = new HashMap<>();
@@ -234,37 +456,12 @@ public class FlushServiceTest {
     channel1Data.setColumnEps(eps1);
     channel2Data.setColumnEps(eps2);
 
-    chunkData.add(channel1Data);
-    chunkData.add(channel2Data);
-    blobData.add(chunkData);
-
-    // Populate test row data
-    ((VarCharVector) vector1).setSafe(0, new Text("alice"));
-    ((VarCharVector) vector1).setSafe(1, new Text("bob"));
-    ((IntVector) vector2).setSafe(0, 11);
-    ((IntVector) vector2).setSafe(1, 22);
-
-    ((VarCharVector) vector3).setSafe(0, new Text("toby"));
-    ((IntVector) vector4).setNull(0);
-
-    vector1.setValueCount(2);
-    vector2.setValueCount(2);
-    vector3.setValueCount(1);
-    vector4.setValueCount(1);
-
     channel1Data.setRowSequencer(0L);
-    channel1Data.setOffsetToken("offset1");
     channel1Data.setBufferSize(100);
-    channel1Data.setChannel(channel1);
-    channel1Data.setRowCount(2);
-
     channel2Data.setRowSequencer(10L);
-    channel2Data.setOffsetToken("offset2");
     channel2Data.setBufferSize(100);
-    channel2Data.setChannel(channel2);
-    channel2Data.setRowCount(1);
 
-    BlobMetadata blobMetadata = flushService.buildAndUpload("file_name", blobData);
+    BlobMetadata blobMetadata = testContext.buildAndUpload();
 
     EpInfo expectedChunkEpInfo =
         AbstractRowBuffer.buildEpInfoFromStats(
@@ -298,7 +495,7 @@ public class FlushServiceTest {
     final ArgumentCaptor<byte[]> blobCaptor = ArgumentCaptor.forClass(byte[].class);
     final ArgumentCaptor<List<ChunkMetadata>> metadataCaptor = ArgumentCaptor.forClass(List.class);
 
-    Mockito.verify(flushService)
+    Mockito.verify(testContext.flushService)
         .upload(nameCaptor.capture(), blobCaptor.capture(), metadataCaptor.capture());
     Assert.assertEquals("file_name", nameCaptor.getValue());
 
@@ -339,67 +536,37 @@ public class FlushServiceTest {
                 (int) (metadataResult.getChunkStartOffset() + metadataResult.getChunkLength())));
     Assert.assertEquals(md5, metadataResult.getChunkMD5());
 
-    try {
-      // Close allocator to make sure no memory leak
-      allocator.close();
-    } catch (Exception e) {
-      Assert.fail(String.format("Allocator close failure. Caused by %s", e.getMessage()));
-    }
+    testContext.close();
   }
 
   @Test
   public void testBuildErrors() throws Exception {
-    // build should error if we try to group channels for different tables together
-    FlushService<VectorSchemaRoot> flushService =
-        Mockito.spy(new FlushService<>(client, channelCache, stage, true));
+    SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1();
+    SnowflakeStreamingIngestChannelInternal<?> channel3 = addChannel3();
 
-    List<List<ChannelData<VectorSchemaRoot>>> channelData = new ArrayList<>();
-    List<ChannelData<VectorSchemaRoot>> channelData1 = new ArrayList<>();
+    List<ColumnMetadata> schema = Arrays.asList(createTestIntegerColumn(), createTestTextColumn());
+    channel1.getRowBuffer().setupSchema(schema);
+    channel3.getRowBuffer().setupSchema(schema);
 
-    // Construct fields
-    ChannelData<VectorSchemaRoot> data1 = new ChannelData<>();
-    ChannelData<VectorSchemaRoot> data2 = new ChannelData<>();
+    List<Map<String, Object>> rows1 =
+        RowSetBuilder.newBuilder().addColumn("COLINT", 0).addColumn("COLCHAR", "alice").build();
+    List<Map<String, Object>> rows2 =
+        RowSetBuilder.newBuilder().addColumn("COLINT", 0).addColumn("COLCHAR", 111).build();
 
-    FieldVector vector1 = new VarCharVector("vector1", allocator);
-    FieldVector vector3 = new IntVector("vector3", allocator);
-    vector1.allocateNew();
-    vector3.allocateNew();
-    List<FieldVector> vectorList1 = new ArrayList<>();
-    vectorList1.add(vector1);
-    List<FieldVector> vectorList2 = new ArrayList<>();
-    vectorList1.add(vector3);
+    channel1.insertRows(rows1, "offset1");
+    channel3.insertRows(rows2, "offset2");
 
-    VectorSchemaRoot vectorRoot1 = new VectorSchemaRoot(vectorList1);
-    vectorRoot1.setRowCount(2);
-    VectorSchemaRoot vectorRoot2 = new VectorSchemaRoot(vectorList2);
-    vectorRoot2.setRowCount(1);
-
-    data1.setVectors(vectorRoot1);
-    data2.setVectors(vectorRoot2);
-
-    channelData1.add(data1);
-    channelData1.add(data2);
-    channelData.add(channelData1);
-
-    // Populate test row data
-    ((VarCharVector) vector1).setSafe(0, new Text("alice"));
-    ((IntVector) vector3).setSafe(0, 111);
-
-    vector1.setValueCount(2);
-    vector3.setValueCount(3);
+    ChannelData<?> data1 = testContext.flushChannel(channel1.getName());
+    ChannelData<?> data2 = testContext.flushChannel(channel3.getName());
 
     data1.setRowSequencer(0L);
-    data1.setOffsetToken("offset1");
     data1.setBufferSize(100);
-    data1.setChannel(channel1);
 
     data2.setRowSequencer(10L);
-    data2.setOffsetToken("offset3");
     data2.setBufferSize(100);
-    data2.setChannel(channel3);
 
     try {
-      flushService.buildAndUpload("file_name", channelData);
+      testContext.buildAndUpload();
       Assert.fail("Expected SFException");
     } catch (SFException err) {
       Assert.assertEquals(ErrorCode.INVALID_DATA_IN_CHUNK.getMessageCode(), err.getVendorCode());
@@ -407,15 +574,15 @@ public class FlushServiceTest {
   }
 
   @Test
-  public void testInvalidateChannels() throws Exception {
+  public void testInvalidateChannels() {
     // Create a new Client in order to not interfere with other tests
-    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
         Mockito.mock(SnowflakeStreamingIngestClientInternal.class);
     ParameterProvider parameterProvider = new ParameterProvider();
-    ChannelCache<VectorSchemaRoot> channelCache = new ChannelCache<>();
+    ChannelCache<StubChunkData> channelCache = new ChannelCache<>();
     Mockito.when(client.getChannelCache()).thenReturn(channelCache);
     Mockito.when(client.getParameterProvider()).thenReturn(parameterProvider);
-    SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel1 =
+    SnowflakeStreamingIngestChannelInternal<StubChunkData> channel1 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel1",
             "db1",
@@ -427,10 +594,9 @@ public class FlushServiceTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+            OpenChannelRequest.OnErrorOption.CONTINUE);
 
-    SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel2 =
+    SnowflakeStreamingIngestChannelInternal<StubChunkData> channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel2",
             "db1",
@@ -442,42 +608,27 @@ public class FlushServiceTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+            OpenChannelRequest.OnErrorOption.CONTINUE);
 
     channelCache.addChannel(channel1);
     channelCache.addChannel(channel2);
 
-    List<List<ChannelData<VectorSchemaRoot>>> blobData = new ArrayList<>();
-    List<ChannelData<VectorSchemaRoot>> innerData = new ArrayList<>();
+    List<List<ChannelData<StubChunkData>>> blobData = new ArrayList<>();
+    List<ChannelData<StubChunkData>> innerData = new ArrayList<>();
     blobData.add(innerData);
 
-    ChannelData<VectorSchemaRoot> channel1Data = new ChannelData<>();
-    ChannelData<VectorSchemaRoot> channel2Data = new ChannelData<>();
+    ChannelData<StubChunkData> channel1Data = new ChannelData<>();
+    ChannelData<StubChunkData> channel2Data = new ChannelData<>();
     channel1Data.setChannel(channel1);
     channel2Data.setChannel(channel1);
 
-    FieldVector vector1 = new VarCharVector("vector1", allocator);
-    FieldVector vector2 = new IntVector("vector2", allocator);
-    FieldVector vector3 = new VarCharVector("vector3", allocator);
-    FieldVector vector4 = new IntVector("vector4", allocator);
-    List<FieldVector> vectorList1 = new ArrayList<>();
-    vectorList1.add(vector1);
-    vectorList1.add(vector2);
-    List<FieldVector> vectorList2 = new ArrayList<>();
-    vectorList2.add(vector3);
-    vectorList2.add(vector4);
-
-    VectorSchemaRoot vectorRoot1 = new VectorSchemaRoot(vectorList1);
-    VectorSchemaRoot vectorRoot2 = new VectorSchemaRoot(vectorList2);
-
-    channel1Data.setVectors(vectorRoot1);
-    channel2Data.setVectors(vectorRoot2);
+    channel1Data.setVectors(new StubChunkData());
+    channel2Data.setVectors(new StubChunkData());
     innerData.add(channel1Data);
     innerData.add(channel2Data);
 
-    FlushService<VectorSchemaRoot> flushService =
-        new FlushService<>(client, channelCache, stage, false);
+    FlushService<StubChunkData> flushService =
+        new FlushService<>(client, channelCache, testContext.stage, false);
     flushService.invalidateAllChannelsInBlob(blobData);
 
     Assert.assertFalse(channel1.isValid());
@@ -486,6 +637,8 @@ public class FlushServiceTest {
 
   @Test
   public void testBlobBuilder() throws Exception {
+    SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1();
+
     ObjectMapper mapper = new ObjectMapper();
     List<ChunkMetadata> chunksMetadataList = new ArrayList<>();
     List<byte[]> chunksDataList = new ArrayList<>();
@@ -516,7 +669,7 @@ public class FlushServiceTest {
             .setOwningTable(channel1)
             .setChunkStartOffset(0L)
             .setChunkLength(dataSize)
-            .setChannelList(Arrays.asList(channelMetadata))
+            .setChannelList(Collections.singletonList(channelMetadata))
             .setChunkMD5("md5")
             .setEncryptionKeyId(1234L)
             .setEpInfo(epInfo)
@@ -578,8 +731,7 @@ public class FlushServiceTest {
 
   @Test
   public void testShutDown() throws Exception {
-    FlushService<VectorSchemaRoot> flushService =
-        new FlushService<>(client, channelCache, stage, false);
+    FlushService<?> flushService = testContext.flushService;
 
     Assert.assertFalse(flushService.buildUploadWorkers.isShutdown());
     Assert.assertFalse(flushService.registerWorker.isShutdown());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
@@ -10,7 +10,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import net.snowflake.ingest.utils.Pair;
-import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -18,16 +17,16 @@ import org.junit.Test;
 public class RegisterServiceTest {
 
   @Test
-  public void testRegisterService() throws Exception {
-    RegisterService<VectorSchemaRoot> rs = new RegisterService<>(null, true);
+  public void testRegisterService() {
+    RegisterService<StubChunkData> rs = new RegisterService<>(null, true);
 
-    Pair<FlushService.BlobData<VectorSchemaRoot>, CompletableFuture<BlobMetadata>> blobFuture =
+    Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blobFuture =
         new Pair<>(
             new FlushService.BlobData<>("test", null),
             CompletableFuture.completedFuture(new BlobMetadata("path", "md5", null)));
     rs.addBlobs(Collections.singletonList(blobFuture));
     Assert.assertEquals(1, rs.getBlobsList().size());
-    List<FlushService.BlobData<VectorSchemaRoot>> errorBlobs = rs.registerBlobs(null);
+    List<FlushService.BlobData<StubChunkData>> errorBlobs = rs.registerBlobs(null);
     Assert.assertEquals(0, rs.getBlobsList().size());
     Assert.assertEquals(0, errorBlobs.size());
   }
@@ -43,22 +42,22 @@ public class RegisterServiceTest {
    */
   @Test
   public void testRegisterServiceTimeoutException() throws Exception {
-    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
         new SnowflakeStreamingIngestClientInternal<>("client");
-    RegisterService<VectorSchemaRoot> rs = new RegisterService<>(client, true);
+    RegisterService<StubChunkData> rs = new RegisterService<>(client, true);
 
-    Pair<FlushService.BlobData<VectorSchemaRoot>, CompletableFuture<BlobMetadata>> blobFuture1 =
+    Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blobFuture1 =
         new Pair<>(
             new FlushService.BlobData<>("success", new ArrayList<>()),
             CompletableFuture.completedFuture(new BlobMetadata("path", "md5", null)));
     CompletableFuture future = new CompletableFuture();
     future.completeExceptionally(new TimeoutException());
-    Pair<FlushService.BlobData<VectorSchemaRoot>, CompletableFuture<BlobMetadata>> blobFuture2 =
-        new Pair<>(new FlushService.BlobData<VectorSchemaRoot>("fail", new ArrayList<>()), future);
+    Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blobFuture2 =
+        new Pair<>(new FlushService.BlobData<StubChunkData>("fail", new ArrayList<>()), future);
     rs.addBlobs(Arrays.asList(blobFuture1, blobFuture2));
     Assert.assertEquals(2, rs.getBlobsList().size());
     try {
-      List<FlushService.BlobData<VectorSchemaRoot>> errorBlobs = rs.registerBlobs(null);
+      List<FlushService.BlobData<StubChunkData>> errorBlobs = rs.registerBlobs(null);
       Assert.assertEquals(0, rs.getBlobsList().size());
       Assert.assertEquals(1, errorBlobs.size());
       Assert.assertEquals("fail", errorBlobs.get(0).getFilePath());
@@ -71,11 +70,11 @@ public class RegisterServiceTest {
   @Ignore
   @Test
   public void testRegisterServiceTimeoutException_testRetries() throws Exception {
-    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
         new SnowflakeStreamingIngestClientInternal<>("client");
-    RegisterService<VectorSchemaRoot> rs = new RegisterService<>(client, true);
+    RegisterService<StubChunkData> rs = new RegisterService<>(client, true);
 
-    Pair<FlushService.BlobData<VectorSchemaRoot>, CompletableFuture<BlobMetadata>> blobFuture1 =
+    Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blobFuture1 =
         new Pair<>(
             new FlushService.BlobData<>("success", new ArrayList<>()),
             CompletableFuture.completedFuture(new BlobMetadata("path", "md5", null)));
@@ -89,12 +88,12 @@ public class RegisterServiceTest {
           }
           return;
         });
-    Pair<FlushService.BlobData<VectorSchemaRoot>, CompletableFuture<BlobMetadata>> blobFuture2 =
-        new Pair<>(new FlushService.BlobData<VectorSchemaRoot>("fail", new ArrayList<>()), future);
+    Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blobFuture2 =
+        new Pair<>(new FlushService.BlobData<StubChunkData>("fail", new ArrayList<>()), future);
     rs.addBlobs(Arrays.asList(blobFuture1, blobFuture2));
     Assert.assertEquals(2, rs.getBlobsList().size());
     try {
-      List<FlushService.BlobData<VectorSchemaRoot>> errorBlobs = rs.registerBlobs(null);
+      List<FlushService.BlobData<StubChunkData>> errorBlobs = rs.registerBlobs(null);
       Assert.assertEquals(0, rs.getBlobsList().size());
       Assert.assertEquals(1, errorBlobs.size());
       Assert.assertEquals("fail", errorBlobs.get(0).getFilePath());
@@ -105,18 +104,18 @@ public class RegisterServiceTest {
 
   @Test
   public void testRegisterServiceNonTimeoutException() {
-    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
         new SnowflakeStreamingIngestClientInternal<>("client");
-    RegisterService<VectorSchemaRoot> rs = new RegisterService<>(client, true);
+    RegisterService<StubChunkData> rs = new RegisterService<>(client, true);
 
-    CompletableFuture future = new CompletableFuture();
+    CompletableFuture<BlobMetadata> future = new CompletableFuture<>();
     future.completeExceptionally(new IndexOutOfBoundsException());
-    Pair<FlushService.BlobData<VectorSchemaRoot>, CompletableFuture<BlobMetadata>> blobFuture =
-        new Pair<>(new FlushService.BlobData<VectorSchemaRoot>("fail", new ArrayList<>()), future);
+    Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blobFuture =
+        new Pair<>(new FlushService.BlobData<>("fail", new ArrayList<>()), future);
     rs.addBlobs(Collections.singletonList(blobFuture));
     Assert.assertEquals(1, rs.getBlobsList().size());
     try {
-      List<FlushService.BlobData<VectorSchemaRoot>> errorBlobs = rs.registerBlobs(null);
+      List<FlushService.BlobData<StubChunkData>> errorBlobs = rs.registerBlobs(null);
       Assert.assertEquals(0, rs.getBlobsList().size());
       Assert.assertEquals(1, errorBlobs.size());
       Assert.assertEquals("fail", errorBlobs.get(0).getFilePath());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -50,13 +50,14 @@ import net.snowflake.ingest.connection.RequestBuilder;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;
-import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.memory.RootAllocator;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -66,10 +67,10 @@ import org.mockito.Mockito;
 public class SnowflakeStreamingIngestClientTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
-  SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel1;
-  SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel2;
-  SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel3;
-  SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel4;
+  SnowflakeStreamingIngestChannelInternal<StubChunkData> channel1;
+  SnowflakeStreamingIngestChannelInternal<StubChunkData> channel2;
+  SnowflakeStreamingIngestChannelInternal<StubChunkData> channel3;
+  SnowflakeStreamingIngestChannelInternal<StubChunkData> channel4;
 
   @Before
   public void setup() {
@@ -88,7 +89,8 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+            Constants.BdecVersion.ONE,
+            new RootAllocator());
     channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel2",
@@ -102,7 +104,8 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+            Constants.BdecVersion.ONE,
+            new RootAllocator());
     channel3 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel3",
@@ -116,7 +119,8 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+            Constants.BdecVersion.ONE,
+            new RootAllocator());
     channel4 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel4",
@@ -130,7 +134,8 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+            Constants.BdecVersion.ONE,
+            new RootAllocator());
   }
 
   @Test
@@ -148,7 +153,10 @@ public class SnowflakeStreamingIngestClientTest {
 
     SnowflakeStreamingIngestClientInternal<?> client =
         (SnowflakeStreamingIngestClientInternal<?>)
-            SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
+            SnowflakeStreamingIngestClientFactory.builder("client")
+                .setProperties(prop)
+                .setParameterOverrides(parameterMap)
+                .build();
 
     Assert.assertEquals("client", client.getName());
     Assert.assertEquals(123, client.getParameterProvider().getBufferFlushIntervalInMs());
@@ -190,8 +198,7 @@ public class SnowflakeStreamingIngestClientTest {
     prop.put(ROLE, "role");
 
     try {
-      SnowflakeStreamingIngestClient client =
-          SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
+      SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
       Assert.fail("Client creation should fail.");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.MISSING_CONFIG.getMessageCode(), e.getVendorCode());
@@ -206,8 +213,7 @@ public class SnowflakeStreamingIngestClientTest {
     prop.put(ROLE, "role");
 
     try {
-      SnowflakeStreamingIngestClient client =
-          SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
+      SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
       Assert.fail("Client creation should fail.");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.MISSING_CONFIG.getMessageCode(), e.getVendorCode());
@@ -223,8 +229,7 @@ public class SnowflakeStreamingIngestClientTest {
     prop.put(ROLE, "role");
 
     try {
-      SnowflakeStreamingIngestClient client =
-          SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
+      SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
       Assert.fail("Client creation should fail.");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.INVALID_URL.getMessageCode(), e.getVendorCode());
@@ -240,8 +245,7 @@ public class SnowflakeStreamingIngestClientTest {
     prop.put(ROLE, "role");
 
     try {
-      SnowflakeStreamingIngestClient client =
-          SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
+      SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
       Assert.fail("Client creation should fail.");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.INVALID_PRIVATE_KEY.getMessageCode(), e.getVendorCode());
@@ -304,7 +308,7 @@ public class SnowflakeStreamingIngestClientTest {
   public void testGetChannelsStatusWithRequest() throws Exception {
     ChannelsStatusResponse.ChannelStatusResponseDTO channelStatus =
         new ChannelsStatusResponse.ChannelStatusResponseDTO();
-    channelStatus.setStatusCode((long) RESPONSE_SUCCESS);
+    channelStatus.setStatusCode(RESPONSE_SUCCESS);
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("honk");
@@ -347,7 +351,8 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+            Constants.BdecVersion.ONE,
+            new RootAllocator());
 
     ChannelsStatusRequest.ChannelStatusRequestDTO dto =
         new ChannelsStatusRequest.ChannelStatusRequestDTO(channel);
@@ -405,7 +410,8 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+            Constants.BdecVersion.ONE,
+            new RootAllocator());
 
     try {
       client.getChannelsStatus(Collections.singletonList(channel));
@@ -443,7 +449,8 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+            Constants.BdecVersion.ONE,
+            new RootAllocator());
 
     ChannelMetadata channelMetadata =
         ChannelMetadata.builder()
@@ -480,8 +487,7 @@ public class SnowflakeStreamingIngestClientTest {
             payload, REGISTER_BLOB_ENDPOINT, "register blob");
 
     Assert.assertEquals(
-        String.format("%s%s", urlStr, REGISTER_BLOB_ENDPOINT),
-        request.getRequestLine().getUri().toString());
+        String.format("%s%s", urlStr, REGISTER_BLOB_ENDPOINT), request.getRequestLine().getUri());
     Assert.assertNotNull(request.getFirstHeader(HttpHeaders.USER_AGENT));
     Assert.assertNotNull(request.getFirstHeader(HttpHeaders.AUTHORIZATION));
     Assert.assertEquals("POST", request.getMethod());
@@ -588,7 +594,7 @@ public class SnowflakeStreamingIngestClientTest {
     badChunkRegisterStatus.setTableName(chunkMetadata1.getTableName());
     badChunkRegisterStatus.setChannelsStatus(channelRegisterStatuses);
     badChunks.add(badChunkRegisterStatus);
-    return new Pair(blobs, badChunks);
+    return new Pair<>(blobs, badChunks);
   }
 
   @Test
@@ -618,7 +624,7 @@ public class SnowflakeStreamingIngestClientTest {
     Assert.assertEquals(
         Sets.newHashSet("channel1", "channel2"),
         result.get(0).getChunks().get(0).getChannels().stream()
-            .map(c -> c.getChannelName())
+            .map(ChannelMetadata::getChannelName)
             .collect(Collectors.toSet()));
     Assert.assertEquals(ParameterProvider.BLOB_FORMAT_VERSION_DEFAULT, result.get(0).getVersion());
   }
@@ -650,8 +656,7 @@ public class SnowflakeStreamingIngestClientTest {
 
     try {
       List<BlobMetadata> blobs =
-          Collections.singletonList(
-              new BlobMetadata("path", "md5", new ArrayList<ChunkMetadata>()));
+          Collections.singletonList(new BlobMetadata("path", "md5", new ArrayList<>()));
       client.registerBlobs(blobs);
       Assert.fail("Register blob should fail on 404 error");
     } catch (SFException e) {
@@ -698,8 +703,7 @@ public class SnowflakeStreamingIngestClientTest {
 
     try {
       List<BlobMetadata> blobs =
-          Collections.singletonList(
-              new BlobMetadata("path", "md5", new ArrayList<ChunkMetadata>()));
+          Collections.singletonList(new BlobMetadata("path", "md5", new ArrayList<>()));
       client.registerBlobs(blobs);
       Assert.fail("Register blob should fail on SF internal error");
     } catch (SFException e) {
@@ -754,7 +758,7 @@ public class SnowflakeStreamingIngestClientTest {
             null);
 
     List<BlobMetadata> blobs =
-        Collections.singletonList(new BlobMetadata("path", "md5", new ArrayList<ChunkMetadata>()));
+        Collections.singletonList(new BlobMetadata("path", "md5", new ArrayList<>()));
     client.registerBlobs(blobs);
   }
 
@@ -794,7 +798,7 @@ public class SnowflakeStreamingIngestClientTest {
 
     List<BlobRegisterStatus> blobRegisterStatuses = new ArrayList<>();
     BlobRegisterStatus blobRegisterStatus1 = new BlobRegisterStatus();
-    blobRegisterStatus1.setChunksStatus(badChunks.stream().collect(Collectors.toList()));
+    blobRegisterStatus1.setChunksStatus(new ArrayList<>(badChunks));
     blobRegisterStatuses.add(blobRegisterStatus1);
     BlobRegisterStatus blobRegisterStatus2 = new BlobRegisterStatus();
     blobRegisterStatus2.setChunksStatus(Collections.singletonList(goodChunkRegisterStatus));
@@ -827,7 +831,7 @@ public class SnowflakeStreamingIngestClientTest {
     RequestBuilder requestBuilder =
         Mockito.spy(
             new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair()));
-    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
         new SnowflakeStreamingIngestClientInternal<>(
             "client",
             new SnowflakeURL("snowflake.dev.local:8082"),
@@ -910,7 +914,7 @@ public class SnowflakeStreamingIngestClientTest {
 
     List<BlobRegisterStatus> blobRegisterStatuses = new ArrayList<>();
     BlobRegisterStatus blobRegisterStatus1 = new BlobRegisterStatus();
-    blobRegisterStatus1.setChunksStatus(badChunks.stream().collect(Collectors.toList()));
+    blobRegisterStatus1.setChunksStatus(new ArrayList<>(badChunks));
     blobRegisterStatuses.add(blobRegisterStatus1);
     BlobRegisterStatus blobRegisterStatus2 = new BlobRegisterStatus();
     blobRegisterStatus2.setChunksStatus(Collections.singletonList(goodChunkRegisterStatus));
@@ -942,7 +946,7 @@ public class SnowflakeStreamingIngestClientTest {
     RequestBuilder requestBuilder =
         Mockito.spy(
             new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair()));
-    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
         new SnowflakeStreamingIngestClientInternal<>(
             "client",
             new SnowflakeURL("snowflake.dev.local:8082"),
@@ -1016,8 +1020,8 @@ public class SnowflakeStreamingIngestClientTest {
 
     RequestBuilder requestBuilder =
         new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair());
-    SnowflakeStreamingIngestClientInternal client =
-        new SnowflakeStreamingIngestClientInternal(
+    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
+        new SnowflakeStreamingIngestClientInternal<>(
             "client",
             new SnowflakeURL("snowflake.dev.local:8082"),
             null,
@@ -1026,8 +1030,8 @@ public class SnowflakeStreamingIngestClientTest {
             requestBuilder,
             null);
 
-    SnowflakeStreamingIngestChannelInternal channel1 =
-        new SnowflakeStreamingIngestChannelInternal(
+    SnowflakeStreamingIngestChannelInternal<StubChunkData> channel1 =
+        new SnowflakeStreamingIngestChannelInternal<>(
             channel1Name,
             dbName,
             schemaName,
@@ -1038,10 +1042,9 @@ public class SnowflakeStreamingIngestClientTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
-    SnowflakeStreamingIngestChannelInternal channel2 =
-        new SnowflakeStreamingIngestChannelInternal(
+            OpenChannelRequest.OnErrorOption.CONTINUE);
+    SnowflakeStreamingIngestChannelInternal<StubChunkData> channel2 =
+        new SnowflakeStreamingIngestChannelInternal<>(
             channel2Name,
             dbName,
             schemaName,
@@ -1052,8 +1055,7 @@ public class SnowflakeStreamingIngestClientTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+            OpenChannelRequest.OnErrorOption.CONTINUE);
     client.getChannelCache().addChannel(channel1);
     client.getChannelCache().addChannel(channel2);
 
@@ -1061,7 +1063,7 @@ public class SnowflakeStreamingIngestClientTest {
     Assert.assertTrue(channel2.isValid());
 
     List<BlobMetadata> blobs =
-        Collections.singletonList(new BlobMetadata("path", "md5", new ArrayList<ChunkMetadata>()));
+        Collections.singletonList(new BlobMetadata("path", "md5", new ArrayList<>()));
     client.registerBlobs(blobs);
 
     // Channel2 should be invalidated now
@@ -1071,8 +1073,8 @@ public class SnowflakeStreamingIngestClientTest {
 
   @Test
   public void testFlush() throws Exception {
-    SnowflakeStreamingIngestClientInternal client =
-        Mockito.spy(new SnowflakeStreamingIngestClientInternal("client"));
+    SnowflakeStreamingIngestClientInternal<?> client =
+        Mockito.spy(new SnowflakeStreamingIngestClientInternal<>("client"));
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("Success");
@@ -1093,8 +1095,8 @@ public class SnowflakeStreamingIngestClientTest {
 
   @Test
   public void testClose() throws Exception {
-    SnowflakeStreamingIngestClientInternal client =
-        Mockito.spy(new SnowflakeStreamingIngestClientInternal("client"));
+    SnowflakeStreamingIngestClientInternal<?> client =
+        Mockito.spy(new SnowflakeStreamingIngestClientInternal<>("client"));
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("Success");
@@ -1127,12 +1129,8 @@ public class SnowflakeStreamingIngestClientTest {
 
   @Test
   public void testCloseWithError() throws Exception {
-    SnowflakeStreamingIngestClientInternal client =
-        Mockito.spy(new SnowflakeStreamingIngestClientInternal("client"));
-    ChannelsStatusResponse response = new ChannelsStatusResponse();
-    response.setStatusCode(20L);
-    response.setMessage("Failure");
-    response.setChannels(new ArrayList<>());
+    SnowflakeStreamingIngestClientInternal<?> client =
+        Mockito.spy(new SnowflakeStreamingIngestClientInternal<>("client"));
 
     CompletableFuture<Void> future = new CompletableFuture<>();
     future.completeExceptionally(new Exception("Simulating Error"));
@@ -1169,10 +1167,10 @@ public class SnowflakeStreamingIngestClientTest {
 
   @Test
   public void testVerifyChannelsAreFullyCommittedSuccess() throws Exception {
-    SnowflakeStreamingIngestClientInternal client =
-        Mockito.spy(new SnowflakeStreamingIngestClientInternal("client"));
-    SnowflakeStreamingIngestChannelInternal channel =
-        new SnowflakeStreamingIngestChannelInternal(
+    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
+        Mockito.spy(new SnowflakeStreamingIngestClientInternal<>("client"));
+    SnowflakeStreamingIngestChannelInternal<StubChunkData> channel =
+        new SnowflakeStreamingIngestChannelInternal<>(
             "channel1",
             "db",
             "schema",
@@ -1183,8 +1181,7 @@ public class SnowflakeStreamingIngestClientTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE,
-            true);
+            OpenChannelRequest.OnErrorOption.CONTINUE);
     client.getChannelCache().addChannel(channel);
 
     ChannelsStatusResponse response = new ChannelsStatusResponse();

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StubChunkData.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StubChunkData.java
@@ -1,0 +1,4 @@
+package net.snowflake.ingest.streaming.internal;
+
+/** Stub class for class parameters where it does not matter. */
+public final class StubChunkData {}


### PR DESCRIPTION
This is a follow up for #202 to refactor tests to run with various BDEC format versions.