### PR TITLE
@snow SNOW-647377 Fix quoted columns scan and with inner space

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -19,7 +19,6 @@ import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.SFException;
-import net.snowflake.ingest.utils.Utils;
 import org.apache.arrow.util.VisibleForTesting;
 
 /**
@@ -198,7 +197,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       Map<String, Object> row, InsertValidationResponse.InsertError error) {
     Map<String, String> inputColNamesMap =
         row.keySet().stream()
-            .collect(Collectors.toMap(AbstractRowBuffer::formatColumnName, value -> value));
+            .collect(Collectors.toMap(LiteralQuoteUtils::formatColumnName, value -> value));
 
     // Check for extra columns in the row
     List<String> extraCols = new ArrayList<>();
@@ -436,14 +435,6 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
 
   @VisibleForTesting
   abstract int getTempRowCount();
-
-  /** Normalize the column name, given with the inserted row, to send to server side. */
-  static String formatColumnName(String columnName) {
-    Utils.assertStringNotNullOrEmpty("invalid column name", columnName);
-    return (columnName.charAt(0) == '"' && columnName.charAt(columnName.length() - 1) == '"')
-        ? columnName
-        : columnName.toUpperCase();
-  }
 
   /**
    * Given a set of col names to stats, build the right ep info

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -339,7 +339,8 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
 
     // Create the corresponding column field base on the column data type
     fieldType = new FieldType(column.getNullable(), arrowType, null, metadata);
-    return new Field(column.getName(), fieldType, children);
+    String columnName = LiteralQuoteUtils.unquoteColumnName(column.getName());
+    return new Field(columnName, fieldType, children);
   }
 
   @Override
@@ -443,7 +444,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
     float rowBufferSize = 0F;
     for (Map.Entry<String, Object> entry : row.entrySet()) {
       rowBufferSize += 0.125; // 1/8 for null value bitmap
-      String columnName = formatColumnName(entry.getKey());
+      String columnName = LiteralQuoteUtils.formatColumnName(entry.getKey());
       Object value = entry.getValue();
       Field field = this.fields.get(columnName);
       Utils.assertNotNull("Arrow column field", field);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -106,7 +106,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
       Field field = buildField(column);
       FieldVector vector = field.createVector(this.allocator);
       if (!field.isNullable()) {
-        addNonNullableFieldName(field.getName());
+        addNonNullableFieldName(column.getName());
       }
       this.fields.put(column.getName(), field);
       vectors.add(vector);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/LiteralQuoteUtils.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/LiteralQuoteUtils.java
@@ -1,0 +1,170 @@
+package net.snowflake.ingest.streaming.internal;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import net.snowflake.ingest.utils.Utils;
+
+/**
+ * Util class to normalise literals to match server side metadata.
+ *
+ * <p>Note: The methods in this class have to be kept in sync with the respective methods on server
+ * side.
+ */
+class LiteralQuoteUtils {
+  private static final String[] reservedKeywords = {
+    // ANSI reserved KW
+    "ALL",
+    "ALTER",
+    "AND",
+    "ANY",
+    "AS",
+    "BETWEEN",
+    "BY",
+    "CHECK",
+    "COLUMN",
+    "CONNECT",
+    "CREATE",
+    "CURRENT",
+    "DELETE",
+    "DISTINCT",
+    "DROP",
+    "ELSE",
+    "EXISTS",
+    "FOLLOWING",
+    "FOR",
+    "FROM",
+    "GRANT",
+    "GROUP",
+    "HAVING",
+    "IN",
+    "INSERT",
+    "INTERSECT",
+    "INTO",
+    "IS",
+    "LIKE",
+    "NOT",
+    "NULL",
+    "OF",
+    "ON",
+    "OR",
+    "ORDER",
+    "REVOKE",
+    "ROW",
+    "ROWS",
+    "SAMPLE",
+    "SELECT",
+    "SET",
+    "START",
+    "TABLE",
+    "TABLESAMPLE",
+    "THEN",
+    "TO",
+    "TRIGGER",
+    "UNION",
+    "UNIQUE",
+    "UPDATE",
+    "VALUES",
+    "WHENEVER",
+    "WHERE",
+    "WITH",
+
+    // oracle reserved KW
+    "INCREMENT",
+    "MINUS",
+
+    // snowflake reserved KW
+    "AGGREGATE",
+    "ILIKE",
+    "REGEXP",
+    "RLIKE",
+    "SOME",
+    "QUALIFY"
+  };
+
+  private static final Set<String> reservedKeywordSet =
+      new HashSet<>(Arrays.asList(reservedKeywords));
+
+  // column names that do not need quoting to match metadata
+  private static final Pattern unquotedIdentifierPattern =
+      Pattern.compile("[$][0-9]+|[_A-Z][_A-Z0-9]*[$]?[_A-Z0-9]*");
+
+  /**
+   * Format the column name, given with the user inserted row, to match column metadata, sent by
+   * server side.
+   */
+  static String formatColumnName(String columnName) {
+    Utils.assertStringNotNullOrEmpty("invalid column name", columnName);
+    // internal server side normalised column name in persistent metadata
+    String normalisedInternalName = unquoteColumnName(columnName);
+    // display name sent by server side to client in open channel column metadata response
+    return quoteColumnNameIfNeeded(normalisedInternalName);
+  }
+
+  /**
+   * Quote user column name to match server side metadata.
+   *
+   * <p>This needs to be in sync with server side to code, until we decide to send the normalised
+   * unquoted column name from server.
+   */
+  private static String quoteColumnNameIfNeeded(String columnName) {
+    if (!unquotedIdentifierPattern.matcher(columnName).matches()
+        || reservedKeywordSet.contains(columnName)) {
+      columnName = '"' + columnName.replace("\"", "\"\"") + '"';
+    }
+    return columnName;
+  }
+
+  /**
+   * Unquote SQL literal.
+   *
+   * <p>Normalises the column name to how it is stored internally. This function needs to keep in
+   * sync with server side normalisation. The reason, we do it here, is to store the normalised
+   * column name in BDEC file metadata.
+   *
+   * @param columnName column name literal to unquote
+   * @return unquoted literal
+   */
+  static String unquoteColumnName(String columnName) {
+    int length = columnName.length();
+
+    if (length == 0) {
+      return columnName;
+    }
+
+    // If this is an identifier that starts and ends with double quotes,
+    // remove them - accounting for escaped double quotes.
+    // Differs from the second condition in that this one allows repeated
+    // double quotes
+    if (columnName.charAt(0) == '"'
+        && (length >= 2
+            && columnName.charAt(length - 1) == '"'
+            &&
+            // Condition that the string contains no single double-quotes
+            // but allows repeated double-quotes
+            !columnName.substring(1, length - 1).replace("\"\"", "").contains("\""))) {
+      // Remove quotes and turn escaped double-quotes to single double-quotes
+      return columnName.substring(1, length - 1).replace("\"\"", "\"");
+    }
+
+    // If this is an identifier that starts and ends with double quotes,
+    // remove them. Internal single double-quotes are not allowed.
+    else if (columnName.charAt(0) == '"'
+        && (length >= 2
+            && columnName.charAt(length - 1) == '"'
+            && !columnName.substring(1, length - 1).contains("\""))) {
+      // Remove the quotes
+      return columnName.substring(1, length - 1);
+    }
+
+    // unquoted string that can have escaped spaces
+    else {
+      // replace escaped spaces in unquoted name
+      if (columnName.contains("\\ ")) {
+        columnName = columnName.replace("\\ ", " ");
+      }
+      return columnName.toUpperCase();
+    }
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
@@ -58,7 +58,7 @@ public class ArrowBufferTest {
   public void buildFieldFixedSB1() {
     // FIXED, SB1
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB1");
     testCol.setNullable(true);
     testCol.setLogicalType("FIXED");
@@ -68,7 +68,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.TINYINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB1");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -81,7 +81,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldFixedSB2() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB2");
     testCol.setNullable(false);
     testCol.setLogicalType("FIXED");
@@ -91,7 +91,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.SMALLINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB2");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -104,7 +104,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldFixedSB4() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB4");
     testCol.setNullable(true);
     testCol.setLogicalType("FIXED");
@@ -114,7 +114,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.INT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB4");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -126,7 +126,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldFixedSB8() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB8");
     testCol.setNullable(true);
     testCol.setLogicalType("FIXED");
@@ -136,7 +136,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIGINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -148,7 +148,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldFixedSB16() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB16");
     testCol.setNullable(true);
     testCol.setLogicalType("FIXED");
@@ -161,7 +161,7 @@ public class ArrowBufferTest {
     ArrowType expectedType =
         new ArrowType.Decimal(testCol.getPrecision(), testCol.getScale(), DECIMAL_BIT_WIDTH);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), expectedType);
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -173,7 +173,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldLobVariant() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("LOB");
     testCol.setNullable(true);
     testCol.setLogicalType("VARIANT");
@@ -183,7 +183,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.VARCHAR.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "LOB");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -195,7 +195,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldTimestampNtzSB8() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB8");
     testCol.setNullable(true);
     testCol.setLogicalType("TIMESTAMP_NTZ");
@@ -205,7 +205,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIGINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -217,7 +217,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldTimestampNtzSB16() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB16");
     testCol.setNullable(true);
     testCol.setLogicalType("TIMESTAMP_NTZ");
@@ -227,7 +227,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.STRUCT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -243,7 +243,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldTimestampTzSB8() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB8");
     testCol.setNullable(true);
     testCol.setLogicalType("TIMESTAMP_TZ");
@@ -253,7 +253,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.STRUCT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -269,7 +269,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldTimestampTzSB16() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB16");
     testCol.setNullable(true);
     testCol.setLogicalType("TIMESTAMP_TZ");
@@ -279,7 +279,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.STRUCT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -297,7 +297,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldDate() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB8");
     testCol.setNullable(true);
     testCol.setLogicalType("DATE");
@@ -307,7 +307,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.DATEDAY.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -319,7 +319,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldTimeSB4() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB4");
     testCol.setNullable(true);
     testCol.setLogicalType("TIME");
@@ -329,7 +329,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.INT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB4");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -341,7 +341,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldTimeSB8() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB8");
     testCol.setNullable(true);
     testCol.setLogicalType("TIME");
@@ -351,7 +351,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIGINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -363,7 +363,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldBoolean() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("BINARY");
     testCol.setNullable(true);
     testCol.setLogicalType("BOOLEAN");
@@ -373,7 +373,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "BINARY");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -385,7 +385,7 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldRealSB16() {
     ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
+    testCol.setName("TESTCOL");
     testCol.setPhysicalType("SB16");
     testCol.setNullable(true);
     testCol.setLogicalType("REAL");
@@ -395,7 +395,7 @@ public class ArrowBufferTest {
     testCol.setPrecision(4);
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.FLOAT8.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -534,7 +534,7 @@ public class RowBufferTest {
     InsertValidationResponse response = rowBuffer.insertRows(Collections.singletonList(row1), null);
     Assert.assertFalse(response.hasErrors());
 
-    Assert.assertEquals((byte) 10, rowBuffer.getVectorValueAt("\"colTinyInt\"", 0));
+    Assert.assertEquals((byte) 10, rowBuffer.getVectorValueAt("colTinyInt", 0));
     Assert.assertEquals((byte) 1, rowBuffer.getVectorValueAt("COLTINYINT", 0));
     Assert.assertEquals((short) 2, rowBuffer.getVectorValueAt("COLSMALLINT", 0));
     Assert.assertEquals(3, rowBuffer.getVectorValueAt("COLINT", 0));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -909,6 +909,13 @@ public class RowBufferTest {
     colBoolean.setLogicalType("BOOLEAN");
     colBoolean.setScale(0);
 
+    ColumnMetadata colBooleanLowCase = new ColumnMetadata();
+    colBooleanLowCase.setName("\"colboolean\"");
+    colBooleanLowCase.setPhysicalType("SB1");
+    colBooleanLowCase.setNullable(false);
+    colBooleanLowCase.setLogicalType("BOOLEAN");
+    colBooleanLowCase.setScale(0);
+
     ColumnMetadata colBoolean2 = new ColumnMetadata();
     colBoolean2.setName("COLBOOLEAN2");
     colBoolean2.setPhysicalType("SB1");
@@ -916,9 +923,10 @@ public class RowBufferTest {
     colBoolean2.setLogicalType("BOOLEAN");
     colBoolean2.setScale(0);
 
-    innerBuffer.setupSchema(Arrays.asList(colBoolean, colBoolean2));
+    innerBuffer.setupSchema(Arrays.asList(colBoolean, colBooleanLowCase, colBoolean2));
     Map<String, Object> row = new HashMap<>();
     row.put("COLBOOLEAN", true);
+    row.put("\"colboolean\"", true);
 
     InsertValidationResponse response = innerBuffer.insertRows(Collections.singletonList(row), "1");
     Assert.assertFalse(response.hasErrors());
@@ -931,8 +939,12 @@ public class RowBufferTest {
       InsertValidationResponse.InsertError error = response.getInsertErrors().get(0);
       Assert.assertEquals(
           ErrorCode.INVALID_ROW.getMessageCode(), error.getException().getVendorCode());
-      Assert.assertEquals(
-          Collections.singletonList("COLBOOLEAN"), error.getMissingNotNullColNames());
+      List<String> missingCols = error.getMissingNotNullColNames();
+      List<String> expected = Arrays.asList("COLBOOLEAN", "\"colboolean\"");
+      Assert.assertTrue(
+          missingCols.size() == expected.size()
+              && missingCols.containsAll(expected)
+              && expected.containsAll(missingCols));
     } else {
       try {
         innerBuffer.insertRows(Collections.singletonList(row2), "2");
@@ -953,9 +965,17 @@ public class RowBufferTest {
     colBoolean.setLogicalType("BOOLEAN");
     colBoolean.setScale(0);
 
-    innerBuffer.setupSchema(Collections.singletonList(colBoolean));
+    ColumnMetadata colBooleanLowCase = new ColumnMetadata();
+    colBooleanLowCase.setName("\"colboolean1\"");
+    colBooleanLowCase.setPhysicalType("SB1");
+    colBooleanLowCase.setNullable(false);
+    colBooleanLowCase.setLogicalType("BOOLEAN");
+    colBooleanLowCase.setScale(0);
+
+    innerBuffer.setupSchema(Arrays.asList(colBoolean, colBooleanLowCase));
     Map<String, Object> row = new HashMap<>();
     row.put("COLBOOLEAN1", true);
+    row.put("\"colboolean1\"", true);
     row.put("COLBOOLEAN2", true);
     row.put("COLBOOLEAN3", true);
 
@@ -964,7 +984,12 @@ public class RowBufferTest {
     InsertValidationResponse.InsertError error = response.getInsertErrors().get(0);
     Assert.assertEquals(
         ErrorCode.INVALID_ROW.getMessageCode(), error.getException().getVendorCode());
-    Assert.assertEquals(Arrays.asList("COLBOOLEAN3", "COLBOOLEAN2"), error.getExtraColNames());
+    List<String> extraCols = error.getExtraColNames();
+    List<String> expected = Arrays.asList("COLBOOLEAN3", "COLBOOLEAN2");
+    Assert.assertTrue(
+        extraCols.size() == expected.size()
+            && extraCols.containsAll(expected)
+            && expected.containsAll(extraCols));
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -94,6 +94,88 @@ public class StreamingIngestIT {
   }
 
   @Test
+  public void testColumnNameQuotes() throws Exception {
+    final String tableName = "T_COLUMN_WITH_QUOTES";
+    final String unquotedColumn = "c1"; // user name <C1>
+    final String quotedColumn = "\"c 2\""; // user name <c 2>
+    final String doubleQuotedColumn = "\"c\"\"a\\ \"\"\\ 3\""; // user name <c"a\ "\ 3>
+    final String escapedSpacesColumn1 =
+        "c\\ 4"; // space is escaped with '\' in Snowflake SQL, user name <C 4>
+    final String escapedSpacesColumn2 =
+        "c\\ 5"; // space is escaped with '\' in Snowflake SQL, user name <C 5>
+    jdbcConnection
+        .createStatement()
+        .execute(
+            String.format(
+                "create or replace table %s.%s.%s (%s NUMBER(38,0), %s NUMBER(38,0), %s"
+                    + " NUMBER(38,0), %s NUMBER(38,0), %s NUMBER(38,0));",
+                testDb,
+                TEST_SCHEMA,
+                tableName,
+                unquotedColumn,
+                quotedColumn,
+                doubleQuotedColumn,
+                escapedSpacesColumn1,
+                escapedSpacesColumn2));
+
+    OpenChannelRequest request1 =
+        OpenChannelRequest.builder("CHANNEL")
+            .setDBName(testDb)
+            .setSchemaName(TEST_SCHEMA)
+            .setTableName(tableName)
+            .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
+            .build();
+
+    // Open a streaming ingest channel from the given client
+    SnowflakeStreamingIngestChannel channel1 = client.openChannel(request1);
+    for (int val = 0; val < 10; val++) {
+      Map<String, Object> row = new HashMap<>();
+      row.put(unquotedColumn, val);
+      row.put(quotedColumn, val);
+      row.put(doubleQuotedColumn, val);
+      row.put(escapedSpacesColumn1, val);
+      // space escape '\' is not really required, because Java always has its own outer double
+      // quotes.
+      // hence, it happens to also work w/o the space escape after the internal literal
+      // normalisation.
+      String escapedSpacesColumn2NoSpaceEscape = escapedSpacesColumn2.replace("\\", "");
+      row.put(escapedSpacesColumn2NoSpaceEscape, val);
+      verifyInsertValidationResponse(channel1.insertRow(row, Integer.toString(val)));
+    }
+
+    // Close the channel after insertion
+    channel1.close().get();
+
+    for (int i = 1; i < 15; i++) {
+      if (channel1.getLatestCommittedOffsetToken() != null
+          && channel1.getLatestCommittedOffsetToken().equals("9")) {
+        ResultSet result =
+            jdbcConnection
+                .createStatement()
+                .executeQuery(
+                    String.format(
+                        "select %s, %s, %s, %s, %s from %s.%s.%s order by %s",
+                        unquotedColumn,
+                        quotedColumn,
+                        doubleQuotedColumn,
+                        escapedSpacesColumn1,
+                        escapedSpacesColumn2,
+                        testDb,
+                        TEST_SCHEMA,
+                        tableName,
+                        unquotedColumn));
+        for (int val = 0; val < 10; val++) {
+          result.next();
+          for (int index = 1; index <= 5; index++) Assert.assertEquals(val, result.getInt(index));
+        }
+        return;
+      }
+      Thread.sleep(500);
+    }
+    Assert.fail("Row sequencer not updated before timeout");
+  }
+
+  @Test
   public void testSimpleIngest() throws Exception {
     OpenChannelRequest request1 =
         OpenChannelRequest.builder("CHANNEL")


### PR DESCRIPTION
This fixes the problem that ingested quoted columns are not queryable by server side.
The problem is that the server side expects column name in Arrow file metadata without quotes and space escape characters.