### PR TITLE
SNOW-655614 Data type validation: Date and Time

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -553,11 +553,11 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
             }
           case TIMESTAMP_LTZ:
           case TIMESTAMP_NTZ:
+            boolean ignoreTimezone = logicalType == ColumnLogicalType.TIMESTAMP_NTZ;
+
             switch (physicalType) {
               case SB8:
                 {
-                  boolean ignoreTimezone = logicalType == ColumnLogicalType.TIMESTAMP_NTZ;
-
                   BigIntVector bigIntVector = (BigIntVector) vector;
                   TimestampWrapper timestampWrapper =
                       DataValidationUtil.validateAndParseTimestampNtzSb16(
@@ -569,8 +569,6 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
                 }
               case SB16:
                 {
-                  boolean ignoreTimezone = logicalType == ColumnLogicalType.TIMESTAMP_NTZ;
-
                   StructVector structVector = (StructVector) vector;
                   BigIntVector epochVector =
                       (BigIntVector) structVector.getChild(FIELD_EPOCH_IN_SECONDS);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -556,16 +556,21 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
             switch (physicalType) {
               case SB8:
                 {
+                  boolean ignoreTimezone = logicalType == ColumnLogicalType.TIMESTAMP_NTZ;
+
                   BigIntVector bigIntVector = (BigIntVector) vector;
-                  BigInteger timeInScale =
-                      DataValidationUtil.validateAndParseTime(value, field.getMetadata());
-                  bigIntVector.setSafe(curRowIndex, timeInScale.longValue());
-                  stats.addIntValue(timeInScale);
+                  TimestampWrapper timestampWrapper =
+                      DataValidationUtil.validateAndParseTimestampNtzSb16(
+                          value, getColumnScale(field.getMetadata()), ignoreTimezone);
+                  bigIntVector.setSafe(curRowIndex, timestampWrapper.getTimeInScale().longValue());
+                  stats.addIntValue(timestampWrapper.getTimeInScale());
                   rowBufferSize += 8;
                   break;
                 }
               case SB16:
                 {
+                  boolean ignoreTimezone = logicalType == ColumnLogicalType.TIMESTAMP_NTZ;
+
                   StructVector structVector = (StructVector) vector;
                   BigIntVector epochVector =
                       (BigIntVector) structVector.getChild(FIELD_EPOCH_IN_SECONDS);
@@ -576,7 +581,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
 
                   TimestampWrapper timestampWrapper =
                       DataValidationUtil.validateAndParseTimestampNtzSb16(
-                          value, field.getMetadata());
+                          value, getColumnScale(field.getMetadata()), ignoreTimezone);
                   epochVector.setSafe(curRowIndex, timestampWrapper.getEpoch());
                   fractionVector.setSafe(curRowIndex, timestampWrapper.getFraction());
                   rowBufferSize += 12;
@@ -600,7 +605,8 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
                   structVector.setIndexDefined(curRowIndex);
 
                   TimestampWrapper timestampWrapper =
-                      DataValidationUtil.validateAndParseTimestampTz(value, field.getMetadata());
+                      DataValidationUtil.validateAndParseTimestampTz(
+                          value, getColumnScale(field.getMetadata()));
                   epochVector.setSafe(curRowIndex, timestampWrapper.getTimeInScale().longValue());
                   timezoneVector.setSafe(
                       curRowIndex,
@@ -639,7 +645,8 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
                   structVector.setIndexDefined(curRowIndex);
 
                   TimestampWrapper timestampWrapper =
-                      DataValidationUtil.validateAndParseTimestampTz(value, field.getMetadata());
+                      DataValidationUtil.validateAndParseTimestampTz(
+                          value, getColumnScale(field.getMetadata()));
                   epochVector.setSafe(curRowIndex, timestampWrapper.getEpoch());
                   fractionVector.setSafe(curRowIndex, timestampWrapper.getFraction());
                   timezoneVector.setSafe(
@@ -685,7 +692,8 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
               case SB4:
                 {
                   BigInteger timeInScale =
-                      DataValidationUtil.validateAndParseTime(value, field.getMetadata());
+                      DataValidationUtil.validateAndParseTime(
+                          value, getColumnScale(field.getMetadata()));
                   stats.addIntValue(timeInScale);
                   ((IntVector) vector).setSafe(curRowIndex, timeInScale.intValue());
                   stats.addIntValue(timeInScale);
@@ -695,7 +703,8 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
               case SB8:
                 {
                   BigInteger timeInScale =
-                      DataValidationUtil.validateAndParseTime(value, field.getMetadata());
+                      DataValidationUtil.validateAndParseTime(
+                          value, getColumnScale(field.getMetadata()));
                   ((BigIntVector) vector).setSafe(curRowIndex, timeInScale.longValue());
                   stats.addIntValue(timeInScale);
                   rowBufferSize += 8;
@@ -766,6 +775,10 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
       throw new SFException(ErrorCode.INTERNAL_ERROR, "Unexpected FieldType");
     }
     stats.incCurrentNullCount();
+  }
+
+  private int getColumnScale(Map<String, String> metadata) {
+    return Integer.parseInt(metadata.get(ArrowRowBuffer.COLUMN_SCALE));
   }
 
   @Override

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -138,16 +138,14 @@ class DataValidationUtil {
   }
 
   /**
-   * Validates and parses input for TIMESTAMP_NTZ or TIMESTAMP_LTZ Snowflake type
-   * Allowed Java types:
-   *  * String
-   *    * Snowflake date format https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats
-   *    * Snowflake timestamp format https://docs.snowflake.com/en/user-guide/date-time-input-output.html#timestamp-formats
-   *    * numeric string
-   *  * java.time.LocalDate
-   *  * java.time.LocalDateTime
-   *  * java.time.OffsetDateTime
-   *  * java.time.ZonedDateTime
+   * Validates and parses input for TIMESTAMP_NTZ or TIMESTAMP_LTZ Snowflake type Allowed Java
+   * types: * String * Snowflake date format
+   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats * Snowflake
+   * timestamp format
+   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#timestamp-formats *
+   * numeric string * java.time.LocalDate * java.time.LocalDateTime * java.time.OffsetDateTime *
+   * java.time.ZonedDateTime
+   *
    * @param input String date in valid format or seconds past the epoch. Accepts fractional seconds
    *     with precision up to the column's scale
    * @param scale decimal scale of timestamp 16 byte integer
@@ -172,7 +170,10 @@ class DataValidationUtil {
               ? ((OffsetDateTime) input).toLocalDateTime().toString()
               : DateTimeFormatter.ISO_DATE_TIME.format((OffsetDateTime) input);
     else
-      throw typeNotAllowedException(input.getClass(), "TIMESTAMP", new String[] {"String", "LocalDate", "LocalDateTime", "ZonedDateTime", "OffsetDateTime"});
+      throw typeNotAllowedException(
+          input.getClass(),
+          "TIMESTAMP",
+          new String[] {"String", "LocalDate", "LocalDateTime", "ZonedDateTime", "OffsetDateTime"});
 
     SnowflakeDateTimeFormat snowflakeDateTimeFormatter = createDateTimeFormatter();
     TimeZone effectiveTimeZone = ignoreTimezone ? GMT : DEFAULT_TIMEZONE;
@@ -195,6 +196,7 @@ class DataValidationUtil {
   /**
    * Given a SFTimestamp, get the number of nanoseconds since the last whole second. This
    * corresponds to the fraction component for Timestamp types
+   *
    * @param input SFTimestamp
    * @return Timestamp fraction value, the number of nanoseconds since the last whole second
    */
@@ -205,16 +207,14 @@ class DataValidationUtil {
   }
 
   /**
-   * Validates and parses input for TIMESTAMP_TZ Snowflake type
-   * Allowed Java types:
-   *  * String
-   *    * Snowflake date format https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats
-   *    * Snowflake timestamp format https://docs.snowflake.com/en/user-guide/date-time-input-output.html#timestamp-formats
-   *    * numeric string
-   *  * java.time.LocalDate
-   *  * java.time.LocalDateTime
-   *  * java.time.OffsetDateTime
-   *  * java.time.ZonedDateTime
+   * Validates and parses input for TIMESTAMP_TZ Snowflake type Allowed Java types: * String *
+   * Snowflake date format
+   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats * Snowflake
+   * timestamp format
+   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#timestamp-formats *
+   * numeric string * java.time.LocalDate * java.time.LocalDateTime * java.time.OffsetDateTime *
+   * java.time.ZonedDateTime
+   *
    * @param input TIMESTAMP_TZ in "2021-01-01 01:00:00 +0100" format
    * @param scale decimal scale of timestamp 16 byte integer
    * @return TimestampWrapper with epoch seconds, fractional seconds, and epoch time in the column
@@ -232,7 +232,10 @@ class DataValidationUtil {
     else if (input instanceof OffsetDateTime)
       stringInput = DateTimeFormatter.ISO_DATE_TIME.format((OffsetDateTime) input);
     else
-      throw typeNotAllowedException(input.getClass(), "TIMESTAMP", new String[] {"String", "LocalDate", "LocalDateTime", "ZonedDateTime", "OffsetDateTime"});
+      throw typeNotAllowedException(
+          input.getClass(),
+          "TIMESTAMP",
+          new String[] {"String", "LocalDate", "LocalDateTime", "ZonedDateTime", "OffsetDateTime"});
 
     SnowflakeDateTimeFormat snowflakeDateTimeFormatter = createDateTimeFormatter();
 
@@ -530,17 +533,14 @@ class DataValidationUtil {
   }
 
   /**
-   * Returns the number of days between the epoch and the passed date.
-   * Allowed Java types:
-   *  * String
-   *    * Snowflake date format https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats
-   *    * Snowflake timestamp format https://docs.snowflake.com/en/user-guide/date-time-input-output.html#timestamp-formats
-   *    * numeric string
-   *  * java.time.LocalDate
-   *  * java.time.LocalDateTime
-   *  * java.time.OffsetDateTime
-   *  * java.time.ZonedDateTime
-   * */
+   * Returns the number of days between the epoch and the passed date. Allowed Java types: * String
+   * * Snowflake date format
+   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats * Snowflake
+   * timestamp format
+   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#timestamp-formats *
+   * numeric string * java.time.LocalDate * java.time.LocalDateTime * java.time.OffsetDateTime *
+   * java.time.ZonedDateTime
+   */
   static int validateAndParseDate(Object input) {
     String inputString;
     if (input instanceof String) {
@@ -554,13 +554,15 @@ class DataValidationUtil {
     } else if (input instanceof OffsetDateTime) {
       inputString = ((OffsetDateTime) input).toLocalDate().toString();
     } else {
-      throw typeNotAllowedException(input.getClass(), "DATE", new String[] {"String", "LocalDate", "LocalDateTime", "ZonedDateTime", "OffsetDateTime"});
+      throw typeNotAllowedException(
+          input.getClass(),
+          "DATE",
+          new String[] {"String", "LocalDate", "LocalDateTime", "ZonedDateTime", "OffsetDateTime"});
     }
 
     SFTimestamp timestamp =
         createDateTimeFormatter().parse(inputString, GMT, 0, DATE | TIMESTAMP, true, null);
-    if (timestamp == null)
-      throw valueFormatNotAllowedException(input, "DATE");
+    if (timestamp == null) throw valueFormatNotAllowedException(input, "DATE");
 
     return (int) TimeUnit.MILLISECONDS.toDays(SFDate.fromTimestamp(timestamp).getTime());
   }
@@ -589,13 +591,9 @@ class DataValidationUtil {
 
   /**
    * Returns the number of units since 00:00, depending on the scale (scale=0: seconds, scale=3:
-   * milliseconds, scale=9: nanoseconds.
-   * Allowed Java types:
-   *  * String
-   *    * Snowflake time format https://docs.snowflake.com/en/user-guide/date-time-input-output.html#time-formats
-   *    * numeric string
-   *  * java.time.LocalTime
-   *  * java.time.OffsetTime
+   * milliseconds, scale=9: nanoseconds. Allowed Java types: * String * Snowflake time format
+   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#time-formats * numeric
+   * string * java.time.LocalTime * java.time.OffsetTime
    */
   static BigInteger validateAndParseTime(Object input, int scale) {
     String stringInput;
@@ -606,7 +604,8 @@ class DataValidationUtil {
     } else if (input instanceof OffsetTime) {
       stringInput = ((OffsetTime) input).toLocalTime().toString();
     } else {
-      throw typeNotAllowedException(input.getClass(), "TIME", new String[] {"String", "LocalTime", "OffsetTime"});
+      throw typeNotAllowedException(
+          input.getClass(), "TIME", new String[] {"String", "LocalTime", "OffsetTime"});
     }
 
     SFTimestamp timestamp =
@@ -663,10 +662,8 @@ class DataValidationUtil {
   /**
    * Validate and parse input to integer output, 1=true, 0=false. String values converted to boolean
    * according to https://docs.snowflake.com/en/sql-reference/functions/to_boolean.html#usage-notes
-   * Allowed types:
-   *  * boolean
-   *  * String
-   *  * java.lang.Number
+   * Allowed types: * boolean * String * java.lang.Number
+   *
    * @param input Input to be converted
    * @return 1 or 0 where 1=true, 0=false
    */
@@ -679,7 +676,8 @@ class DataValidationUtil {
       return convertStringToBoolean((String) input) ? 1 : 0;
     }
 
-    throw typeNotAllowedException(input.getClass(), "BOOLEAN", new String[]  { "boolean", "Number", "String"});
+    throw typeNotAllowedException(
+        input.getClass(), "BOOLEAN", new String[] {"boolean", "Number", "String"});
   }
 
   static Set<String> allowedBooleanStringsLowerCased =
@@ -705,26 +703,29 @@ class DataValidationUtil {
    * @param snowflakeType Target Snowflake column type
    * @param allowedJavaTypes Java types supported for the Java type
    */
-  private static SFException typeNotAllowedException(Class<?> javaType, String snowflakeType, String[] allowedJavaTypes) {
+  private static SFException typeNotAllowedException(
+      Class<?> javaType, String snowflakeType, String[] allowedJavaTypes) {
     return new SFException(
-            ErrorCode.INVALID_ROW,
-            String.format("Object of type %s cannot be ingested into Snowflake column of type %s", javaType.getName(), snowflakeType),
-            String.format(String.format("Allowed Java types: %s", String.join(", ", allowedJavaTypes)))
-    );
+        ErrorCode.INVALID_ROW,
+        String.format(
+            "Object of type %s cannot be ingested into Snowflake column of type %s",
+            javaType.getName(), snowflakeType),
+        String.format(
+            String.format("Allowed Java types: %s", String.join(", ", allowedJavaTypes))));
   }
 
   /**
-   * Create exception when the Java type is correct, but the value is invalid (e.g. boolean cannot be parsed from a string)
+   * Create exception when the Java type is correct, but the value is invalid (e.g. boolean cannot
+   * be parsed from a string)
    *
    * @param value Invalid value causing the exception
    * @param snowflakeType Snowflake column type
    */
   private static SFException valueFormatNotAllowedException(Object value, String snowflakeType) {
     return new SFException(
-            ErrorCode.INVALID_ROW,
-            sanitizeValueForExceptionMessage(value),
-            String.format("Value cannot be ingested into Snowflake column %s", snowflakeType)
-    );
+        ErrorCode.INVALID_ROW,
+        sanitizeValueForExceptionMessage(value),
+        String.format("Value cannot be ingested into Snowflake column %s", snowflakeType));
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -138,13 +138,16 @@ class DataValidationUtil {
   }
 
   /**
-   * Validates and parses input for TIMESTAMP_NTZ or TIMESTAMP_LTZ Snowflake type Allowed Java
-   * types: * String * Snowflake date format
-   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats * Snowflake
-   * timestamp format
-   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#timestamp-formats *
-   * numeric string * java.time.LocalDate * java.time.LocalDateTime * java.time.OffsetDateTime *
-   * java.time.ZonedDateTime
+   * Validates and parses input for TIMESTAMP_NTZ or TIMESTAMP_LTZ Snowflake type. Allowed Java
+   * types:
+   *
+   * <ul>
+   *   <li>String
+   *   <li>LocalDate
+   *   <li>LocalDateTime
+   *   <li>OffsetDateTime
+   *   <li>ZonedDateTime
+   * </ul>
    *
    * @param input String date in valid format or seconds past the epoch. Accepts fractional seconds
    *     with precision up to the column's scale
@@ -207,13 +210,15 @@ class DataValidationUtil {
   }
 
   /**
-   * Validates and parses input for TIMESTAMP_TZ Snowflake type Allowed Java types: * String *
-   * Snowflake date format
-   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats * Snowflake
-   * timestamp format
-   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#timestamp-formats *
-   * numeric string * java.time.LocalDate * java.time.LocalDateTime * java.time.OffsetDateTime *
-   * java.time.ZonedDateTime
+   * Validates and parses input for TIMESTAMP_TZ Snowflake type. Allowed Java types:
+   *
+   * <ul>
+   *   <li>String
+   *   <li>LocalDate
+   *   <li>LocalDateTime
+   *   <li>OffsetDateTime
+   *   <li>ZonedDateTime
+   * </ul>
    *
    * @param input TIMESTAMP_TZ in "2021-01-01 01:00:00 +0100" format
    * @param scale decimal scale of timestamp 16 byte integer
@@ -533,13 +538,15 @@ class DataValidationUtil {
   }
 
   /**
-   * Returns the number of days between the epoch and the passed date. Allowed Java types: * String
-   * * Snowflake date format
-   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats * Snowflake
-   * timestamp format
-   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#timestamp-formats *
-   * numeric string * java.time.LocalDate * java.time.LocalDateTime * java.time.OffsetDateTime *
-   * java.time.ZonedDateTime
+   * Returns the number of days between the epoch and the passed date. Allowed Java types:
+   *
+   * <ul>
+   *   <li>String
+   *   <li>LocalDate
+   *   <li>LocalDateTime
+   *   <li>OffsetDateTime
+   *   <li>ZonedDateTime
+   * </ul>
    */
   static int validateAndParseDate(Object input) {
     String inputString;
@@ -591,9 +598,13 @@ class DataValidationUtil {
 
   /**
    * Returns the number of units since 00:00, depending on the scale (scale=0: seconds, scale=3:
-   * milliseconds, scale=9: nanoseconds. Allowed Java types: * String * Snowflake time format
-   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#time-formats * numeric
-   * string * java.time.LocalTime * java.time.OffsetTime
+   * milliseconds, scale=9: nanoseconds. Allowed Java types:
+   *
+   * <ul>
+   *   <li>String
+   *   <li>LocalTime
+   *   <li>OffsetTime
+   * </ul>
    */
   static BigInteger validateAndParseTime(Object input, int scale) {
     String stringInput;
@@ -662,7 +673,13 @@ class DataValidationUtil {
   /**
    * Validate and parse input to integer output, 1=true, 0=false. String values converted to boolean
    * according to https://docs.snowflake.com/en/sql-reference/functions/to_boolean.html#usage-notes
-   * Allowed types: * boolean * String * java.lang.Number
+   * Allowed Java types:
+   *
+   * <ul>
+   *   <li>boolean
+   *   <li>String
+   *   <li>java.lang.Number
+   * </ul>
    *
    * @param input Input to be converted
    * @return 1 or 0 where 1=true, 0=false

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
@@ -2,7 +2,6 @@ package net.snowflake.ingest.streaming.internal;
 
 import static net.snowflake.ingest.streaming.internal.ArrowRowBuffer.DECIMAL_BIT_WIDTH;
 
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -432,7 +431,7 @@ public class ArrowBufferTest {
 
     Map<String, Object> row = new HashMap<>();
     row.put("COLTIMESTAMPLTZ_SB8", "1621899220");
-    row.put("COLTIMESTAMPLTZ_SB16", new BigDecimal("1621899220.123456789"));
+    row.put("COLTIMESTAMPLTZ_SB16", "1621899220123456789");
 
     InsertValidationResponse response =
         innerBuffer.insertRows(Collections.singletonList(row), null);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -42,7 +42,8 @@ public class DataValidationUtilTest {
     expectError(expectedErrorCode, () -> func.apply(args));
   }
 
-  private void expectErrorCodeAndMessage(ErrorCode expectedErrorCode, String expectedExceptionMessage, Runnable action) {
+  private void expectErrorCodeAndMessage(
+      ErrorCode expectedErrorCode, String expectedExceptionMessage, Runnable action) {
     try {
       action.run();
       Assert.fail("Expected Exception");
@@ -54,6 +55,7 @@ public class DataValidationUtilTest {
       Assert.fail("Invalid error through");
     }
   }
+
   private void expectError(ErrorCode expectedErrorCode, Runnable action) {
     expectErrorCodeAndMessage(expectedErrorCode, null, action);
   }
@@ -699,33 +701,87 @@ public class DataValidationUtilTest {
   }
 
   /**
-   * Tests that exception message are constructed correctly when ingesting forbidden Java type, as well a value of an allowed type, but in invalid format
+   * Tests that exception message are constructed correctly when ingesting forbidden Java type, as
+   * well a value of an allowed type, but in invalid format
    */
   @Test
   public void testExceptionMessages() {
     // BOOLEAN
-    expectErrorCodeAndMessage(ErrorCode.INVALID_ROW, "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot be ingested into Snowflake column of type BOOLEAN. Allowed Java types: boolean, Number, String", () -> validateAndParseBoolean(new Object()));
-    expectErrorCodeAndMessage(ErrorCode.INVALID_ROW, "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into Snowflake column BOOLEAN", () -> validateAndParseBoolean("abc"));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot"
+            + " be ingested into Snowflake column of type BOOLEAN. Allowed Java types: boolean,"
+            + " Number, String",
+        () -> validateAndParseBoolean(new Object()));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
+            + " Snowflake column BOOLEAN",
+        () -> validateAndParseBoolean("abc"));
 
     // TIME
-    expectErrorCodeAndMessage(ErrorCode.INVALID_ROW, "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot be ingested into Snowflake column of type TIME. Allowed Java types: String, LocalTime, OffsetTime", () -> validateAndParseTime(new Object(), 10));
-    expectErrorCodeAndMessage(ErrorCode.INVALID_ROW, "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into Snowflake column TIME", () -> validateAndParseTime("abc", 10));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot"
+            + " be ingested into Snowflake column of type TIME. Allowed Java types: String,"
+            + " LocalTime, OffsetTime",
+        () -> validateAndParseTime(new Object(), 10));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
+            + " Snowflake column TIME",
+        () -> validateAndParseTime("abc", 10));
 
     // DATE
-    expectErrorCodeAndMessage(ErrorCode.INVALID_ROW, "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot be ingested into Snowflake column of type DATE. Allowed Java types: String, LocalDate, LocalDateTime, ZonedDateTime, OffsetDateTime", () -> validateAndParseDate(new Object()));
-    expectErrorCodeAndMessage(ErrorCode.INVALID_ROW, "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into Snowflake column DATE", () -> validateAndParseDate("abc"));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot"
+            + " be ingested into Snowflake column of type DATE. Allowed Java types: String,"
+            + " LocalDate, LocalDateTime, ZonedDateTime, OffsetDateTime",
+        () -> validateAndParseDate(new Object()));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
+            + " Snowflake column DATE",
+        () -> validateAndParseDate("abc"));
 
     // TIMESTAMP_NTZ
-    expectErrorCodeAndMessage(ErrorCode.INVALID_ROW, "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot be ingested into Snowflake column of type TIMESTAMP. Allowed Java types: String, LocalDate, LocalDateTime, ZonedDateTime, OffsetDateTime", () -> validateAndParseTimestampNtzSb16(new Object(), 3, true));
-    expectErrorCodeAndMessage(ErrorCode.INVALID_ROW, "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into Snowflake column TIMESTAMP", () -> validateAndParseTimestampNtzSb16("abc", 3, true));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot"
+            + " be ingested into Snowflake column of type TIMESTAMP. Allowed Java types: String,"
+            + " LocalDate, LocalDateTime, ZonedDateTime, OffsetDateTime",
+        () -> validateAndParseTimestampNtzSb16(new Object(), 3, true));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
+            + " Snowflake column TIMESTAMP",
+        () -> validateAndParseTimestampNtzSb16("abc", 3, true));
 
     // TIMESTAMP_LTZ
-    expectErrorCodeAndMessage(ErrorCode.INVALID_ROW, "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot be ingested into Snowflake column of type TIMESTAMP. Allowed Java types: String, LocalDate, LocalDateTime, ZonedDateTime, OffsetDateTime", () -> validateAndParseTimestampNtzSb16(new Object(), 3, false));
-    expectErrorCodeAndMessage(ErrorCode.INVALID_ROW, "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into Snowflake column TIMESTAMP", () -> validateAndParseTimestampNtzSb16("abc", 3, false));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot"
+            + " be ingested into Snowflake column of type TIMESTAMP. Allowed Java types: String,"
+            + " LocalDate, LocalDateTime, ZonedDateTime, OffsetDateTime",
+        () -> validateAndParseTimestampNtzSb16(new Object(), 3, false));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
+            + " Snowflake column TIMESTAMP",
+        () -> validateAndParseTimestampNtzSb16("abc", 3, false));
 
     // TIMESTAMP_TZ
-    expectErrorCodeAndMessage(ErrorCode.INVALID_ROW, "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot be ingested into Snowflake column of type TIMESTAMP. Allowed Java types: String, LocalDate, LocalDateTime, ZonedDateTime, OffsetDateTime", () -> validateAndParseTimestampTz(new Object(), 3));
-    expectErrorCodeAndMessage(ErrorCode.INVALID_ROW, "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into Snowflake column TIMESTAMP", () -> validateAndParseTimestampTz("abc", 3));
-
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot"
+            + " be ingested into Snowflake column of type TIMESTAMP. Allowed Java types: String,"
+            + " LocalDate, LocalDateTime, ZonedDateTime, OffsetDateTime",
+        () -> validateAndParseTimestampTz(new Object(), 3));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
+            + " Snowflake column TIMESTAMP",
+        () -> validateAndParseTimestampTz("abc", 3));
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -683,13 +683,13 @@ public class RowBufferTest {
 
     Map<String, Object> row1 = new HashMap<>();
     row1.put("COLTIMESTAMPLTZ_SB8", "1621899220");
-    row1.put("COLTIMESTAMPLTZ_SB16", "1621899220.123456789");
-    row1.put("COLTIMESTAMPLTZ_SB16_SCALE6", "1621899220.123456");
+    row1.put("COLTIMESTAMPLTZ_SB16", "1621899220123456789");
+    row1.put("COLTIMESTAMPLTZ_SB16_SCALE6", "1621899220123456");
 
     Map<String, Object> row2 = new HashMap<>();
     row2.put("COLTIMESTAMPLTZ_SB8", "1621899221");
-    row2.put("COLTIMESTAMPLTZ_SB16", "1621899220.12345679");
-    row2.put("COLTIMESTAMPLTZ_SB16_SCALE6", "1621899220.123457");
+    row2.put("COLTIMESTAMPLTZ_SB16", "1621899220223456789");
+    row2.put("COLTIMESTAMPLTZ_SB16_SCALE6", "1621899220123457");
 
     Map<String, Object> row3 = new HashMap<>();
     row3.put("COLTIMESTAMPLTZ_SB8", null);
@@ -713,7 +713,7 @@ public class RowBufferTest {
         new BigInteger("1621899220123456789"),
         result.getColumnEps().get("COLTIMESTAMPLTZ_SB16").getCurrentMinIntValue());
     Assert.assertEquals(
-        new BigInteger("1621899220123456790"),
+        new BigInteger("1621899220223456789"),
         result.getColumnEps().get("COLTIMESTAMPLTZ_SB16").getCurrentMaxIntValue());
 
     Assert.assertEquals(
@@ -748,10 +748,10 @@ public class RowBufferTest {
     innerBuffer.setupSchema(Collections.singletonList(colDate));
 
     Map<String, Object> row1 = new HashMap<>();
-    row1.put("COLDATE", "18772");
+    row1.put("COLDATE", String.valueOf(18772 * 24 * 60 * 60 * 1000L + 1));
 
     Map<String, Object> row2 = new HashMap<>();
-    row2.put("COLDATE", "18773");
+    row2.put("COLDATE", String.valueOf(18773 * 24 * 60 * 60 * 1000L + 1));
 
     Map<String, Object> row3 = new HashMap<>();
     row3.put("COLDATE", null);
@@ -803,12 +803,12 @@ public class RowBufferTest {
     innerBuffer.setupSchema(Arrays.asList(colTimeSB4, colTimeSB8));
 
     Map<String, Object> row1 = new HashMap<>();
-    row1.put("COLTIMESB4", "43200");
-    row1.put("COLTIMESB8", "44200.123");
+    row1.put("COLTIMESB4", "10:00:00");
+    row1.put("COLTIMESB8", "10:00:00.123");
 
     Map<String, Object> row2 = new HashMap<>();
-    row2.put("COLTIMESB4", "43260");
-    row2.put("COLTIMESB8", "44201");
+    row2.put("COLTIMESB4", "11:15:00.000");
+    row2.put("COLTIMESB8", "11:15:00.456");
 
     Map<String, Object> row3 = new HashMap<>();
     row3.put("COLTIMESB4", null);
@@ -819,12 +819,13 @@ public class RowBufferTest {
     Assert.assertFalse(response.hasErrors());
 
     // Check data was inserted into the buffer correctly
-    Assert.assertEquals(43200, innerBuffer.getVectorValueAt("COLTIMESB4", 0));
-    Assert.assertEquals(43260, innerBuffer.getVectorValueAt("COLTIMESB4", 1));
+    Assert.assertEquals(10 * 60 * 60, innerBuffer.getVectorValueAt("COLTIMESB4", 0));
+    Assert.assertEquals(11 * 60 * 60 + 15 * 60, innerBuffer.getVectorValueAt("COLTIMESB4", 1));
     Assert.assertNull(innerBuffer.getVectorValueAt("COLTIMESB4", 2));
 
-    Assert.assertEquals(44200123L, innerBuffer.getVectorValueAt("COLTIMESB8", 0));
-    Assert.assertEquals(44201000L, innerBuffer.getVectorValueAt("COLTIMESB8", 1));
+    Assert.assertEquals(10 * 60 * 60 * 1000L + 123, innerBuffer.getVectorValueAt("COLTIMESB8", 0));
+    Assert.assertEquals(
+        11 * 60 * 60 * 1000L + 15 * 60 * 1000 + 456, innerBuffer.getVectorValueAt("COLTIMESB8", 1));
     Assert.assertNull(innerBuffer.getVectorValueAt("COLTIMESB8", 2));
 
     // Check stats generation
@@ -832,16 +833,18 @@ public class RowBufferTest {
     Assert.assertEquals(3, result.getRowCount());
 
     Assert.assertEquals(
-        BigInteger.valueOf(43200), result.getColumnEps().get("COLTIMESB4").getCurrentMinIntValue());
+        BigInteger.valueOf(10 * 60 * 60),
+        result.getColumnEps().get("COLTIMESB4").getCurrentMinIntValue());
     Assert.assertEquals(
-        BigInteger.valueOf(43260), result.getColumnEps().get("COLTIMESB4").getCurrentMaxIntValue());
+        BigInteger.valueOf(11 * 60 * 60 + 15 * 60),
+        result.getColumnEps().get("COLTIMESB4").getCurrentMaxIntValue());
     Assert.assertEquals(1, result.getColumnEps().get("COLTIMESB4").getCurrentNullCount());
 
     Assert.assertEquals(
-        BigInteger.valueOf(44200123),
+        BigInteger.valueOf(10 * 60 * 60 * 1000L + 123),
         result.getColumnEps().get("COLTIMESB8").getCurrentMinIntValue());
     Assert.assertEquals(
-        BigInteger.valueOf(44201000),
+        BigInteger.valueOf(11 * 60 * 60 * 1000L + 15 * 60 * 1000 + 456),
         result.getColumnEps().get("COLTIMESB8").getCurrentMaxIntValue());
     Assert.assertEquals(1, result.getColumnEps().get("COLTIMESB8").getCurrentNullCount());
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -396,22 +396,22 @@ public class StreamingIngestIT {
     row.put("ttzbig", "2021-01-01 09:00:00.12345678 -0300");
     row.put("tsmall", "01:00:00.123");
     row.put("tbig", "09:00:00.12345678");
-    row.put("tntzsmall", "1609462800.123");
-    row.put("tntzbig", "1609462800.12345");
+    row.put("tntzsmall", "1609462800123");
+    row.put("tntzbig", "1609462800123450000");
     verifyInsertValidationResponse(channel1.insertRow(row, null));
     row.put("ttzsmall", "2021-01-01 10:00:00.123 +0700");
     row.put("ttzbig", "2021-01-01 19:00:00.12345678 -0300");
     row.put("tsmall", "02:00:00.123");
     row.put("tbig", "10:00:00.12345678");
-    row.put("tntzsmall", "1709462800.123");
-    row.put("tntzbig", "1709462800.12345");
+    row.put("tntzsmall", "1709462800123");
+    row.put("tntzbig", "170946280212345000");
     verifyInsertValidationResponse(channel1.insertRow(row, null));
     row.put("ttzsmall", "2021-01-01 05:00:00 +0100");
     row.put("ttzbig", "2021-01-01 23:00:00.12345678 -0300");
     row.put("tsmall", "03:00:00.123");
     row.put("tbig", "11:00:00.12345678");
-    row.put("tntzsmall", "1809462800.123");
-    row.put("tntzbig", "2031-01-01 09:00:00.12345678");
+    row.put("tntzsmall", "1809462800123");
+    row.put("tntzbig", "2031-01-01 09:00:00.123456780");
     verifyInsertValidationResponse(channel1.insertRow(row, "1"));
 
     // Close the channel after insertion
@@ -502,7 +502,7 @@ public class StreamingIngestIT {
     row.put("f", 3.14);
     row.put("tinyfloat", 1.1);
     row.put("var", "{\"e\":2.7}");
-    row.put("t", timestamp);
+    row.put("t", String.valueOf(timestamp));
     row.put("d", "1969-12-31 00:00:00");
     verifyInsertValidationResponse(channel1.insertRow(row, "1"));
 
@@ -1103,23 +1103,31 @@ public class StreamingIngestIT {
     row.put("var", nextJson(r));
     row.put("obj", nextJson(r));
     row.put("arr", Arrays.asList(r.nextInt(100), r.nextInt(100), r.nextInt(100)));
-    row.put("epochdays", Math.abs(r.nextInt()) % 18963); // DATE, 02.12.2021
+    row.put(
+        "epochdays",
+        String.valueOf(Math.abs(r.nextInt()) % (18963 * 24 * 60 * 60))); // DATE, 02.12.2021
     row.put(
         "timesec",
-        (r.nextInt(11) * 60 * 60 + r.nextInt(59) * 60 + r.nextInt(59)) * 10000
-            + r.nextInt(9999)); // TIME(4), 05:12:43.4536
+        String.valueOf(
+            (r.nextInt(11) * 60 * 60 + r.nextInt(59) * 60 + r.nextInt(59)) * 10000
+                + r.nextInt(9999))); // TIME(4), 05:12:43.4536
     row.put(
         "timenano",
-        (14 * 60 * 60 + 26 * 60 + 34) * 1000000000L + 437582643); // TIME(9), 14:26:34.437582643
+        String.valueOf(
+            (14 * 60 * 60 + 26 * 60 + 34) * 1000000000L
+                + 437582643)); // TIME(9), 14:26:34.437582643
     row.put(
-        "epochsec", Math.abs(r.nextLong()) % 1638459438); // TIMESTAMP_LTZ(0), 02.12.2021 15:37:18
+        "epochsec",
+        String.valueOf(
+            Math.abs(r.nextLong()) % 1638459438)); // TIMESTAMP_LTZ(0), 02.12.2021 15:37:18
     row.put(
         "epochnano",
-        new BigDecimal(
-            (Math.abs(r.nextInt()) % 1999999999)
-                + "."
+        String.format(
+            "%d%d",
+            Math.abs(r.nextInt()) % 1999999999,
+            100000000
                 + Math.abs(
-                    r.nextInt(999999999)))); // TIMESTAMP_LTZ(9), 18.05.2033 03:33:19.999999999
+                    r.nextInt(899999999)))); // TIMESTAMP_LTZ(9), 18.05.2033 03:33:19.999999999
     return row;
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
@@ -1,0 +1,1715 @@
+package net.snowflake.ingest.streaming.internal.datatypes;
+
+import java.sql.SQLException;
+import java.time.*;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Supported date, time and timestamp formats:
+ * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats
+ */
+public class DateTimeIT extends AbstractDataTypeTest {
+
+  @Test
+  public void testTimestampWithTimeZone() throws Exception {
+    useLosAngelesTimeZone();
+
+    // Test timestamp formats
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2/18/2008 02:36:48",
+        "2008-02-18 02:36:48.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20",
+        "2013-04-28 20:00:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20:57",
+        "2013-04-28 20:57:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20:57:01",
+        "2013-04-28 20:57:01.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20:57:01 +07:00",
+        "2013-04-28 20:57:01.000000000 +0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20:57:01 +0700",
+        "2013-04-28 20:57:01.000000000 +0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20:57:01-07",
+        "2013-04-28 20:57:01.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20:57:01-07:00",
+        "2013-04-28 20:57:01.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20:57:01.123456",
+        "2013-04-28 20:57:01.123456000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20:57:01.123456789 +07:00",
+        "2013-04-28 20:57:01.123456789 +0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20:57:01.123456789 +0700",
+        "2013-04-28 20:57:01.123456789 +0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20:57:01.123456789+07",
+        "2013-04-28 20:57:01.123456789 +0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20:57:01.123456789+07:00",
+        "2013-04-28 20:57:01.123456789 +0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28 20:57+07:00",
+        "2013-04-28 20:57:00.000000000 +0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28T20",
+        "2013-04-28 20:00:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28T20:57",
+        "2013-04-28 20:57:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28T20:57:01",
+        "2013-04-28 20:57:01.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28T20:57:01-07:00",
+        "2013-04-28 20:57:01.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28T20:57:01.123456",
+        "2013-04-28 20:57:01.123456000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28T20:57:01.123456789+07:00",
+        "2013-04-28 20:57:01.123456789 +0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28T20:57+07:00",
+        "2013-04-28 20:57:00.000000000 +0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "Mon Jul 08 18:09:51 +0000 2013",
+        "2013-07-08 18:09:51.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "Thu, 21 Dec 2000 04:01:07 PM",
+        "2000-12-21 16:01:07.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "Thu, 21 Dec 2000 04:01:07 PM +0200",
+        "2000-12-21 16:01:07.000000000 +0200",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "Thu, 21 Dec 2000 04:01:07.123456789 PM",
+        "2000-12-21 16:01:07.123456789 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "Thu, 21 Dec 2000 04:01:07.123456789 PM +0200",
+        "2000-12-21 16:01:07.123456789 +0200",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "Thu, 21 Dec 2000 16:01:07",
+        "2000-12-21 16:01:07.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "Thu, 21 Dec 2000 16:01:07 +0200",
+        "2000-12-21 16:01:07.000000000 +0200",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "Thu, 21 Dec 2000 16:01:07.123456789",
+        "2000-12-21 16:01:07.123456789 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "Thu, 21 Dec 2000 16:01:07.123456789 +0200",
+        "2000-12-21 16:01:07.123456789 +0200",
+        new StringProvider(),
+        new StringProvider());
+
+    // Test date formats
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2013-04-28",
+        "2013-04-28 00:00:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "17-DEC-1980",
+        "1980-12-17 00:00:00.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "12/17/1980",
+        "1980-12-17 00:00:00.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+
+    // Test leap years
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "2024-02-29T23:59:59.999999999Z",
+        "2024-02-29 23:59:59.999999999 Z",
+        new StringProvider(),
+        new StringProvider());
+    expectArrowNotSupported("TIMESTAMP_TZ", "2023-02-29T23:59:59.999999999Z");
+
+    // Test numeric strings
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "0",
+        "1970-01-01 00:00:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "86399",
+        "1970-01-01 23:59:59.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "86401",
+        "1970-01-02 00:00:01.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "-86401",
+        "1969-12-30 23:59:59.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "-86399",
+        "1969-12-31 00:00:01.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "1662731080",
+        "2022-09-09 13:44:40.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "1662731080123456789",
+        "2022-09-09 13:44:40.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+  }
+
+  @Test
+  public void testTimestampWithLocalTimeZone() throws Exception {
+    useLosAngelesTimeZone();
+
+    // Test timestamp formats
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2/18/2008 02:36:48",
+        "2008-02-18 02:36:48.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20",
+        "2013-04-28 20:00:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20:57",
+        "2013-04-28 20:57:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20:57:01",
+        "2013-04-28 20:57:01.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20:57:01 +07:00",
+        "2013-04-28 06:57:01.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20:57:01 +0700",
+        "2013-04-28 06:57:01.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20:57:01-07",
+        "2013-04-28 20:57:01.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20:57:01-07:00",
+        "2013-04-28 20:57:01.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20:57:01.123456",
+        "2013-04-28 20:57:01.123456000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20:57:01.123456789 +07:00",
+        "2013-04-28 06:57:01.123456789 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20:57:01.123456789 +0700",
+        "2013-04-28 06:57:01.123456789 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20:57:01.123456789+07",
+        "2013-04-28 06:57:01.123456789 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20:57:01.123456789+07:00",
+        "2013-04-28 06:57:01.123456789 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28 20:57+07:00",
+        "2013-04-28 06:57:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28T20",
+        "2013-04-28 20:00:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28T20:57",
+        "2013-04-28 20:57:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28T20:57:01",
+        "2013-04-28 20:57:01.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28T20:57:01-07:00",
+        "2013-04-28 20:57:01.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28T20:57:01.123456",
+        "2013-04-28 20:57:01.123456000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28T20:57:01.123456789+07:00",
+        "2013-04-28 06:57:01.123456789 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28T20:57+07:00",
+        "2013-04-28 06:57:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "Mon Jul 08 18:09:51 +0000 2013",
+        "2013-07-08 11:09:51.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "Thu, 21 Dec 2000 04:01:07 PM",
+        "2000-12-21 16:01:07.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "Thu, 21 Dec 2000 04:01:07 PM +0200",
+        "2000-12-21 06:01:07.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "Thu, 21 Dec 2000 04:01:07.123456789 PM",
+        "2000-12-21 16:01:07.123456789 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "Thu, 21 Dec 2000 04:01:07.123456789 PM +0200",
+        "2000-12-21 06:01:07.123456789 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "Thu, 21 Dec 2000 16:01:07",
+        "2000-12-21 16:01:07.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "Thu, 21 Dec 2000 16:01:07 +0200",
+        "2000-12-21 06:01:07.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "Thu, 21 Dec 2000 16:01:07.123456789",
+        "2000-12-21 16:01:07.123456789 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "Thu, 21 Dec 2000 16:01:07.123456789 +0200",
+        "2000-12-21 06:01:07.123456789 -0800",
+        new StringProvider(),
+        new StringProvider());
+
+    // Test date formats
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28",
+        "2013-04-28 00:00:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "17-DEC-1980",
+        "1980-12-17 00:00:00.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "12/17/1980",
+        "1980-12-17 00:00:00.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+
+    // Test boundary time zone
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28T00:00:00+07:00",
+        "2013-04-27 10:00:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2013-04-28T00:00:00-07:00",
+        "2013-04-28 00:00:00.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+
+    // Test leap years
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "2024-02-29T23:59:59.999999999Z",
+        "2024-02-29 15:59:59.999999999 -0800",
+        new StringProvider(),
+        new StringProvider());
+    expectArrowNotSupported("TIMESTAMP_LTZ", "2023-02-29T23:59:59.999999999Z");
+
+    // Test numeric strings
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "0",
+        "1969-12-31 16:00:00.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "86399",
+        "1970-01-01 15:59:59.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "86401",
+        "1970-01-01 16:00:01.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "-86401",
+        "1969-12-30 15:59:59.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "-86399",
+        "1969-12-30 16:00:01.000000000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "1662731080",
+        "2022-09-09 06:44:40.000000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "1662731080123456789",
+        "2022-09-09 06:44:40.123456789 -0700",
+        new StringProvider(),
+        new StringProvider());
+  }
+
+  @Test
+  public void testTimestampWithoutTimeZone() throws Exception {
+    // Test timestamp formats
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2/18/2008 02:36:48",
+        "2008-02-18 02:36:48.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20",
+        "2013-04-28 20:00:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20:57",
+        "2013-04-28 20:57:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20:57:01",
+        "2013-04-28 20:57:01.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20:57:01 +07:00",
+        "2013-04-28 20:57:01.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20:57:01 +0700",
+        "2013-04-28 20:57:01.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20:57:01-07",
+        "2013-04-28 20:57:01.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20:57:01-07:00",
+        "2013-04-28 20:57:01.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20:57:01.123456",
+        "2013-04-28 20:57:01.123456000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20:57:01.123456789 +07:00",
+        "2013-04-28 20:57:01.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20:57:01.123456789 +0700",
+        "2013-04-28 20:57:01.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20:57:01.123456789+07",
+        "2013-04-28 20:57:01.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20:57:01.123456789+07:00",
+        "2013-04-28 20:57:01.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28 20:57+07:00",
+        "2013-04-28 20:57:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28T20",
+        "2013-04-28 20:00:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28T20:57",
+        "2013-04-28 20:57:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28T20:57:01",
+        "2013-04-28 20:57:01.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28T20:57:01-07:00",
+        "2013-04-28 20:57:01.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28T20:57:01.123456",
+        "2013-04-28 20:57:01.123456000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28T20:57:01.123456789+07:00",
+        "2013-04-28 20:57:01.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28T20:57+07:00",
+        "2013-04-28 20:57:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "Mon Jul 08 18:09:51 +0000 2013",
+        "2013-07-08 18:09:51.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "Thu, 21 Dec 2000 04:01:07 PM",
+        "2000-12-21 16:01:07.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "Thu, 21 Dec 2000 04:01:07 PM +0200",
+        "2000-12-21 16:01:07.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "Thu, 21 Dec 2000 04:01:07.123456789 PM",
+        "2000-12-21 16:01:07.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "Thu, 21 Dec 2000 04:01:07.123456789 PM +0200",
+        "2000-12-21 16:01:07.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "Thu, 21 Dec 2000 16:01:07",
+        "2000-12-21 16:01:07.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "Thu, 21 Dec 2000 16:01:07 +0200",
+        "2000-12-21 16:01:07.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "Thu, 21 Dec 2000 16:01:07.123456789",
+        "2000-12-21 16:01:07.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "Thu, 21 Dec 2000 16:01:07.123456789 +0200",
+        "2000-12-21 16:01:07.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    // Test date formats
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28",
+        "2013-04-28 00:00:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "17-DEC-1980",
+        "1980-12-17 00:00:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "12/17/1980",
+        "1980-12-17 00:00:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    // Test boundary time zone
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28T00:00:00+07:00",
+        "2013-04-28 00:00:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2013-04-28T00:00:00-07:00",
+        "2013-04-28 00:00:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    // Test leap years
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "2024-02-29T23:59:59.999999999Z",
+        "2024-02-29 23:59:59.999999999 Z",
+        new StringProvider(),
+        new StringProvider());
+    expectArrowNotSupported("TIMESTAMP_NTZ", "2023-02-29T23:59:59.999999999Z");
+
+    // Test numeric strings
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "0",
+        "1970-01-01 00:00:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "86399",
+        "1970-01-01 23:59:59.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "86401",
+        "1970-01-02 00:00:01.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "-86401",
+        "1969-12-30 23:59:59.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "-86399",
+        "1969-12-31 00:00:01.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "1662731080",
+        "2022-09-09 13:44:40.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "1662731080123456789",
+        "2022-09-09 13:44:40.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+  }
+
+  @Test
+  public void testJavaTimeObjects() throws Exception {
+    // TIME (LocalTime and OffsetTime are supported)
+    testIngestion("TIME", LocalTime.of(23, 59, 59), "23:59:59.000000000 Z", new StringProvider());
+    testIngestion(
+        "TIME",
+        OffsetTime.of(23, 59, 59, 0, ZoneOffset.ofHoursMinutes(4, 0)),
+        "23:59:59.000000000 Z",
+        new StringProvider());
+    testIngestion(
+        "TIME",
+        OffsetTime.of(23, 59, 59, 0, ZoneOffset.ofHoursMinutes(-4, 0)),
+        "23:59:59.000000000 Z",
+        new StringProvider());
+    testIngestion(
+        "TIME",
+        OffsetTime.of(23, 59, 59, 123, ZoneOffset.ofHoursMinutes(-4, 0)),
+        "23:59:59.000000123 Z",
+        new StringProvider());
+    testIngestion(
+        "TIME",
+        OffsetTime.of(23, 59, 59, 123456789, ZoneOffset.ofHoursMinutes(-4, 0)),
+        "23:59:59.123456789 Z",
+        new StringProvider());
+
+    // DATE (LocalDate, LocalDateTime, OffsetDateTime, ZonedDateTime are supported)
+    testIngestion("DATE", LocalDate.parse("2007-12-03"), "2007-12-03", new StringProvider());
+    testIngestion(
+        "DATE", LocalDateTime.parse("2007-12-03T10:15:30"), "2007-12-03", new StringProvider());
+    testIngestion(
+        "DATE",
+        OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
+        "2007-12-03",
+        new StringProvider());
+    testIngestion(
+        "DATE",
+        ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]"),
+        "2007-12-03",
+        new StringProvider());
+
+    // TIMESTAMP_NTZ (LocalDate, LocalDateTime, OffsetDateTime, ZonedDateTime are supported)
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        LocalDate.parse("2007-12-03"),
+        "2007-12-03 00:00:00.000000000 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        LocalDateTime.parse("2007-12-03T10:15:30"),
+        "2007-12-03 10:15:30.000000000 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
+        "2007-12-03 10:15:30.000000000 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]"),
+        "2007-12-03 10:15:30.000000000 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        ZonedDateTime.parse("2007-12-03T10:15:30.123456789+01:00[Europe/Paris]"),
+        "2007-12-03 10:15:30.123456789 Z",
+        new StringProvider());
+
+    useLosAngelesTimeZone();
+    // TIMESTAMP_LTZ (LocalDate, LocalDateTime, OffsetDateTime, ZonedDateTime are supported)
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        LocalDate.parse("2007-12-03"),
+        "2007-12-03 00:00:00.000000000 -0800",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        LocalDateTime.parse("2007-12-03T10:15:30"),
+        "2007-12-03 10:15:30.000000000 -0800",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
+        "2007-12-03 01:15:30.000000000 -0800",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]"),
+        "2007-12-03 01:15:30.000000000 -0800",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        ZonedDateTime.parse("2007-12-03T10:15:30.123456789+01:00[Europe/Paris]"),
+        "2007-12-03 01:15:30.123456789 -0800",
+        new StringProvider());
+
+    // TIMESTAMP_TZ (LocalDate, LocalDateTime, OffsetDateTime, ZonedDateTime are supported)
+    testIngestion(
+        "TIMESTAMP_TZ",
+        LocalDate.parse("2007-12-03"),
+        "2007-12-03 00:00:00.000000000 -0800",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ",
+        LocalDateTime.parse("2007-12-03T10:15:30"),
+        "2007-12-03 10:15:30.000000000 -0800",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ",
+        OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
+        "2007-12-03 10:15:30.000000000 +0100",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ",
+        ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]"),
+        "2007-12-03 10:15:30.000000000 +0100",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ",
+        ZonedDateTime.parse("2007-12-03T10:15:30.123456789+01:00[Europe/Paris]"),
+        "2007-12-03 10:15:30.123456789 +0100",
+        new StringProvider());
+  }
+
+  @Test
+  public void testTime() throws Exception {
+    // All (7) documented time formats are supported
+    // https://docs.snowflake.com/en/user-guide/date-time-input-output.html#time-formats
+
+    testJdbcTypeCompatibility(
+        "TIME",
+        "20:57:01.123456789+07:00",
+        "20:57:01.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME",
+        "20:57:01.123456789",
+        "20:57:01.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME", "20:57:01", "20:57:01.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME", "20:57", "20:57:00.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME",
+        "07:57:01.123456789 AM",
+        "07:57:01.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME", "04:01:07 AM", "04:01:07.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME", "04:01 PM", "16:01:00.000000000 Z", new StringProvider(), new StringProvider());
+
+    // Test numeric strings
+    testJdbcTypeCompatibility(
+        "TIME", "0", "00:00:00.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME", "86399", "23:59:59.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME", "86401", "00:00:01.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME", "-86401", "23:59:59.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME", "-86399", "00:00:01.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME", "1662731080", "13:44:40.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME",
+        "1662731080123456789",
+        "13:44:40.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+  }
+
+  @Test
+  public void testLimitedScale() throws Exception {
+    // Of TIME
+    testJdbcTypeCompatibility(
+        "TIME(0)", "13:00:00.999", "13:00:00. Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME(0)", "13:00:00.999999999", "13:00:00. Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME(0)",
+        "13:00:00.999999999+07:30",
+        "13:00:00. Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME(0)",
+        "1662731080123456789",
+        "13:44:40. Z",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIME(4)", "13:00:00.999", "13:00:00.9990 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME(4)",
+        "13:00:00.999999999",
+        "13:00:00.9999 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME(4)",
+        "13:00:00.999999999+07:30",
+        "13:00:00.9999 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME(4)",
+        "1662731080123456789",
+        "13:44:40.1234 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIME(9)",
+        "13:00:00.999",
+        "13:00:00.999000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME(9)",
+        "13:00:00.999999999",
+        "13:00:00.999999999 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME(9)",
+        "13:00:00.999999999+07:30",
+        "13:00:00.999999999 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME(9)",
+        "1662731080123456789",
+        "13:44:40.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME(9)",
+        "1662731080123456",
+        "13:44:40.123456000 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    // Of TIMESTAMP_NTZ
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(0)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00. Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(0)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00. Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(0)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-07 13:00:00. Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(0)",
+        "1662731080123456789",
+        "2022-09-09 13:44:40. Z",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(4)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00.9990 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(4)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00.9999 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(4)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-07 13:00:00.9999 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(4)",
+        "1662731080123456789",
+        "2022-09-09 13:44:40.1234 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(7)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00.9990000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(7)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00.9999999 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(7)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-07 13:00:00.9999999 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(7)",
+        "1662731080123456789",
+        "2022-09-09 13:44:40.1234567 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(8)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00.99900000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(8)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00.99999999 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(8)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-07 13:00:00.99999999 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(8)",
+        "1662731080123456789",
+        "2022-09-09 13:44:40.12345678 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(9)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00.999000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(9)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00.999999999 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(9)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-07 13:00:00.999999999 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ(9)",
+        "1662731080123456789",
+        "2022-09-09 13:44:40.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    // Of TIMESTAMP_LTZ
+    useLosAngelesTimeZone();
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(0)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00. -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(0)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00. -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(0)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-06 22:30:00. -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(0)",
+        "1662731080123456789",
+        "2022-09-09 06:44:40. -0700",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(4)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00.9990 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(4)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00.9999 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(4)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-06 22:30:00.9999 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(4)",
+        "1662731080123456789",
+        "2022-09-09 06:44:40.1234 -0700",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(7)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00.9990000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(7)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00.9999999 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(7)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-06 22:30:00.9999999 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(7)",
+        "1662731080123456789",
+        "2022-09-09 06:44:40.1234567 -0700",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(8)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00.99900000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(8)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00.99999999 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(8)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-06 22:30:00.99999999 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(8)",
+        "1662731080123456789",
+        "2022-09-09 06:44:40.12345678 -0700",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(9)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00.999000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(9)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00.999999999 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(9)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-06 22:30:00.999999999 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ(9)",
+        "1662731080123456789",
+        "2022-09-09 06:44:40.123456789 -0700",
+        new StringProvider(),
+        new StringProvider());
+
+    // Of TIMESTAMP_TZ
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(0)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00. -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(0)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00. -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(0)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-07 13:00:00. +0730",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(0)",
+        "1662731080123456789",
+        "2022-09-09 13:44:40. Z",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(4)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00.9990 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(4)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00.9999 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(4)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-07 13:00:00.9999 +0730",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(4)",
+        "1662731080123456789",
+        "2022-09-09 13:44:40.1234 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(7)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00.9990000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(7)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00.9999999 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(7)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-07 13:00:00.9999999 +0730",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(7)",
+        "1662731080123456789",
+        "2022-09-09 13:44:40.1234567 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(8)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00.99900000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(8)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00.99999999 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(8)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-07 13:00:00.99999999 +0730",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(8)",
+        "1662731080123456789",
+        "2022-09-09 13:44:40.12345678 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(9)",
+        "2010-07-07 13:00:00.999",
+        "2010-07-07 13:00:00.999000000 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(9)",
+        "2010-07-07 13:00:00.999999999",
+        "2010-07-07 13:00:00.999999999 -0700",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(9)",
+        "2010-07-07 13:00:00.999999999+07:30",
+        "2010-07-07 13:00:00.999999999 +0730",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(9)",
+        "1662731080123456789",
+        "2022-09-09 13:44:40.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+  }
+
+  @Test
+  public void testDate() throws Exception {
+    // Test timestamp formats
+    testJdbcTypeCompatibility(
+        "DATE", "2/18/2008 02:36:48", "2008-02-18", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "2013-04-28 20", "2013-04-28", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "2013-04-28 20:57", "2013-04-28", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "2013-04-28 20:57:01", "2013-04-28", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28 20:57:01 +07:00",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28 20:57:01 +0700",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "2013-04-28 20:57:01-07", "2013-04-28", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28 20:57:01-07:00",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28 20:57:01.123456",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28 20:57:01.123456789 +07:00",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28 20:57:01.123456789 +0700",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28 20:57:01.123456789+07",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28 20:57:01.123456789+07:00",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "2013-04-28 20:57+07:00", "2013-04-28", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "2013-04-28T20", "2013-04-28", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "2013-04-28T20:57", "2013-04-28", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "2013-04-28T20:57:01", "2013-04-28", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28T20:57:01-07:00",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28T20:57:01.123456",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28T20:57:01.123456789+07:00",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "2013-04-28T20:57+07:00", "2013-04-28", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "Mon Jul 08 18:09:51 +0000 2013",
+        "2013-07-08",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "Thu, 21 Dec 2000 04:01:07 PM",
+        "2000-12-21",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "Thu, 21 Dec 2000 04:01:07 PM +0200",
+        "2000-12-21",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "Thu, 21 Dec 2000 04:01:07.123456789 PM",
+        "2000-12-21",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "Thu, 21 Dec 2000 04:01:07.123456789 PM +0200",
+        "2000-12-21",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "Thu, 21 Dec 2000 16:01:07",
+        "2000-12-21",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "Thu, 21 Dec 2000 16:01:07 +0200",
+        "2000-12-21",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "Thu, 21 Dec 2000 16:01:07.123456789",
+        "2000-12-21",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "Thu, 21 Dec 2000 16:01:07.123456789 +0200",
+        "2000-12-21",
+        new StringProvider(),
+        new StringProvider());
+
+    // Test date formats
+    testJdbcTypeCompatibility(
+        "DATE", "2013-04-28", "2013-04-28", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "17-DEC-1980", "1980-12-17", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "12/17/1980", "1980-12-17", new StringProvider(), new StringProvider());
+
+    // Test leap years
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2024-02-29T23:59:59.999999999Z",
+        "2024-02-29",
+        new StringProvider(),
+        new StringProvider());
+    expectArrowNotSupported("DATE", "2023-02-29T23:59:59.999999999Z");
+
+    testJdbcTypeCompatibility(
+        "DATE", "9999-12-31", "9999-12-31", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "9999-12-31T23:59:59.999999999Z",
+        "9999-12-31",
+        new StringProvider(),
+        new StringProvider());
+
+    // Test boundary date
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28T00:00:00+07:00",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE",
+        "2013-04-28T00:00:00-07:00",
+        "2013-04-28",
+        new StringProvider(),
+        new StringProvider());
+
+    // Test numeric strings
+    testJdbcTypeCompatibility(
+        "DATE", "0", "1970-01-01", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "86399", "1970-01-01", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "86401", "1970-01-02", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "-86401", "1969-12-30", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "-86399", "1969-12-31", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "1662731080", "2022-09-09", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "1662731080123456789", "2022-09-09", new StringProvider(), new StringProvider());
+  }
+
+  @Test
+  @Ignore("SNOW-663646")
+  public void testOldValues() throws Exception {
+    testJdbcTypeCompatibility(
+        "DATE", "1582-01-01", "1582-10-01", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "1582-10-14", "1582-10-14", new StringProvider(), new StringProvider());
+  }
+
+  @Test
+  public void testFutureDates() throws Exception {
+    useLosAngelesTimeZone();
+
+    testJdbcTypeCompatibility(
+        "DATE", "99999-12-31", "99999-12-31", new StringProvider(), new StringProvider());
+
+    testJdbcTypeCompatibility( // SB16
+        "TIMESTAMP_NTZ",
+        "9999-12-31 23:59:59.999999999",
+        "9999-12-31 23:59:59.999999999 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility( // SB8
+        "TIMESTAMP_NTZ(7)",
+        "9999-12-31 23:59:59.999999999",
+        "9999-12-31 23:59:59.9999999 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility( // SB16
+        "TIMESTAMP_LTZ",
+        "9999-12-31 23:59:59.999999999",
+        "9999-12-31 23:59:59.999999999 -0800",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility( // SB8
+        "TIMESTAMP_LTZ(7)",
+        "9999-12-31 23:59:59.999999999",
+        "9999-12-31 23:59:59.9999999 -0800",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "9999-12-31 23:59:59.999999999",
+        "9999-12-31 23:59:59.999999999 -0800",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ(3)",
+        "9999-12-31 23:59:59.999999999",
+        "9999-12-31 23:59:59.999 -0800",
+        new StringProvider(),
+        new StringProvider());
+  }
+
+  /**
+   * To make assertions of timestamps without timezone to work, make sure JDBC connection session
+   * time zone is the same as the streaming ingest default timezone
+   */
+  private void useLosAngelesTimeZone() throws SQLException {
+    conn.createStatement().execute("alter session set timezone = 'America/Los_Angeles';");
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
@@ -1,7 +1,14 @@
 package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.sql.SQLException;
-import java.time.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
@@ -8,7 +8,6 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-
 import org.junit.Ignore;
 import org.junit.Test;
 


### PR DESCRIPTION
Type validation for Snowflake data types DATE, TIME, TIMESTAMP_*.
It tries to achieve consistency with the behavior of Snowflake
Worksheets.

* Only limited set of Java data types is accepted
    * No longer try to parse the result of Object#toString() call
* Never interpret any input in our code, always delegate the
  parsing logic to SnowflakeDateTimeFormat
* Numeric values are not allowed for any column (e.g. int 123)
* Decimal strings are not allowed (e.g. "1663580793.123")
* Numeric strings (e.g. "123") are still allowed because Snowflake
  Worksheets also allow them, but they are not documented on the
  website and the SDK also should not advertise them.
* Date and timestamp strings cannot be passed into TIME columns
* Time strings cannot be passed into DATE and TIMESTAMP_* columns
* Some objects from java.time.* package are accepted
    * LocalTime, OffsetTime for TIME column
    * LocalDate, LocalDateTime, OffsetDateTime, ZonedDateTime for
      DATE and TIMESTAMP_* columns
* Time zones conversions are handled correctly
    * For DATE, TIME and TIMESTAMP_NTZ the timestamp is truncated
    * For TIMESTAMP_LTZ, timezone is accounted for before converting
      into the timezone America/Los_Angeles, which is the default
      value of the Snowflake parameter TIMEZONE
    * For TIMESTAMP_TZ, the timezone is preserved
        * America/Los_Angeles is used when timezone is missing