### PR TITLE
NO-SNOW: add stacktrace during blob building failure

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
@@ -89,7 +89,7 @@ class ChannelCache<T> {
     if (channelsMapPerTable != null) {
       SnowflakeStreamingIngestChannelInternal<T> channel = channelsMapPerTable.get(channelName);
       if (channel != null && channel.getChannelSequencer().equals(channelSequencer)) {
-        channel.invalidate("error from server");
+        channel.invalidate("invalidate with matched sequencer");
       }
     }
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
@@ -37,7 +37,7 @@ class ChannelCache<T> {
         channels.put(channel.getName(), channel);
     // Invalidate old channel if it exits to block new inserts and return error to users earlier
     if (oldChannel != null) {
-      oldChannel.invalidate();
+      oldChannel.invalidate("removed from cache");
     }
   }
 
@@ -89,7 +89,7 @@ class ChannelCache<T> {
     if (channelsMapPerTable != null) {
       SnowflakeStreamingIngestChannelInternal<T> channel = channelsMapPerTable.get(channelName);
       if (channel != null && channel.getChannelSequencer().equals(channelSequencer)) {
-        channel.invalidate();
+        channel.invalidate("error from server");
       }
     }
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -379,6 +379,12 @@ class FlushService<T> {
                           | IllegalBlockSizeException
                           | BadPaddingException
                           | InvalidKeyException e) {
+                        String errorMessage =
+                            String.format(
+                                "Building blob failed, client=%s, file=%s, exception=%s,"
+                                    + " detail=%s, all channels in the blob will be invalidated",
+                                this.owningClient.getName(), filePath, e, e.getMessage());
+                        logger.logError(errorMessage);
                         throw new SFException(e, ErrorCode.ENCRYPTION_FAILURE);
                       }
                     },

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -9,6 +9,7 @@ import static net.snowflake.ingest.utils.Constants.DISABLE_BACKGROUND_FLUSH;
 import static net.snowflake.ingest.utils.Constants.MAX_BLOB_SIZE_IN_BYTES;
 import static net.snowflake.ingest.utils.Constants.MAX_THREAD_COUNT;
 import static net.snowflake.ingest.utils.Constants.THREAD_SHUTDOWN_TIMEOUT_IN_SEC;
+import static net.snowflake.ingest.utils.Utils.getStackTrace;
 
 import com.codahale.metrics.Timer;
 import java.io.ByteArrayOutputStream;
@@ -279,7 +280,25 @@ class FlushService<T> {
     this.flushWorker = Executors.newSingleThreadScheduledExecutor(flushThreadFactory);
     this.flushWorker.scheduleWithFixedDelay(
         () -> {
-          flush(false);
+          flush(false)
+              .exceptionally(
+                  e -> {
+                    String errorMessage =
+                        String.format(
+                            "Background flush task failed, client=%s, exception=%s, detail=%s,"
+                                + " trace=%s.",
+                            this.owningClient.getName(),
+                            e.getCause(),
+                            e.getCause().getMessage(),
+                            getStackTrace(e.getCause()));
+                    logger.logError(errorMessage);
+                    if (this.owningClient.getTelemetryService() != null) {
+                      this.owningClient
+                          .getTelemetryService()
+                          .reportClientFailure(this.getClass().getSimpleName(), errorMessage);
+                    }
+                    return null;
+                  });
         },
         0,
         this.owningClient.getParameterProvider().getBufferFlushCheckIntervalInMs(),
@@ -357,23 +376,18 @@ class FlushService<T> {
                     () -> {
                       try {
                         return buildAndUpload(filePath, blobData);
-                      } catch (IOException
-                          | InvalidAlgorithmParameterException
-                          | NoSuchPaddingException
-                          | IllegalBlockSizeException
-                          | BadPaddingException
-                          | InvalidKeyException
-                          | NoSuchAlgorithmException e) {
-                        StringBuilder stackTrace = new StringBuilder();
-                        for (StackTraceElement element : e.getStackTrace()) {
-                          stackTrace.append(System.lineSeparator()).append(element.toString());
-                        }
+                      } catch (Throwable e) {
+                        Throwable ex = e.getCause() == null ? e : e.getCause();
                         String errorMessage =
                             String.format(
                                 "Building blob failed, client=%s, file=%s, exception=%s,"
                                     + " detail=%s, trace=%s, all channels in the blob will be"
                                     + " invalidated",
-                                this.owningClient.getName(), e, e.getMessage(), stackTrace);
+                                this.owningClient.getName(),
+                                filePath,
+                                ex,
+                                ex.getMessage(),
+                                getStackTrace(ex));
                         logger.logError(errorMessage);
                         if (this.owningClient.getTelemetryService() != null) {
                           this.owningClient
@@ -386,8 +400,14 @@ class FlushService<T> {
                           return null;
                         } else if (e instanceof NoSuchAlgorithmException) {
                           throw new SFException(e, ErrorCode.MD5_HASHING_NOT_AVAILABLE);
-                        } else {
+                        } else if (e instanceof InvalidAlgorithmParameterException
+                            | e instanceof NoSuchPaddingException
+                            | e instanceof IllegalBlockSizeException
+                            | e instanceof BadPaddingException
+                            | e instanceof InvalidKeyException) {
                           throw new SFException(e, ErrorCode.ENCRYPTION_FAILURE);
+                        } else {
+                          throw new SFException(e, ErrorCode.INTERNAL_ERROR, e.getMessage());
                         }
                       }
                     },

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
@@ -5,6 +5,7 @@
 package net.snowflake.ingest.streaming.internal;
 
 import static net.snowflake.ingest.utils.Constants.BLOB_UPLOAD_TIMEOUT_IN_SEC;
+import static net.snowflake.ingest.utils.Utils.getStackTrace;
 
 import com.codahale.metrics.Timer;
 import java.util.ArrayList;
@@ -156,24 +157,18 @@ class RegisterService<T> {
                 retry++;
                 break;
               }
-              StringBuilder stackTrace = new StringBuilder();
-              if (e.getCause() != null) {
-                for (StackTraceElement element : e.getCause().getStackTrace()) {
-                  stackTrace.append(System.lineSeparator()).append(element.toString());
-                }
-              }
               String errorMessage =
                   String.format(
                       "Building or uploading blob failed, client=%s, file=%s, exception=%s,"
-                          + " detail=%s, cause=%s, detail=%s, trace=%s all channels in the blob"
-                          + " will be invalidated",
+                          + " detail=%s, cause=%s, cause_detail=%s, cause_trace=%s all channels in"
+                          + " the blob will be invalidated",
                       this.owningClient.getName(),
                       futureBlob.getKey().getFilePath(),
                       e,
                       e.getMessage(),
                       e.getCause(),
                       e.getCause() == null ? null : e.getCause().getMessage(),
-                      stackTrace);
+                      getStackTrace(e.getCause()));
               logger.logError(errorMessage);
               if (this.owningClient.getTelemetryService() != null) {
                 this.owningClient

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
@@ -152,7 +152,7 @@ class RegisterService<T> {
               String errorMessage =
                   String.format(
                       "Building or uploading blob failed, client=%s, file=%s, exception=%s,"
-                          + " detail=%s, cause=%s, detail=%s trace=%s all channels in the blob"
+                          + " detail=%s, cause=%s, detail=%s, trace=%s all channels in the blob"
                           + " will be invalidated",
                       this.owningClient.getName(),
                       futureBlob.getKey().getFilePath(),

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -242,14 +242,15 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   }
 
   /** Mark the channel as invalid, and release resources */
-  void invalidate() {
+  void invalidate(String message) {
     this.isValid = false;
     this.rowBuffer.close("invalidate");
     logger.logWarn(
-        "Channel is invalidated, name={}, channel sequencer={}, row sequencer={}",
+        "Channel is invalidated, name={}, channel sequencer={}, row sequencer={}, message={}",
         getFullyQualifiedName(),
         channelSequencer,
-        rowSequencer);
+        rowSequencer,
+        message);
   }
 
   /** @return a boolean to indicate whether the channel is closed or not */

--- a/src/main/java/net/snowflake/ingest/utils/Cryptor.java
+++ b/src/main/java/net/snowflake/ingest/utils/Cryptor.java
@@ -9,6 +9,7 @@ import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.Random;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -102,6 +103,11 @@ public class Cryptor {
           InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
     // Generate the derived key
     SecretKey derivedKey = deriveKey(encryptionKey, diversifier);
+
+    Random rand = new Random();
+    if (rand.nextInt(1) == 0) {
+      throw new NoSuchPaddingException();
+    }
 
     // Encrypt with zero IV
     Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);

--- a/src/main/java/net/snowflake/ingest/utils/Cryptor.java
+++ b/src/main/java/net/snowflake/ingest/utils/Cryptor.java
@@ -9,7 +9,6 @@ import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
-import java.util.Random;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -103,11 +102,6 @@ public class Cryptor {
           InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
     // Generate the derived key
     SecretKey derivedKey = deriveKey(encryptionKey, diversifier);
-
-    Random rand = new Random();
-    if (rand.nextInt(1) == 0) {
-      throw new NoSuchPaddingException();
-    }
 
     // Encrypt with zero IV
     Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);

--- a/src/main/java/net/snowflake/ingest/utils/Utils.java
+++ b/src/main/java/net/snowflake/ingest/utils/Utils.java
@@ -301,4 +301,17 @@ public class Utils {
         heapMem.getUsed(),
         heapMem.getCommitted());
   }
+
+  /** Return the stack trace for a given exception */
+  public static String getStackTrace(Throwable e) {
+    if (e == null) {
+      return null;
+    }
+
+    StringBuilder stackTrace = new StringBuilder();
+    for (StackTraceElement element : e.getStackTrace()) {
+      stackTrace.append(System.lineSeparator()).append(element.toString());
+    }
+    return stackTrace.toString();
+  }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -141,7 +141,7 @@ public class SnowflakeStreamingIngestChannelTest {
             OpenChannelRequest.OnErrorOption.CONTINUE);
 
     Assert.assertTrue(channel.isValid());
-    channel.invalidate();
+    channel.invalidate("from testChannelValid");
     Assert.assertFalse(channel.isValid());
 
     // Can't insert rows to invalid channel


### PR DESCRIPTION
This PR contains two changes:
1. As part of investigating an encryption related issue, we realize the stacktrace and error message are not captured in log for any encryption related exceptions, so this PR adds that support
2. Add a small message indicates the code path of channel invalidation