### PR TITLE
SNOW-655614 Data type validation: Semi-structured types

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -150,23 +150,37 @@ class DataValidationUtil {
    * @return If the passed object is allowed for ingestion into a VARIANT column
    */
   static boolean isAllowedVariantType(Object o) {
-    if (o == null) return true;
-    if (o instanceof String || o instanceof Boolean || o instanceof Character) return true;
+    if (o == null) {
+      return true;
+    }
+    if (o instanceof String || o instanceof Boolean || o instanceof Character) {
+      return true;
+    }
     if (o instanceof Long
         || o instanceof Integer
         || o instanceof Short
         || o instanceof Byte
-        || o instanceof BigInteger) return true;
-    if (o instanceof Float || o instanceof Double || o instanceof BigDecimal) return true;
-    if (o instanceof java.time.LocalTime || o instanceof OffsetTime) return true;
+        || o instanceof BigInteger) {
+      return true;
+    }
+    if (o instanceof Float || o instanceof Double || o instanceof BigDecimal) {
+      return true;
+    }
+    if (o instanceof java.time.LocalTime || o instanceof OffsetTime) {
+      return true;
+    }
     if (o instanceof LocalDate
         || o instanceof LocalDateTime
         || o instanceof ZonedDateTime
-        || o instanceof OffsetDateTime) return true;
+        || o instanceof OffsetDateTime) {
+      return true;
+    }
     if (o instanceof Map) {
       boolean allKeysAreStrings =
           ((Map<?, ?>) o).keySet().stream().allMatch(x -> x instanceof String);
-      if (!allKeysAreStrings) return false;
+      if (!allKeysAreStrings) {
+        return false;
+      }
       boolean allValuesAreAllowed =
           ((Map<?, ?>) o).values().stream().allMatch(DataValidationUtil::isAllowedVariantType);
       return allValuesAreAllowed;
@@ -178,11 +192,15 @@ class DataValidationUtil {
         || o instanceof float[]
         || o instanceof double[]
         || o instanceof boolean[]
-        || o instanceof char[]) return true;
-    if (o.getClass().isArray())
+        || o instanceof char[]) {
+      return true;
+    }
+    if (o.getClass().isArray()) {
       return Arrays.stream((Object[]) o).allMatch(DataValidationUtil::isAllowedVariantType);
-    if (o instanceof List)
+    }
+    if (o instanceof List) {
       return ((List<?>) o).stream().allMatch(DataValidationUtil::isAllowedVariantType);
+    }
     return false;
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -99,7 +99,8 @@ class DataValidationUtil {
           "Primitive data types and their arrays",
           "java.time.*",
           "List<T>",
-          "Map<String, T>"
+          "Map<String, T>",
+          "T[]"
         });
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -7,10 +7,14 @@ package net.snowflake.ingest.streaming.internal;
 import static net.snowflake.client.jdbc.internal.snowflake.common.core.SnowflakeDateTimeFormat.DATE;
 import static net.snowflake.client.jdbc.internal.snowflake.common.core.SnowflakeDateTimeFormat.TIMESTAMP;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -18,7 +22,9 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
@@ -29,6 +35,8 @@ import net.snowflake.client.jdbc.internal.snowflake.common.core.SFDate;
 import net.snowflake.client.jdbc.internal.snowflake.common.core.SFTimestamp;
 import net.snowflake.client.jdbc.internal.snowflake.common.core.SnowflakeDateTimeFormat;
 import net.snowflake.client.jdbc.internal.snowflake.common.util.Power10;
+import net.snowflake.ingest.streaming.internal.serialization.ByteArraySerializer;
+import net.snowflake.ingest.streaming.internal.serialization.ZonedDateTimeSerializer;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 
@@ -37,11 +45,25 @@ class DataValidationUtil {
   public static final int BYTES_8_MB = 8 * 1024 * 1024;
   public static final int BYTES_16_MB = 2 * BYTES_8_MB;
 
+  static final int MAX_VARIANT_LENGTH = BYTES_16_MB - 1024; // SNOW-664249
+
   private static final TimeZone DEFAULT_TIMEZONE =
       TimeZone.getTimeZone("America/Los_Angeles"); // default value of TIMEZONE system parameter
   private static final TimeZone GMT = TimeZone.getTimeZone("GMT");
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  static {
+    SimpleModule module = new SimpleModule();
+    module.addSerializer(byte[].class, new ByteArraySerializer());
+    module.addSerializer(ZonedDateTime.class, new ZonedDateTimeSerializer());
+    module.addSerializer(LocalTime.class, new ToStringSerializer());
+    module.addSerializer(OffsetTime.class, new ToStringSerializer());
+    module.addSerializer(LocalDate.class, new ToStringSerializer());
+    module.addSerializer(LocalDateTime.class, new ToStringSerializer());
+    module.addSerializer(OffsetDateTime.class, new ToStringSerializer());
+    objectMapper.registerModule(module);
+  }
 
   /**
    * Creates a new SnowflakeDateTimeFormat. In order to avoid SnowflakeDateTimeFormat's
@@ -52,80 +74,169 @@ class DataValidationUtil {
   }
 
   /**
-   * Expects string JSON
+   * Validates and parses input as JSON. All types in the object tree must be valid variant types,
+   * see {@link DataValidationUtil#isAllowedVariantType}.
    *
-   * @param input the input data, must be able to convert to String
+   * @param input Object to validate
+   * @return JSON tree representing the input
+   */
+  private static JsonNode validateAndParseVariantAsJsonTree(Object input, String snowflakeType) {
+    if (input instanceof String) {
+      try {
+        return objectMapper.readTree((String) input);
+      } catch (JsonProcessingException e) {
+        throw valueFormatNotAllowedException(input, snowflakeType, "Not a valid JSON");
+      }
+    } else if (isAllowedVariantType(input)) {
+      return objectMapper.valueToTree(input);
+    }
+
+    throw typeNotAllowedException(
+        input.getClass(),
+        snowflakeType,
+        new String[] {
+          "String",
+          "Primitive data types and their arrays",
+          "java.time.*",
+          "List<T>",
+          "Map<String, T>"
+        });
+  }
+
+  /**
+   * Validates and parses input as JSON. All types in the object tree must be valid variant types,
+   * see {@link DataValidationUtil#isAllowedVariantType}.
+   *
+   * @param input Object to validate
+   * @return JSON string representing the input
    */
   static String validateAndParseVariant(Object input) {
-    String output;
-    try {
-      output = input.toString();
-    } catch (Exception e) {
-      throw new SFException(
-          e, ErrorCode.INVALID_ROW, input, "Input column can't be convert to String.");
-    }
-
-    if (output.length() > BYTES_16_MB) {
-      throw new SFException(
-          ErrorCode.INVALID_ROW,
-          input.toString(),
-          String.format("Variant too long: length=%d maxLength=%d", output.length(), BYTES_16_MB));
+    String output = validateAndParseVariantAsJsonTree(input, "VARIANT").toString();
+    int stringLength = output.getBytes(StandardCharsets.UTF_8).length;
+    if (stringLength > MAX_VARIANT_LENGTH) {
+      throw valueFormatNotAllowedException(
+          input,
+          "VARIANT",
+          String.format(
+              "Variant too long: length=%d maxLength=%d", stringLength, MAX_VARIANT_LENGTH));
     }
     return output;
   }
 
   /**
-   * Expects an Array or List object
+   * Validates that passed object is allowed variant type. For non-trivial types like Maps, arrays
+   * or Lists, it recursively traverses the object tree and validates that all types in the tree are
+   * also allowed. Allowed Java types:
    *
-   * @param input the input data, must be able to convert to String
+   * <ul>
+   *   <li>primitive types (int, long, boolean, ...)
+   *   <li>String
+   *   <li>BigInteger
+   *   <li>BigDecimal
+   *   <li>LocalTime
+   *   <li>OffsetTime
+   *   <li>LocalDate
+   *   <li>LocalDateTime
+   *   <li>OffsetDateTime
+   *   <li>ZonedDateTime
+   *   <li>Map<String, T> where T is an allowed variant type
+   *   <li>List<T> where T is an allowed variant type
+   *   <li>primitive arrays (char[], int[], ...)
+   *   <li>T[] where T is an allowed variant type
+   * </ul>
+   *
+   * @param o Object to validate
+   * @return If the passed object is allowed for ingestion into a VARIANT column
+   */
+  static boolean isAllowedVariantType(Object o) {
+    if (o == null) return true;
+    if (o instanceof String || o instanceof Boolean || o instanceof Character) return true;
+    if (o instanceof Long
+        || o instanceof Integer
+        || o instanceof Short
+        || o instanceof Byte
+        || o instanceof BigInteger) return true;
+    if (o instanceof Float || o instanceof Double || o instanceof BigDecimal) return true;
+    if (o instanceof java.time.LocalTime || o instanceof OffsetTime) return true;
+    if (o instanceof LocalDate
+        || o instanceof LocalDateTime
+        || o instanceof ZonedDateTime
+        || o instanceof OffsetDateTime) return true;
+    if (o instanceof Map) {
+      boolean allKeysAreStrings =
+          ((Map<?, ?>) o).keySet().stream().allMatch(x -> x instanceof String);
+      if (!allKeysAreStrings) return false;
+      boolean allValuesAreAllowed =
+          ((Map<?, ?>) o).values().stream().allMatch(DataValidationUtil::isAllowedVariantType);
+      return allValuesAreAllowed;
+    }
+    if (o instanceof byte[]
+        || o instanceof short[]
+        || o instanceof int[]
+        || o instanceof long[]
+        || o instanceof float[]
+        || o instanceof double[]
+        || o instanceof boolean[]
+        || o instanceof char[]) return true;
+    if (o.getClass().isArray())
+      return Arrays.stream((Object[]) o).allMatch(DataValidationUtil::isAllowedVariantType);
+    if (o instanceof List)
+      return ((List<?>) o).stream().allMatch(DataValidationUtil::isAllowedVariantType);
+    return false;
+  }
+
+  /**
+   * Validates and parses JSON array. Non-array types are converted into single-element arrays. All
+   * types in the array tree must be valid variant types, see {@link
+   * DataValidationUtil#isAllowedVariantType}.
+   *
+   * @param input Object to validate
+   * @return JSON array representing the input
    */
   static String validateAndParseArray(Object input) {
-    if (!input.getClass().isArray() && !(input instanceof List)) {
-      throw new SFException(
-          ErrorCode.INVALID_ROW, input, "Input column must be an Array or List object.");
+    JsonNode jsonNode = validateAndParseVariantAsJsonTree(input, "ARRAY");
+
+    // Non-array values are ingested as single-element arrays, mimicking the Worksheets behavior
+    if (!jsonNode.isArray()) {
+      jsonNode = objectMapper.createArrayNode().add(jsonNode);
     }
 
-    String output;
-    try {
-      output = objectMapper.writeValueAsString(input);
-    } catch (Exception e) {
-      throw new SFException(
-          e,
-          ErrorCode.INVALID_ROW,
-          input.toString(),
-          "Input column can't be convert to a valid string");
-    }
-
+    String output = jsonNode.toString();
     // Throw an exception if the size is too large
-    if (output.length() > BYTES_16_MB) {
-      throw new SFException(
-          ErrorCode.INVALID_ROW,
-          input.toString(),
-          String.format("Array too large. length=%d maxLength=%d", output.length(), BYTES_16_MB));
+    int stringLength = output.getBytes(StandardCharsets.UTF_8).length;
+    if (stringLength > MAX_VARIANT_LENGTH) {
+      throw valueFormatNotAllowedException(
+          jsonNode.toString(),
+          "ARRAY",
+          String.format(
+              "Array too large. length=%d maxLength=%d", stringLength, MAX_VARIANT_LENGTH));
     }
     return output;
   }
 
   /**
-   * Expects string JSON or JsonNode
+   * Validates and parses JSON object. Input is rejected if the value does not represent JSON object
+   * (e.g. String '{}' or Map<String, T>). All types in the object tree must be valid variant types,
+   * see {@link DataValidationUtil#isAllowedVariantType}.
    *
-   * @param input Must be valid string JSON or JsonNode
+   * @param input Object to validate
+   * @return JSON object representing the input
    */
   static String validateAndParseObject(Object input) {
-    String output;
-    try {
-      JsonNode node = objectMapper.readTree(input.toString());
-      output = node.toString();
-    } catch (Exception e) {
-      throw new SFException(
-          e, ErrorCode.INVALID_ROW, input.toString(), "Input column can't be convert to Json");
+    JsonNode jsonNode = validateAndParseVariantAsJsonTree(input, "OBJECT");
+    if (!jsonNode.isObject()) {
+      throw valueFormatNotAllowedException(jsonNode, "OBJECT", "Not an object");
     }
 
-    if (output.length() > BYTES_16_MB) {
-      throw new SFException(
-          ErrorCode.INVALID_ROW,
-          input.toString(),
-          String.format("Object too large. length=%d maxLength=%d", output.length(), BYTES_16_MB));
+    String output = jsonNode.toString();
+    // Throw an exception if the size is too large
+    int stringLength = output.getBytes(StandardCharsets.UTF_8).length;
+    if (stringLength > MAX_VARIANT_LENGTH) {
+      throw valueFormatNotAllowedException(
+          output,
+          "OBJECT",
+          String.format(
+              "Object too large. length=%d maxLength=%d", stringLength, MAX_VARIANT_LENGTH));
     }
     return output;
   }
@@ -420,7 +531,7 @@ class DataValidationUtil {
 
   /**
    * Returns the number of units since 00:00, depending on the scale (scale=0: seconds, scale=3:
-   * milliseconds, scale=9: nanoseconds. Allowed Java types:
+   * milliseconds, scale=9: nanoseconds). Allowed Java types:
    *
    * <ul>
    *   <li>String
@@ -458,19 +569,6 @@ class DataValidationUtil {
           .toBigInteger()
           .mod(BigInteger.valueOf(24L * 60 * 60 * Power10.intTable[scale]));
     }
-  }
-
-  static String getStringValue(Object value) {
-    String stringValue;
-
-    if (value instanceof String) {
-      stringValue = (String) value;
-    } else if (value instanceof BigDecimal) {
-      stringValue = ((BigDecimal) value).toPlainString();
-    } else {
-      stringValue = value.toString();
-    }
-    return stringValue;
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/serialization/ByteArraySerializer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/serialization/ByteArraySerializer.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal.serialization;
 
 import com.fasterxml.jackson.core.JsonGenerator;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/serialization/ByteArraySerializer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/serialization/ByteArraySerializer.java
@@ -1,0 +1,22 @@
+package net.snowflake.ingest.streaming.internal.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+/**
+ * Serialize Java byte arrays as JSON arrays of numbers instead of the default Jackson
+ * base64-encoding.
+ */
+public class ByteArraySerializer extends JsonSerializer<byte[]> {
+  @Override
+  public void serialize(byte[] value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeStartArray();
+    for (byte v : value) {
+      gen.writeNumber(v);
+    }
+    gen.writeEndArray();
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/serialization/ZonedDateTimeSerializer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/serialization/ZonedDateTimeSerializer.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal.serialization;
 
 import com.fasterxml.jackson.core.JsonGenerator;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/serialization/ZonedDateTimeSerializer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/serialization/ZonedDateTimeSerializer.java
@@ -1,0 +1,16 @@
+package net.snowflake.ingest.streaming.internal.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+/** Snowflake does not support parsing zones, so serialize it in offset instead */
+public class ZonedDateTimeSerializer extends JsonSerializer<ZonedDateTime> {
+  @Override
+  public void serialize(ZonedDateTime value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeString(value.toOffsetDateTime().toString());
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -518,35 +518,6 @@ public class DataValidationUtilTest {
   }
 
   @Test
-  public void testTooLargeVariantWithNonAsciiChars() {
-    // Length is measured in bytes, not in chars
-    char[] stringContent = new char[9 * 1024 * 1024];
-    Arrays.fill(stringContent, 'č');
-
-    Map<String, Object> m = new HashMap<>();
-    m.put("a", "11");
-    m.put("b", new String(stringContent));
-    expectErrorCodeAndMessage(
-        ErrorCode.INVALID_ROW,
-        "The given row cannot be converted to Arrow format: {a=11, b=ččččččččččč.... Value cannot"
-            + " be ingested into Snowflake column VARIANT: Variant too long: length=18874385"
-            + " maxLength=16776192",
-        () -> validateAndParseVariant(m));
-    expectErrorCodeAndMessage(
-        ErrorCode.INVALID_ROW,
-        "The given row cannot be converted to Arrow format: [{\"a\":\"11\",\"b\":\"čččč.... Value"
-            + " cannot be ingested into Snowflake column ARRAY: Array too large. length=18874387"
-            + " maxLength=16776192",
-        () -> validateAndParseArray(m));
-    expectErrorCodeAndMessage(
-        ErrorCode.INVALID_ROW,
-        "The given row cannot be converted to Arrow format: {\"a\":\"11\",\"b\":\"ččččč.... Value"
-            + " cannot be ingested into Snowflake column OBJECT: Object too large. length=18874385"
-            + " maxLength=16776192",
-        () -> validateAndParseObject(m));
-  }
-
-  @Test
   public void testTooLargeMultiByteSemiStructuredValues() {
     // Variant max size is not in characters, but in bytes
     char[] stringContent = new char[9 * 1024 * 1024]; // 8MB < value < 16MB

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -2,7 +2,7 @@ package net.snowflake.ingest.streaming.internal;
 
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.BYTES_16_MB;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.BYTES_8_MB;
-import static net.snowflake.ingest.streaming.internal.DataValidationUtil.isAllowedVariantType;
+import static net.snowflake.ingest.streaming.internal.DataValidationUtil.isAllowedSemiStructuredType;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseArray;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseBigDecimal;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseBinary;
@@ -535,100 +535,101 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: {a=ČČČČČČČČČČČČČČČČČ.... Value cannot"
             + " be ingested into Snowflake column VARIANT: Variant too long: length=18874376"
-            + " maxLength=16776192",
+            + " maxLength=16777152",
         () -> validateAndParseVariant(m));
     expectErrorCodeAndMessage(
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: [{\"a\":\"ČČČČČČČČČČČČČ.... Value"
             + " cannot be ingested into Snowflake column ARRAY: Array too large. length=18874378"
-            + " maxLength=16776192",
+            + " maxLength=16777152",
         () -> validateAndParseArray(m));
     expectErrorCodeAndMessage(
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: {\"a\":\"ČČČČČČČČČČČČČČ.... Value"
             + " cannot be ingested into Snowflake column OBJECT: Object too large. length=18874376"
-            + " maxLength=16776192",
+            + " maxLength=16777152",
         () -> validateAndParseObject(m));
   }
 
   @Test
   public void testValidVariantType() {
     // Test primitive types
-    Assert.assertTrue(isAllowedVariantType((byte) 1));
-    Assert.assertTrue(isAllowedVariantType((short) 1));
-    Assert.assertTrue(isAllowedVariantType(1));
-    Assert.assertTrue(isAllowedVariantType(1L));
-    Assert.assertTrue(isAllowedVariantType(1.25f));
-    Assert.assertTrue(isAllowedVariantType(1.25d));
-    Assert.assertTrue(isAllowedVariantType(false));
-    Assert.assertTrue(isAllowedVariantType('c'));
+    Assert.assertTrue(isAllowedSemiStructuredType((byte) 1));
+    Assert.assertTrue(isAllowedSemiStructuredType((short) 1));
+    Assert.assertTrue(isAllowedSemiStructuredType(1));
+    Assert.assertTrue(isAllowedSemiStructuredType(1L));
+    Assert.assertTrue(isAllowedSemiStructuredType(1.25f));
+    Assert.assertTrue(isAllowedSemiStructuredType(1.25d));
+    Assert.assertTrue(isAllowedSemiStructuredType(false));
+    Assert.assertTrue(isAllowedSemiStructuredType('c'));
 
     // Test boxed primitive types
-    Assert.assertTrue(isAllowedVariantType(Byte.valueOf((byte) 1)));
-    Assert.assertTrue(isAllowedVariantType(Short.valueOf((short) 1)));
-    Assert.assertTrue(isAllowedVariantType(Integer.valueOf(1)));
-    Assert.assertTrue(isAllowedVariantType(Long.valueOf(1L)));
-    Assert.assertTrue(isAllowedVariantType(Float.valueOf(1.25f)));
-    Assert.assertTrue(isAllowedVariantType(Double.valueOf(1.25d)));
-    Assert.assertTrue(isAllowedVariantType(Boolean.valueOf(false)));
-    Assert.assertTrue(isAllowedVariantType(Character.valueOf('c')));
+    Assert.assertTrue(isAllowedSemiStructuredType(Byte.valueOf((byte) 1)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Short.valueOf((short) 1)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Integer.valueOf(1)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Long.valueOf(1L)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Float.valueOf(1.25f)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Double.valueOf(1.25d)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Boolean.valueOf(false)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Character.valueOf('c')));
 
     // Test primitive arrays
-    Assert.assertTrue(isAllowedVariantType(new byte[] {1}));
-    Assert.assertTrue(isAllowedVariantType(new short[] {1}));
-    Assert.assertTrue(isAllowedVariantType(new int[] {1}));
-    Assert.assertTrue(isAllowedVariantType(new long[] {1L}));
-    Assert.assertTrue(isAllowedVariantType(new float[] {1.25f}));
-    Assert.assertTrue(isAllowedVariantType(new double[] {1.25d}));
-    Assert.assertTrue(isAllowedVariantType(new boolean[] {false}));
-    Assert.assertTrue(isAllowedVariantType(new char[] {'c'}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new byte[] {1}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new short[] {1}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new int[] {1}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new long[] {1L}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new float[] {1.25f}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new double[] {1.25d}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new boolean[] {false}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new char[] {'c'}));
 
     // Test primitive lists
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList((byte) 1)));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList((short) 1)));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(1)));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(1L)));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(1.25f)));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(1.25d)));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(false)));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList('c')));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList((byte) 1)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList((short) 1)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList(1)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList(1L)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList(1.25f)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList(1.25d)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList(false)));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList('c')));
 
     // Test additional numeric types and their collections
-    Assert.assertTrue(isAllowedVariantType(new BigInteger("1")));
-    Assert.assertTrue(isAllowedVariantType(new BigInteger[] {new BigInteger("1")}));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(new BigInteger("1"))));
-    Assert.assertTrue(isAllowedVariantType(new BigDecimal("1.25")));
-    Assert.assertTrue(isAllowedVariantType(new BigDecimal[] {new BigDecimal("1.25")}));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(new BigDecimal("1.25"))));
+    Assert.assertTrue(isAllowedSemiStructuredType(new BigInteger("1")));
+    Assert.assertTrue(isAllowedSemiStructuredType(new BigInteger[] {new BigInteger("1")}));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList(new BigInteger("1"))));
+    Assert.assertTrue(isAllowedSemiStructuredType(new BigDecimal("1.25")));
+    Assert.assertTrue(isAllowedSemiStructuredType(new BigDecimal[] {new BigDecimal("1.25")}));
+    Assert.assertTrue(
+        isAllowedSemiStructuredType(Collections.singletonList(new BigDecimal("1.25"))));
 
     // Test strings
-    Assert.assertTrue(isAllowedVariantType("foo"));
-    Assert.assertTrue(isAllowedVariantType(new String[] {"foo"}));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList("foo")));
+    Assert.assertTrue(isAllowedSemiStructuredType("foo"));
+    Assert.assertTrue(isAllowedSemiStructuredType(new String[] {"foo"}));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList("foo")));
 
     // Test date/time objects and their collections
-    Assert.assertTrue(isAllowedVariantType(LocalTime.now()));
-    Assert.assertTrue(isAllowedVariantType(OffsetTime.now()));
-    Assert.assertTrue(isAllowedVariantType(LocalDate.now()));
-    Assert.assertTrue(isAllowedVariantType(LocalDateTime.now()));
-    Assert.assertTrue(isAllowedVariantType(ZonedDateTime.now()));
-    Assert.assertTrue(isAllowedVariantType(OffsetDateTime.now()));
-    Assert.assertTrue(isAllowedVariantType(new LocalTime[] {LocalTime.now()}));
-    Assert.assertTrue(isAllowedVariantType(new OffsetTime[] {OffsetTime.now()}));
-    Assert.assertTrue(isAllowedVariantType(new LocalDate[] {LocalDate.now()}));
-    Assert.assertTrue(isAllowedVariantType(new LocalDateTime[] {LocalDateTime.now()}));
-    Assert.assertTrue(isAllowedVariantType(new ZonedDateTime[] {ZonedDateTime.now()}));
-    Assert.assertTrue(isAllowedVariantType(new OffsetDateTime[] {OffsetDateTime.now()}));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(LocalTime.now())));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(OffsetTime.now())));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(LocalDate.now())));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(LocalDateTime.now())));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(ZonedDateTime.now())));
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(OffsetDateTime.now())));
+    Assert.assertTrue(isAllowedSemiStructuredType(LocalTime.now()));
+    Assert.assertTrue(isAllowedSemiStructuredType(OffsetTime.now()));
+    Assert.assertTrue(isAllowedSemiStructuredType(LocalDate.now()));
+    Assert.assertTrue(isAllowedSemiStructuredType(LocalDateTime.now()));
+    Assert.assertTrue(isAllowedSemiStructuredType(ZonedDateTime.now()));
+    Assert.assertTrue(isAllowedSemiStructuredType(OffsetDateTime.now()));
+    Assert.assertTrue(isAllowedSemiStructuredType(new LocalTime[] {LocalTime.now()}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new OffsetTime[] {OffsetTime.now()}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new LocalDate[] {LocalDate.now()}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new LocalDateTime[] {LocalDateTime.now()}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new ZonedDateTime[] {ZonedDateTime.now()}));
+    Assert.assertTrue(isAllowedSemiStructuredType(new OffsetDateTime[] {OffsetDateTime.now()}));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList(LocalTime.now())));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList(OffsetTime.now())));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList(LocalDate.now())));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList(LocalDateTime.now())));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList(ZonedDateTime.now())));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonList(OffsetDateTime.now())));
 
     // Test mixed collections
     Assert.assertTrue(
-        isAllowedVariantType(
+        isAllowedSemiStructuredType(
             new Object[] {
               1,
               false,
@@ -637,7 +638,7 @@ public class DataValidationUtilTest {
               new Object[] {new Object[] {new Object[] {LocalDateTime.now(), false}}}
             }));
     Assert.assertFalse(
-        isAllowedVariantType(
+        isAllowedSemiStructuredType(
             new Object[] {
               1,
               false,
@@ -646,14 +647,14 @@ public class DataValidationUtilTest {
               new Object[] {new Object[] {new Object[] {new Object(), false}}}
             }));
     Assert.assertTrue(
-        isAllowedVariantType(
+        isAllowedSemiStructuredType(
             Arrays.asList(
                 new BigInteger("1"),
                 "foo",
                 false,
                 Arrays.asList(13, Arrays.asList(Arrays.asList(false, 'c'))))));
     Assert.assertFalse(
-        isAllowedVariantType(
+        isAllowedSemiStructuredType(
             Arrays.asList(
                 new BigInteger("1"),
                 "foo",
@@ -661,11 +662,11 @@ public class DataValidationUtilTest {
                 Arrays.asList(13, Arrays.asList(Arrays.asList(new Object(), 'c'))))));
 
     // Test maps
-    Assert.assertTrue(isAllowedVariantType(Collections.singletonMap("foo", "bar")));
-    Assert.assertFalse(isAllowedVariantType(Collections.singletonMap(new Object(), "foo")));
-    Assert.assertFalse(isAllowedVariantType(Collections.singletonMap("foo", new Object())));
+    Assert.assertTrue(isAllowedSemiStructuredType(Collections.singletonMap("foo", "bar")));
+    Assert.assertFalse(isAllowedSemiStructuredType(Collections.singletonMap(new Object(), "foo")));
+    Assert.assertFalse(isAllowedSemiStructuredType(Collections.singletonMap("foo", new Object())));
     Assert.assertTrue(
-        isAllowedVariantType(
+        isAllowedSemiStructuredType(
             Collections.singletonMap(
                 "foo",
                 new Object[] {
@@ -676,7 +677,7 @@ public class DataValidationUtilTest {
                   new Object[] {new Object[] {new Object[] {LocalDateTime.now(), false}}}
                 })));
     Assert.assertFalse(
-        isAllowedVariantType(
+        isAllowedSemiStructuredType(
             Collections.singletonMap(
                 "foo",
                 new Object[] {
@@ -687,7 +688,7 @@ public class DataValidationUtilTest {
                   new Object[] {new Object[] {new Object[] {new Object(), false}}}
                 })));
     Assert.assertTrue(
-        isAllowedVariantType(
+        isAllowedSemiStructuredType(
             Collections.singletonMap(
                 "foo",
                 Arrays.asList(
@@ -696,7 +697,7 @@ public class DataValidationUtilTest {
                     false,
                     Arrays.asList(13, Arrays.asList(Arrays.asList(false, 'c')))))));
     Assert.assertFalse(
-        isAllowedVariantType(
+        isAllowedSemiStructuredType(
             Collections.singletonMap(
                 "foo",
                 Arrays.asList(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -1014,7 +1014,7 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot"
             + " be ingested into Snowflake column of type VARIANT. Allowed Java types: String,"
-            + " Primitive data types and their arrays, java.time.*, List<T>, Map<String, T>",
+            + " Primitive data types and their arrays, java.time.*, List<T>, Map<String, T>, T[]",
         () -> validateAndParseVariant(new Object()));
     expectErrorCodeAndMessage(
         ErrorCode.INVALID_ROW,
@@ -1027,7 +1027,7 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot"
             + " be ingested into Snowflake column of type ARRAY. Allowed Java types: String,"
-            + " Primitive data types and their arrays, java.time.*, List<T>, Map<String, T>",
+            + " Primitive data types and their arrays, java.time.*, List<T>, Map<String, T>, T[]",
         () -> validateAndParseArray(new Object()));
     expectErrorCodeAndMessage(
         ErrorCode.INVALID_ROW,
@@ -1040,7 +1040,7 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot"
             + " be ingested into Snowflake column of type OBJECT. Allowed Java types: String,"
-            + " Primitive data types and their arrays, java.time.*, List<T>, Map<String, T>",
+            + " Primitive data types and their arrays, java.time.*, List<T>, Map<String, T>, T[]",
         () -> validateAndParseObject(new Object()));
     expectErrorCodeAndMessage(
         ErrorCode.INVALID_ROW,

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -356,6 +356,9 @@ public class DataValidationUtilTest {
 
   @Test
   public void testValidateAndParseVariant() throws Exception {
+    assertEquals("1", validateAndParseVariant(1));
+    assertEquals("1", validateAndParseVariant("1"));
+    assertEquals("1", validateAndParseVariant("                          1   "));
     String stringVariant = "{\"key\":1}";
     assertEquals(stringVariant, validateAndParseVariant(stringVariant));
 
@@ -395,6 +398,9 @@ public class DataValidationUtilTest {
 
   @Test
   public void testValidateAndParseArray() throws Exception {
+    assertEquals("[1]", validateAndParseArray(1));
+    assertEquals("[1]", validateAndParseArray("1"));
+    assertEquals("[1]", validateAndParseArray("                          1   "));
     int[] intArray = new int[] {1, 2, 3};
     assertEquals("[1,2,3]", validateAndParseArray(intArray));
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -2,19 +2,22 @@ package net.snowflake.ingest.streaming.internal;
 
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.BYTES_16_MB;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.BYTES_8_MB;
+import static net.snowflake.ingest.streaming.internal.DataValidationUtil.isAllowedVariantType;
+import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseArray;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseBigDecimal;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseBinary;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseBoolean;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseDate;
+import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseObject;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseReal;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseString;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseTime;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseTimestampNtzSb16;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseTimestampTz;
+import static net.snowflake.ingest.streaming.internal.DataValidationUtil.validateAndParseVariant;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -24,8 +27,10 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -352,72 +357,106 @@ public class DataValidationUtilTest {
   @Test
   public void testValidateAndParseVariant() throws Exception {
     String stringVariant = "{\"key\":1}";
-    Assert.assertEquals(stringVariant, DataValidationUtil.validateAndParseVariant(stringVariant));
-    JsonNode nodeVariant = objectMapper.readTree(stringVariant);
-    Assert.assertEquals(stringVariant, DataValidationUtil.validateAndParseVariant(nodeVariant));
+    assertEquals(stringVariant, validateAndParseVariant(stringVariant));
 
-    char[] data = new char[20000000];
-    Arrays.fill(data, 'a');
-    String stringVal = new String(data);
-    try {
-      DataValidationUtil.validateAndParseVariant(stringVal);
-      Assert.fail("Expected INVALID_ROW error");
-    } catch (SFException err) {
-      Assert.assertEquals(ErrorCode.INVALID_ROW.getMessageCode(), err.getVendorCode());
-    }
+    // Test custom serializers
+    assertEquals(
+        "[-128,0,127]", validateAndParseVariant(new byte[] {Byte.MIN_VALUE, 0, Byte.MAX_VALUE}));
+    assertEquals(
+        "\"2022-09-28T03:04:12.123456789-07:00\"",
+        validateAndParseVariant(
+            ZonedDateTime.of(2022, 9, 28, 3, 4, 12, 123456789, ZoneId.of("America/Los_Angeles"))));
+
+    // Test forbidden values
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseVariant,
+        objectMapper.readTree("{}"));
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseVariant, new Object());
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseVariant, "foo");
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseVariant, new Date());
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseVariant,
+        Collections.singletonList(new Object()));
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseVariant,
+        Collections.singletonList(Collections.singletonMap("foo", new Object())));
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseVariant,
+        Collections.singletonMap(new Object(), "foo"));
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseVariant,
+        Collections.singletonMap("foo", new Object()));
   }
 
   @Test
   public void testValidateAndParseArray() throws Exception {
-    int invalidArray = 1;
-    try {
-      DataValidationUtil.validateAndParseArray(invalidArray);
-      Assert.fail("Expected INVALID_ROW error");
-    } catch (SFException err) {
-      Assert.assertEquals(ErrorCode.INVALID_ROW.getMessageCode(), err.getVendorCode());
-    }
-
     int[] intArray = new int[] {1, 2, 3};
-    Assert.assertEquals("[1,2,3]", DataValidationUtil.validateAndParseArray(intArray));
+    assertEquals("[1,2,3]", validateAndParseArray(intArray));
 
     String[] stringArray = new String[] {"a", "b", "c"};
-    Assert.assertEquals(
-        "[\"a\",\"b\",\"c\"]", DataValidationUtil.validateAndParseArray(stringArray));
+    assertEquals("[\"a\",\"b\",\"c\"]", validateAndParseArray(stringArray));
 
     Object[] objectArray = new Object[] {1, 2, 3};
-    Assert.assertEquals("[1,2,3]", DataValidationUtil.validateAndParseArray(objectArray));
+    assertEquals("[1,2,3]", validateAndParseArray(objectArray));
 
     Object[] ObjectArrayWithNull = new Object[] {1, null, 3};
-    Assert.assertEquals(
-        "[1,null,3]", DataValidationUtil.validateAndParseArray(ObjectArrayWithNull));
+    assertEquals("[1,null,3]", validateAndParseArray(ObjectArrayWithNull));
 
     Object[][] nestedArray = new Object[][] {{1, 2, 3}, null, {4, 5, 6}};
-    Assert.assertEquals(
-        "[[1,2,3],null,[4,5,6]]", DataValidationUtil.validateAndParseArray(nestedArray));
+    assertEquals("[[1,2,3],null,[4,5,6]]", validateAndParseArray(nestedArray));
 
     List<Integer> intList = Arrays.asList(1, 2, 3);
-    Assert.assertEquals("[1,2,3]", DataValidationUtil.validateAndParseArray(intList));
+    assertEquals("[1,2,3]", validateAndParseArray(intList));
 
     List<Object> objectList = Arrays.asList(1, 2, 3);
-    Assert.assertEquals("[1,2,3]", DataValidationUtil.validateAndParseArray(objectList));
+    assertEquals("[1,2,3]", validateAndParseArray(objectList));
 
     List<Object> nestedList = Arrays.asList(Arrays.asList(1, 2, 3), 2, 3);
-    Assert.assertEquals("[[1,2,3],2,3]", DataValidationUtil.validateAndParseArray(nestedList));
+    assertEquals("[[1,2,3],2,3]", validateAndParseArray(nestedList));
+
+    // Test forbidden values
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseArray,
+        objectMapper.readTree("[]"));
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseArray, new Object());
+    expectError(
+        ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseArray, "foo"); // invalid JSON
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseArray, new Date());
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseArray,
+        Collections.singletonList(new Object()));
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseArray,
+        Collections.singletonList(Collections.singletonMap("foo", new Object())));
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseArray,
+        Collections.singletonMap(new Object(), "foo"));
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseArray,
+        Collections.singletonMap("foo", new Object()));
   }
 
   @Test
   public void testValidateAndParseObject() throws Exception {
     String stringObject = "{\"key\":1}";
-    Assert.assertEquals(stringObject, DataValidationUtil.validateAndParseObject(stringObject));
-    JsonNode nodeObject = objectMapper.readTree(stringObject);
-    Assert.assertEquals(stringObject, DataValidationUtil.validateAndParseObject(nodeObject));
+    assertEquals(stringObject, validateAndParseObject(stringObject));
 
     String badObject = "foo";
     try {
-      DataValidationUtil.validateAndParseObject(badObject);
+      validateAndParseObject(badObject);
       Assert.fail("Expected INVALID_ROW error");
     } catch (SFException err) {
-      Assert.assertEquals(ErrorCode.INVALID_ROW.getMessageCode(), err.getVendorCode());
+      assertEquals(ErrorCode.INVALID_ROW.getMessageCode(), err.getVendorCode());
     }
 
     char[] data = new char[20000000];
@@ -427,11 +466,267 @@ public class DataValidationUtilTest {
     mapVal.put("key", stringVal);
     String tooLargeObject = objectMapper.writeValueAsString(mapVal);
     try {
-      DataValidationUtil.validateAndParseObject(tooLargeObject);
+      validateAndParseObject(tooLargeObject);
       Assert.fail("Expected INVALID_ROW error");
     } catch (SFException err) {
-      Assert.assertEquals(ErrorCode.INVALID_ROW.getMessageCode(), err.getVendorCode());
+      assertEquals(ErrorCode.INVALID_ROW.getMessageCode(), err.getVendorCode());
     }
+
+    // Test forbidden values
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseObject,
+        objectMapper.readTree("{}"));
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseObject, "[]");
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseObject, "1");
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseObject, 1);
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseObject, 1.5);
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseObject, false);
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseObject, new Object());
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseObject, "foo");
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseObject, new Date());
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseObject,
+        Collections.singletonList(new Object()));
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseObject,
+        Collections.singletonList(Collections.singletonMap("foo", new Object())));
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseObject,
+        Collections.singletonMap(new Object(), "foo"));
+    expectError(
+        ErrorCode.INVALID_ROW,
+        DataValidationUtil::validateAndParseObject,
+        Collections.singletonMap("foo", new Object()));
+  }
+
+  @Test
+  public void testTooLargeVariant() {
+    char[] stringContent = new char[16 * 1024 * 1024 - 16]; // {"a":"11","b":""}
+    Arrays.fill(stringContent, 'c');
+
+    // {"a":"11","b":""}
+    Map<String, Object> m = new HashMap<>();
+    m.put("a", "11");
+    m.put("b", new String(stringContent));
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseVariant, m);
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseArray, m);
+    expectError(ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseObject, m);
+  }
+
+  @Test
+  public void testTooLargeVariantWithNonAsciiChars() {
+    // Length is measured in bytes, not in chars
+    char[] stringContent = new char[9 * 1024 * 1024];
+    Arrays.fill(stringContent, 'č');
+
+    Map<String, Object> m = new HashMap<>();
+    m.put("a", "11");
+    m.put("b", new String(stringContent));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: {a=11, b=ččččččččččč.... Value cannot"
+            + " be ingested into Snowflake column VARIANT: Variant too long: length=18874385"
+            + " maxLength=16776192",
+        () -> validateAndParseVariant(m));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: [{\"a\":\"11\",\"b\":\"čččč.... Value"
+            + " cannot be ingested into Snowflake column ARRAY: Array too large. length=18874387"
+            + " maxLength=16776192",
+        () -> validateAndParseArray(m));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: {\"a\":\"11\",\"b\":\"ččččč.... Value"
+            + " cannot be ingested into Snowflake column OBJECT: Object too large. length=18874385"
+            + " maxLength=16776192",
+        () -> validateAndParseObject(m));
+  }
+
+  @Test
+  public void testTooLargeMultiByteSemiStructuredValues() {
+    // Variant max size is not in characters, but in bytes
+    char[] stringContent = new char[9 * 1024 * 1024]; // 8MB < value < 16MB
+    Arrays.fill(stringContent, 'Č');
+
+    Map<String, Object> m = new HashMap<>();
+    m.put("a", new String(stringContent));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: {a=ČČČČČČČČČČČČČČČČČ.... Value cannot"
+            + " be ingested into Snowflake column VARIANT: Variant too long: length=18874376"
+            + " maxLength=16776192",
+        () -> validateAndParseVariant(m));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: [{\"a\":\"ČČČČČČČČČČČČČ.... Value"
+            + " cannot be ingested into Snowflake column ARRAY: Array too large. length=18874378"
+            + " maxLength=16776192",
+        () -> validateAndParseArray(m));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: {\"a\":\"ČČČČČČČČČČČČČČ.... Value"
+            + " cannot be ingested into Snowflake column OBJECT: Object too large. length=18874376"
+            + " maxLength=16776192",
+        () -> validateAndParseObject(m));
+  }
+
+  @Test
+  public void testValidVariantType() {
+    // Test primitive types
+    Assert.assertTrue(isAllowedVariantType((byte) 1));
+    Assert.assertTrue(isAllowedVariantType((short) 1));
+    Assert.assertTrue(isAllowedVariantType(1));
+    Assert.assertTrue(isAllowedVariantType(1L));
+    Assert.assertTrue(isAllowedVariantType(1.25f));
+    Assert.assertTrue(isAllowedVariantType(1.25d));
+    Assert.assertTrue(isAllowedVariantType(false));
+    Assert.assertTrue(isAllowedVariantType('c'));
+
+    // Test boxed primitive types
+    Assert.assertTrue(isAllowedVariantType(Byte.valueOf((byte) 1)));
+    Assert.assertTrue(isAllowedVariantType(Short.valueOf((short) 1)));
+    Assert.assertTrue(isAllowedVariantType(Integer.valueOf(1)));
+    Assert.assertTrue(isAllowedVariantType(Long.valueOf(1L)));
+    Assert.assertTrue(isAllowedVariantType(Float.valueOf(1.25f)));
+    Assert.assertTrue(isAllowedVariantType(Double.valueOf(1.25d)));
+    Assert.assertTrue(isAllowedVariantType(Boolean.valueOf(false)));
+    Assert.assertTrue(isAllowedVariantType(Character.valueOf('c')));
+
+    // Test primitive arrays
+    Assert.assertTrue(isAllowedVariantType(new byte[] {1}));
+    Assert.assertTrue(isAllowedVariantType(new short[] {1}));
+    Assert.assertTrue(isAllowedVariantType(new int[] {1}));
+    Assert.assertTrue(isAllowedVariantType(new long[] {1L}));
+    Assert.assertTrue(isAllowedVariantType(new float[] {1.25f}));
+    Assert.assertTrue(isAllowedVariantType(new double[] {1.25d}));
+    Assert.assertTrue(isAllowedVariantType(new boolean[] {false}));
+    Assert.assertTrue(isAllowedVariantType(new char[] {'c'}));
+
+    // Test primitive lists
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList((byte) 1)));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList((short) 1)));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(1)));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(1L)));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(1.25f)));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(1.25d)));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(false)));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList('c')));
+
+    // Test additional numeric types and their collections
+    Assert.assertTrue(isAllowedVariantType(new BigInteger("1")));
+    Assert.assertTrue(isAllowedVariantType(new BigInteger[] {new BigInteger("1")}));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(new BigInteger("1"))));
+    Assert.assertTrue(isAllowedVariantType(new BigDecimal("1.25")));
+    Assert.assertTrue(isAllowedVariantType(new BigDecimal[] {new BigDecimal("1.25")}));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(new BigDecimal("1.25"))));
+
+    // Test strings
+    Assert.assertTrue(isAllowedVariantType("foo"));
+    Assert.assertTrue(isAllowedVariantType(new String[] {"foo"}));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList("foo")));
+
+    // Test date/time objects and their collections
+    Assert.assertTrue(isAllowedVariantType(LocalTime.now()));
+    Assert.assertTrue(isAllowedVariantType(OffsetTime.now()));
+    Assert.assertTrue(isAllowedVariantType(LocalDate.now()));
+    Assert.assertTrue(isAllowedVariantType(LocalDateTime.now()));
+    Assert.assertTrue(isAllowedVariantType(ZonedDateTime.now()));
+    Assert.assertTrue(isAllowedVariantType(OffsetDateTime.now()));
+    Assert.assertTrue(isAllowedVariantType(new LocalTime[] {LocalTime.now()}));
+    Assert.assertTrue(isAllowedVariantType(new OffsetTime[] {OffsetTime.now()}));
+    Assert.assertTrue(isAllowedVariantType(new LocalDate[] {LocalDate.now()}));
+    Assert.assertTrue(isAllowedVariantType(new LocalDateTime[] {LocalDateTime.now()}));
+    Assert.assertTrue(isAllowedVariantType(new ZonedDateTime[] {ZonedDateTime.now()}));
+    Assert.assertTrue(isAllowedVariantType(new OffsetDateTime[] {OffsetDateTime.now()}));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(LocalTime.now())));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(OffsetTime.now())));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(LocalDate.now())));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(LocalDateTime.now())));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(ZonedDateTime.now())));
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonList(OffsetDateTime.now())));
+
+    // Test mixed collections
+    Assert.assertTrue(
+        isAllowedVariantType(
+            new Object[] {
+              1,
+              false,
+              new BigInteger("1"),
+              LocalDateTime.now(),
+              new Object[] {new Object[] {new Object[] {LocalDateTime.now(), false}}}
+            }));
+    Assert.assertFalse(
+        isAllowedVariantType(
+            new Object[] {
+              1,
+              false,
+              new BigInteger("1"),
+              LocalDateTime.now(),
+              new Object[] {new Object[] {new Object[] {new Object(), false}}}
+            }));
+    Assert.assertTrue(
+        isAllowedVariantType(
+            Arrays.asList(
+                new BigInteger("1"),
+                "foo",
+                false,
+                Arrays.asList(13, Arrays.asList(Arrays.asList(false, 'c'))))));
+    Assert.assertFalse(
+        isAllowedVariantType(
+            Arrays.asList(
+                new BigInteger("1"),
+                "foo",
+                false,
+                Arrays.asList(13, Arrays.asList(Arrays.asList(new Object(), 'c'))))));
+
+    // Test maps
+    Assert.assertTrue(isAllowedVariantType(Collections.singletonMap("foo", "bar")));
+    Assert.assertFalse(isAllowedVariantType(Collections.singletonMap(new Object(), "foo")));
+    Assert.assertFalse(isAllowedVariantType(Collections.singletonMap("foo", new Object())));
+    Assert.assertTrue(
+        isAllowedVariantType(
+            Collections.singletonMap(
+                "foo",
+                new Object[] {
+                  1,
+                  false,
+                  new BigInteger("1"),
+                  LocalDateTime.now(),
+                  new Object[] {new Object[] {new Object[] {LocalDateTime.now(), false}}}
+                })));
+    Assert.assertFalse(
+        isAllowedVariantType(
+            Collections.singletonMap(
+                "foo",
+                new Object[] {
+                  1,
+                  false,
+                  new BigInteger("1"),
+                  LocalDateTime.now(),
+                  new Object[] {new Object[] {new Object[] {new Object(), false}}}
+                })));
+    Assert.assertTrue(
+        isAllowedVariantType(
+            Collections.singletonMap(
+                "foo",
+                Arrays.asList(
+                    new BigInteger("1"),
+                    "foo",
+                    false,
+                    Arrays.asList(13, Arrays.asList(Arrays.asList(false, 'c')))))));
+    Assert.assertFalse(
+        isAllowedVariantType(
+            Collections.singletonMap(
+                "foo",
+                Arrays.asList(
+                    new BigInteger("1"),
+                    "foo",
+                    false,
+                    Arrays.asList(13, Arrays.asList(Arrays.asList(new Object(), 'c')))))));
   }
 
   @Test
@@ -469,17 +764,6 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseDate, BigInteger.valueOf(1));
     expectError(
         ErrorCode.INVALID_ROW, DataValidationUtil::validateAndParseDate, BigDecimal.valueOf(1.25));
-  }
-
-  @Test
-  public void testGetStringValue() throws Exception {
-    Assert.assertEquals("123", DataValidationUtil.getStringValue("123"));
-    Assert.assertEquals("123", DataValidationUtil.getStringValue(123));
-    Assert.assertEquals("123", DataValidationUtil.getStringValue(new BigDecimal("123")));
-    Assert.assertEquals("123", DataValidationUtil.getStringValue(new BigInteger("123")));
-    Assert.assertEquals("123.0", DataValidationUtil.getStringValue(123f));
-    Assert.assertEquals("123.0", DataValidationUtil.getStringValue(123d));
-    Assert.assertEquals("123", DataValidationUtil.getStringValue(123l));
   }
 
   @Test
@@ -724,5 +1008,44 @@ public class DataValidationUtilTest {
         "The given row cannot be converted to Arrow format: ghi. Value cannot be ingested into"
             + " Snowflake column BINARY: Not a valid hex string",
         () -> validateAndParseBinary("ghi", Optional.empty()));
+
+    // VARIANT
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot"
+            + " be ingested into Snowflake column of type VARIANT. Allowed Java types: String,"
+            + " Primitive data types and their arrays, java.time.*, List<T>, Map<String, T>",
+        () -> validateAndParseVariant(new Object()));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: ][. Value cannot be ingested into"
+            + " Snowflake column VARIANT: Not a valid JSON",
+        () -> validateAndParseVariant("]["));
+
+    // ARRAY
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot"
+            + " be ingested into Snowflake column of type ARRAY. Allowed Java types: String,"
+            + " Primitive data types and their arrays, java.time.*, List<T>, Map<String, T>",
+        () -> validateAndParseArray(new Object()));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: ][. Value cannot be ingested into"
+            + " Snowflake column ARRAY: Not a valid JSON",
+        () -> validateAndParseArray("]["));
+
+    // OBJECT
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: Object of type java.lang.Object cannot"
+            + " be ingested into Snowflake column of type OBJECT. Allowed Java types: String,"
+            + " Primitive data types and their arrays, java.time.*, List<T>, Map<String, T>",
+        () -> validateAndParseObject(new Object()));
+    expectErrorCodeAndMessage(
+        ErrorCode.INVALID_ROW,
+        "The given row cannot be converted to Arrow format: }{. Value cannot be ingested into"
+            + " Snowflake column OBJECT: Not a valid JSON",
+        () -> validateAndParseObject("}{"));
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -284,16 +284,6 @@ public abstract class AbstractDataTypeTest {
       String expectedValue,
       String expectedType)
       throws Exception {
-    assertVariant(dataType, streamingIngestWriteValue, expectedValue, expectedType, true);
-  }
-
-  <STREAMING_INGEST_WRITE> void assertVariant(
-      String dataType,
-      STREAMING_INGEST_WRITE streamingIngestWriteValue,
-      String expectedValue,
-      String expectedType,
-      boolean compareAsJsons)
-      throws Exception {
 
     String tableName = createTable(dataType);
     String offsetToken = UUID.randomUUID().toString();
@@ -317,9 +307,7 @@ public abstract class AbstractDataTypeTest {
     }
 
     Assert.assertEquals(1, counter);
-    if (compareAsJsons)
-      Assert.assertEquals(objectMapper.readTree(expectedValue), objectMapper.readTree(value));
-    else Assert.assertEquals(expectedValue, value);
+    Assert.assertEquals(objectMapper.readTree(expectedValue), objectMapper.readTree(value));
     Assert.assertEquals(expectedType, typeof);
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NullIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NullIT.java
@@ -1,0 +1,33 @@
+package net.snowflake.ingest.streaming.internal.datatypes;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+public class NullIT extends AbstractDataTypeTest {
+  @Test
+  public void testNullIngestion() throws Exception {
+    for (String type :
+        Arrays.asList(
+            "INT",
+            "NUMBER(1, 1)",
+            "NUMBER(1, 0)",
+            "BOOLEAN",
+            "VARCHAR",
+            "BINARY",
+            "DATE",
+            "TIME",
+            "TIME(0)",
+            "TIMESTAMP_NTZ",
+            "TIMESTAMP_NTZ(0)",
+            "TIMESTAMP_LTZ",
+            "TIMESTAMP_LTZ(0)",
+            "TIMESTAMP_TZ",
+            "TIMESTAMP_TZ(0)",
+            "VARIANT",
+            "ARRAY",
+            "OBJECT")) {
+      // Provider type does not matter as we are expecting null anyway
+      testIngestion(type, null, null, new StringProvider());
+    }
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
@@ -20,7 +20,9 @@ import org.junit.Test;
 
 public class SemiStructuredIT extends AbstractDataTypeTest {
 
-  private static final int MAX_ALLOWED_LENGTH = 16 * 1024 * 1024 - 1024; // SNOW-664249
+  // TODO SNOW-664249: There is a few-byte mismatch between the value sent by the user and its
+  // server-side representation. Validation leaves a small buffer for this difference.
+  private static final int MAX_ALLOWED_LENGTH = 16 * 1024 * 1024 - 64;
 
   @Test
   public void testVariant() throws Exception {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
@@ -1,0 +1,214 @@
+package net.snowflake.ingest.streaming.internal.datatypes;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SemiStructuredIT extends AbstractDataTypeTest {
+
+  private static final int MAX_ALLOWED_LENGTH = 16 * 1024 * 1024 - 1024; // SNOW-664249
+
+  @Test
+  public void testVariant() throws Exception {
+    // Test dates
+    assertVariant("VARIANT", LocalTime.of(0, 0, 0, 123), "\"00:00:00.000000123\"", "VARCHAR");
+    assertVariant(
+        "VARIANT",
+        OffsetTime.of(0, 0, 0, 123, ZoneOffset.ofHours(-1)),
+        "\"00:00:00.000000123-01:00\"",
+        "VARCHAR");
+    assertVariant("VARIANT", LocalDate.of(1970, 1, 1), "\"1970-01-01\"", "VARCHAR");
+    assertVariant(
+        "VARIANT", LocalDateTime.of(1970, 1, 1, 0, 0, 0), "\"1970-01-01T00:00\"", "VARCHAR");
+    assertVariant(
+        "VARIANT",
+        Instant.EPOCH.atOffset(ZoneOffset.ofHours(-1)),
+        "\"1969-12-31T23:00-01:00\"",
+        "VARCHAR");
+    assertVariant(
+        "VARIANT",
+        Instant.EPOCH.atZone(ZoneId.of("America/Los_Angeles")),
+        "\"1969-12-31T16:00-08:00\"",
+        "VARCHAR");
+
+    // Test arrays
+    assertVariant("VARIANT", "[]", "[]", "ARRAY");
+    assertVariant("VARIANT", "[1]", "[1]", "ARRAY");
+    assertVariant(
+        "VARIANT", new byte[] {Byte.MIN_VALUE, 0, Byte.MAX_VALUE}, "[-128,0,127]", "ARRAY");
+    assertVariant(
+        "VARIANT", Arrays.asList(Byte.MIN_VALUE, 0, Byte.MAX_VALUE), "[-128,0,127]", "ARRAY");
+    assertVariant(
+        "VARIANT", new short[] {Short.MIN_VALUE, 0, Short.MAX_VALUE}, "[-32768,0,32767]", "ARRAY");
+    assertVariant(
+        "VARIANT", Arrays.asList(Short.MIN_VALUE, 0, Short.MAX_VALUE), "[-32768,0,32767]", "ARRAY");
+    assertVariant(
+        "VARIANT",
+        new int[] {Integer.MIN_VALUE, 0, Integer.MAX_VALUE},
+        "[-2147483648,0,2147483647]",
+        "ARRAY");
+    assertVariant(
+        "VARIANT",
+        Arrays.asList(Integer.MIN_VALUE, 0, Integer.MAX_VALUE),
+        "[-2147483648,0,2147483647]",
+        "ARRAY");
+    assertVariant(
+        "VARIANT",
+        new long[] {Long.MIN_VALUE, 0L, Long.MAX_VALUE},
+        "[-9223372036854775808,0,9223372036854775807]",
+        "ARRAY");
+    assertVariant(
+        "VARIANT",
+        Arrays.asList(Long.MIN_VALUE, 0L, Long.MAX_VALUE),
+        "[-9223372036854775808,0,9223372036854775807]",
+        "ARRAY");
+    assertVariant(
+        "VARIANT",
+        new Object[] {
+          Byte.MIN_VALUE,
+          Short.MAX_VALUE,
+          0,
+          Long.MAX_VALUE,
+          new Object[2],
+          Collections.emptyMap(),
+          null
+        },
+        "[-128,32767,0,9223372036854775807,[null,null],{}, null]",
+        "ARRAY");
+    assertVariant(
+        "VARIANT",
+        Arrays.asList(
+            Byte.MIN_VALUE,
+            Short.MAX_VALUE,
+            0,
+            Long.MAX_VALUE,
+            new Object[2],
+            Collections.emptyMap(),
+            null),
+        "[-128,32767,0,9223372036854775807,[null,null],{}, null]",
+        "ARRAY");
+    assertVariant("VARIANT", new BigInteger[] {BigInteger.TEN}, "[10]", "ARRAY");
+    assertVariant("VARIANT", Collections.singletonList(BigInteger.TEN), "[10]", "ARRAY");
+    assertVariant("VARIANT", new BigDecimal[] {new BigDecimal("10.5")}, "[10.5]", "ARRAY");
+    assertVariant("VARIANT", Collections.singletonList(new BigDecimal("10.5")), "[10.5]", "ARRAY");
+
+    // Test booleans
+    assertVariant("VARIANT", "false", "false", "BOOLEAN");
+    assertVariant("VARIANT", false, "false", "BOOLEAN");
+    assertVariant("VARIANT", true, "true", "BOOLEAN");
+
+    // Test numbers
+    assertVariant("VARIANT", 34, "34", "INTEGER");
+    assertVariant("VARIANT", "34", "34", "INTEGER");
+
+    assertVariant("VARIANT", Byte.MAX_VALUE, String.valueOf(Byte.MAX_VALUE), "INTEGER");
+    assertVariant("VARIANT", Short.MAX_VALUE, String.valueOf(Short.MAX_VALUE), "INTEGER");
+    assertVariant("VARIANT", Integer.MAX_VALUE, String.valueOf(Integer.MAX_VALUE), "INTEGER");
+    assertVariant("VARIANT", Long.MAX_VALUE, String.valueOf(Long.MAX_VALUE), "INTEGER");
+    assertVariant("VARIANT", Long.MIN_VALUE, String.valueOf(Long.MIN_VALUE), "INTEGER");
+    assertVariant("VARIANT", BigInteger.TEN, BigInteger.TEN.toString(), "INTEGER");
+    assertVariant(
+        "VARIANT", new BigDecimal("10.54"), new BigDecimal("10.54").toString(), "DECIMAL");
+    assertVariant("VARIANT", "-1000.25", "-1000.25", "DECIMAL");
+    assertVariant("VARIANT", -1000.25f, "-1000.25", "DECIMAL");
+    assertVariant("VARIANT", -1000.25, "-1000.25", "DECIMAL");
+
+    // Test objects
+    assertVariant("VARIANT", "{}", "{}", "OBJECT");
+    String testObject =
+        "{\"a\": \"foo\", \"b\":15, \"c\": false, \"d\": [1, 2, 3], \"e\": {\"q\": false}, \"f\":"
+            + " null}";
+    assertVariant("VARIANT", testObject, testObject, "OBJECT");
+    assertVariant(
+        "VARIANT",
+        Collections.singletonMap(
+            "A",
+            Collections.singletonMap("B", Collections.singletonMap("C", new String[] {"foo"}))),
+        "{\"A\": {\"B\": {\"C\": [\"foo\"]}}}",
+        "OBJECT");
+
+    // Test strings
+    assertVariant("VARIANT", "\"foo\"", "\"foo\"", "VARCHAR");
+    assertVariant("VARIANT", '1', "\"1\"", "VARCHAR");
+    assertVariant("VARIANT", 'd', "\"d\"", "VARCHAR");
+    assertVariant(
+        "VARIANT", "\"ž, š, č, ř, c, j, ď, ť, ň\"", "\"ž, š, č, ř, c, j, ď, ť, ň\"", "VARCHAR");
+
+    // Date/time strings are ingested as varchars
+    assertVariant("VARIANT", "\"13:05:33.299094\"", "\"13:05:33.299094\"", "VARCHAR");
+    assertVariant("VARIANT", "\"13:05:55.684003Z\"", "\"13:05:55.684003Z\"", "VARCHAR");
+    assertVariant("VARIANT", "\"2022-09-14\"", "\"2022-09-14\"", "VARCHAR");
+    assertVariant(
+        "VARIANT", "\"2022-09-14T13:04:53.578667\"", "\"2022-09-14T13:04:53.578667\"", "VARCHAR");
+    assertVariant(
+        "VARIANT",
+        "\"2022-09-14T06:16:09.797704-07:00[America/Los_Angeles]\"",
+        "\"2022-09-14T06:16:09.797704-07:00[America/Los_Angeles]\"",
+        "VARCHAR");
+
+    // Test JSON null
+    assertVariant("VARIANT", "null", "null", "NULL_VALUE");
+  }
+
+  @Test
+  public void testMaxVariantAndObject() throws Exception {
+    String maxObject = createLargeVariantObject(MAX_ALLOWED_LENGTH);
+    assertVariant("VARIANT", maxObject, maxObject, "OBJECT");
+    assertVariant("OBJECT", maxObject, maxObject, "OBJECT");
+  }
+
+  @Test
+  public void testMaxArray() throws Exception {
+    String maxArray = "[" + createLargeVariantObject(MAX_ALLOWED_LENGTH - 2) + "]";
+    assertVariant("ARRAY", maxArray, maxArray, "ARRAY");
+  }
+
+  @Test
+  public void testObject() throws Exception {
+    assertVariant("OBJECT", "{}", "{}", "OBJECT");
+    assertVariant("OBJECT", Collections.emptyMap(), "{}", "OBJECT");
+    assertVariant("OBJECT", Collections.singletonMap("1", 2), "{\"1\": 2}", "OBJECT");
+    assertVariant(
+        "OBJECT", Collections.singletonMap("1", new byte[] {1, 2}), "{\"1\": [1,2]}", "OBJECT");
+  }
+
+  @Test
+  public void testArray() throws Exception {
+    assertVariant("ARRAY", "[]", "[]", "ARRAY");
+    assertVariant("ARRAY", Collections.emptyList(), "[]", "ARRAY");
+    assertVariant("ARRAY", new Object[0], "[]", "ARRAY");
+    assertVariant("ARRAY", new int[0], "[]", "ARRAY");
+    assertVariant("ARRAY", new double[0], "[]", "ARRAY");
+
+    assertVariant("ARRAY", 1, "[1]", "ARRAY");
+    assertVariant("ARRAY", "null", "[null]", "ARRAY");
+    assertVariant("ARRAY", "{}", "[{}]", "ARRAY");
+    assertVariant("ARRAY", Collections.emptyMap(), "[{}]", "ARRAY");
+    assertVariant("ARRAY", Collections.singletonMap("1", "2"), "[{\"1\": \"2\"}]", "ARRAY");
+  }
+
+  private String createLargeVariantObject(int size) throws JsonProcessingException {
+    char[] stringContent = new char[size - 17]; // {"a":"11","b":""}
+    Arrays.fill(stringContent, 'c');
+    Map<String, Object> m = new HashMap<>();
+    m.put("a", "11");
+    m.put("b", new String(stringContent));
+    String s = new ObjectMapper().writeValueAsString(m);
+    Assert.assertEquals(s.length(), size);
+    return s;
+  }
+}


### PR DESCRIPTION
More restricted validation of VARIANT, ARRAY AND OBJECT has been implemented:

* Only selected types are allowed 
    * String **must** be a valid JSON, otherwise it is rejected 
        * i.e. `"foo"` is rejected, but `"\"foo\""` is allowed 
    * java primitive data types and their arrays 
    * `java.time.*` objects 
    * `T[]` if `T` is a valid variant type 
    * `List<T>` if `T` is a valid variant type 
    * `Map<String, T>` if `T` is a valid variant type
* Custom JSON serialization of `ZonedDateTime` and `byte[]`
* Collections (array, list, map) are recursively validated
* ARRAY: Non-array input is converted into a 1-element array
* OBJECT: Non-object input is rejected
* Due to SNOW-664249, the max allowed limit is reduced by 1KB
* Integration tests for ingesting `null` added