### PR TITLE
Introduce parquet file generator 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,13 @@
       <url>https://github.com/snowflakedb/snowflake-ingest-java/tree/master</url>
     </scm>
 
+    <repositories>
+        <repository>
+            <id>cloudera-repo</id>
+            <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+        </repository>
+    </repositories>
+
     <!-- Set our Language Level to Java 8 -->
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -293,63 +300,18 @@
             <version>${arrow.version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.apache.parquet/parquet-hadoop -->
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-hadoop</artifactId>
-            <version>1.11.2</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>1.10.99.7.2.15.0-147</version>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.github.spotbugs</groupId>
-                    <artifactId>spotbugs-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-json</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>servlet-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.servlet.jsp</groupId>
-                    <artifactId>jsp-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-mapper-asl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-java</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>jetty</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>3.1.1.7.2.15.0-147</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <jacoco.skip.instrument>true</jacoco.skip.instrument>
         <jacoco.version>0.8.5</jacoco.version>
         <arrow.version>9.0.0</arrow.version>
+        <hadoop.version>2.10.1</hadoop.version>
     </properties>
 
     <build>
@@ -290,6 +291,65 @@
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-compression</artifactId>
             <version>${arrow.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop</artifactId>
+            <version>1.11.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet.jsp</groupId>
+                    <artifactId>jsp-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/scripts/check_content.sh
+++ b/scripts/check_content.sh
@@ -5,7 +5,23 @@
 set -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v mime.types | grep -v project.properties | grep -v -E "javax" | grep -v -E "^org/" | grep -v -E "^com/google" | grep -v -E "^com/sun" | grep -v "log4j.properties" | grep -v "git.properties" | grep -v "io/" | grep -v "codegen/" | grep -v "com/codahale/" | grep -v "com/ibm/" | grep -v "LICENSE" | grep -v "aix/" | grep -v "darwin/" | grep -v "win/" | grep -v "freebsd/" | grep -v "linux/" | grep -v "com/github/"; then
+if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" \
+    | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v mime.types \
+    | grep -v project.properties | grep -v -E "javax" | grep -v -E "^org/" | grep -v -E "^com/google" \
+    | grep -v -E "^com/sun" | grep -v "log4j.properties" | grep -v "git.properties" | grep -v "io/" \
+    | grep -v "codegen/" | grep -v "com/codahale/" | grep -v "com/ibm/" | grep -v "LICENSE" | grep -v "aix/" \
+    | grep -v "darwin/" | grep -v "win/" | grep -v "freebsd/" | grep -v "linux/" | grep -v "com/github/" \
+    | grep -v -E "shaded/" | grep -v "webapps/"  | grep -v "microsoft/" | grep -v "com/ctc/" \
+    | grep -v "edu/" | grep -v "com/jcraft/" | grep -v "contribs/" | grep -v "com/zaxxer/"  | grep -v "com/squareup/" \
+    | grep -v "com/thoughtworks/" | grep -v "com/jamesmurty/"  | grep -v "net/iharder/" \
+    | grep -v -E "^core-default.xml" \
+    | grep -v "yarn-version-info.properties" | grep -v "yarn-version-info.properties" \
+    | grep -v "common-version-info.properties" | grep -v "LocalizedFormats_fr.properties" \
+    | grep -v "org.apache.hadoop.application-classloader.properties" | grep -v "assets/" | grep -v "ehcache-core.xsd" \
+    | grep -v "ehcache-107ext.xsd" | grep -v "parquet.thrift" | grep -v "mapred-default.xml" \
+    | grep -v "yarn-default.xml" | grep -v ".keep"  | grep -v "NOTICE" | grep -v "digesterRules.xml" \
+    | grep -v "properties.dtd" | grep -v "PropertyList-1.0.dtd"  \
+    ; then
   echo "[ERROR] Ingest SDK jar includes class not under the snowflake namespace"
   exit 1
 fi

--- a/scripts/check_content.sh
+++ b/scripts/check_content.sh
@@ -11,11 +11,14 @@ if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v
     | grep -v -E "^com/sun" | grep -v "log4j.properties" | grep -v "git.properties" | grep -v "io/" \
     | grep -v "codegen/" | grep -v "com/codahale/" | grep -v "com/ibm/" | grep -v "LICENSE" | grep -v "aix/" \
     | grep -v "darwin/" | grep -v "win/" | grep -v "freebsd/" | grep -v "linux/" | grep -v "com/github/" \
-    | grep -v -E "shaded/" | grep -v "webapps/"  | grep -v "microsoft/" | grep -v "com/ctc/" \
+    | grep -v -E "shaded/" | grep -v "webapps/"  | grep -v "microsoft/" | grep -v "com/ctc/" | grep -v "jersey/" \
     | grep -v "edu/" | grep -v "com/jcraft/" | grep -v "contribs/" | grep -v "com/zaxxer/"  | grep -v "com/squareup/" \
     | grep -v "com/thoughtworks/" | grep -v "com/jamesmurty/"  | grep -v "net/iharder/" \
     | grep -v -E "^core-default.xml" \
     | grep -v "yarn-version-info.properties" | grep -v "yarn-version-info.properties" \
+    | grep -v "about.html" | grep -v "jetty-dir.css" \
+    | grep -v "krb5_udp-template.conf" | grep -v "krb5-template.conf" \
+    | grep -v "ccache.txt" | grep -v "keytab.txt" \
     | grep -v "common-version-info.properties" | grep -v "LocalizedFormats_fr.properties" \
     | grep -v "org.apache.hadoop.application-classloader.properties" | grep -v "assets/" | grep -v "ehcache-core.xsd" \
     | grep -v "ehcache-107ext.xsd" | grep -v "parquet.thrift" | grep -v "mapred-default.xml" \

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -471,15 +471,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
             // vector.setSafe requires the BigDecimal input scale explicitly match its scale
             inputAsBigDecimal = inputAsBigDecimal.setScale(columnScale, RoundingMode.HALF_UP);
 
-            if (inputAsBigDecimal.abs().compareTo(BigDecimal.TEN.pow(columnPrecision - columnScale))
-                >= 0) {
-              throw new SFException(
-                  ErrorCode.INVALID_ROW,
-                  inputAsBigDecimal,
-                  String.format(
-                      "Number out of representable exclusive range of (-1e%s..1e%s)",
-                      columnPrecision - columnScale, columnPrecision - columnScale));
-            }
+            DataValidationUtil.checkValueInRange(inputAsBigDecimal, columnScale, columnPrecision);
 
             if (columnScale != 0 || physicalType == ColumnPhysicalType.SB16) {
               ((DecimalVector) vector).setSafe(curRowIndex, inputAsBigDecimal);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadata.java
@@ -49,9 +49,16 @@ class BlobMetadata {
     return this.chunks;
   }
 
-  // TODO: send the bdec_version once server side supports this in production
-  //  @JsonProperty("bdec_version")
-  //  byte getVersionByte() {
-  //    return bdecVersion.toByte();
-  //  }
+  /**
+   * Create {@link BlobMetadata} in case of {@link Constants.BdecVersion#ONE} and {@link
+   * BlobMetadataWithBdecVersion} otherwise to send BDEC version to server side.
+   */
+  static BlobMetadata createBlobMetadata(
+      String path, String md5, Constants.BdecVersion bdecVersion, List<ChunkMetadata> chunks) {
+    // TODO SNOW-659721: Unify BlobMetadata with BlobMetadataWithBdecVersion once server side
+    // BdecVersion in production
+    return bdecVersion == Constants.BdecVersion.ONE
+        ? new BlobMetadata(path, md5, bdecVersion, chunks)
+        : new BlobMetadataWithBdecVersion(path, md5, bdecVersion, chunks);
+  }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadataWithBdecVersion.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobMetadataWithBdecVersion.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import net.snowflake.ingest.utils.Constants;
+
+/**
+ * Same as {@link BlobMetadata} but with {@link Constants.BdecVersion} to send it to server side if
+ * the version is greater than {@link Constants.BdecVersion#ONE}.
+ */
+class BlobMetadataWithBdecVersion extends BlobMetadata {
+  BlobMetadataWithBdecVersion(
+      String path, String md5, Constants.BdecVersion bdecVersion, List<ChunkMetadata> chunks) {
+    super(path, md5, bdecVersion, chunks);
+  }
+
+  @JsonProperty("bdec_version")
+  byte getVersionByte() {
+    return getVersion().toByte();
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
@@ -14,7 +14,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * during flush. The key is a fully qualified table name and the value is a set of channels that
  * belongs to this table
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 class ChannelCache<T> {
   // Cache to hold all the valid channels, the key for the outer map is FullyQualifiedTableName and

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -674,6 +674,17 @@ class DataValidationUtil {
         input.getClass(), "BOOLEAN", new String[] {"boolean", "Number", "String"});
   }
 
+  static void checkValueInRange(BigDecimal bigDecimalValue, int scale, int precision) {
+    if (bigDecimalValue.abs().compareTo(BigDecimal.TEN.pow(precision - scale)) >= 0) {
+      throw new SFException(
+          ErrorCode.INVALID_ROW,
+          bigDecimalValue,
+          String.format(
+              "Number out of representable exclusive range of (-1e%s..1e%s)",
+              precision - scale, precision - scale));
+    }
+  }
+
   static Set<String> allowedBooleanStringsLowerCased =
       Sets.newHashSet("1", "0", "yes", "no", "y", "n", "t", "f", "true", "false", "on", "off");
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -58,7 +58,8 @@ import org.apache.arrow.vector.VectorSchemaRoot;
  * <li>upload the blob to stage
  * <li>register the blob to the targeted Snowflake table
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 class FlushService<T> {
 
@@ -467,7 +468,6 @@ class FlushService<T> {
         // We need to maintain IV as a block counter for the whole file, even interleaved,
         // to align with decryption on the Snowflake query path.
         // TODO: address alignment for the header SNOW-557866
-        // TODO: encryption is not yet supported by server side for Parquet
         long iv = curDataSize / Constants.ENCRYPTION_ALGORITHM_BLOCK_SIZE_BYTES;
         byte[] encryptedCompressedChunkData =
             Cryptor.encrypt(
@@ -559,7 +559,8 @@ class FlushService<T> {
         blob.length,
         System.currentTimeMillis() - startTime);
 
-    return new BlobMetadata(filePath, BlobBuilder.computeMD5(blob), bdecVersion, metadata);
+    return BlobMetadata.createBlobMetadata(
+        filePath, BlobBuilder.computeMD5(blob), bdecVersion, metadata);
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
@@ -13,7 +13,8 @@ import java.util.Map;
  * Interface to convert {@link ChannelData} buffered in {@link RowBuffer} to the underlying format
  * implementation for faster processing.
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 public interface Flusher<T> {
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import java.util.List;
+import java.util.Map;
+
+/** Parquet data holder to buffer rows. */
+public class ParquetChunkData {
+  final List<List<Object>> rows;
+  final Map<String, String> metadata;
+
+  /**
+   * Construct parquet data chunk.
+   *
+   * @param rows chunk row set
+   * @param metadata chunk metadata
+   */
+  public ParquetChunkData(List<List<Object>> rows, Map<String, String> metadata) {
+    this.rows = rows;
+    this.metadata = metadata;
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import static net.snowflake.ingest.utils.Constants.MAX_CHUNK_SIZE_IN_BYTES;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import net.snowflake.ingest.utils.Constants;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.Logging;
+import net.snowflake.ingest.utils.SFException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.api.WriteSupport;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.DelegatingPositionOutputStream;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.ParquetEncodingException;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.RecordConsumer;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+
+/**
+ * Converts {@link ChannelData} buffered in {@link RowBuffer} to the Parquet format for faster
+ * processing.
+ */
+public class ParquetFlusher implements Flusher<ParquetChunkData> {
+  private static final Logging logger = new Logging(ParquetFlusher.class);
+  private final MessageType schema;
+
+  /** Construct parquet flusher from its schema. */
+  public ParquetFlusher(MessageType schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public SerializationResult serialize(
+      List<ChannelData<ParquetChunkData>> channelsDataPerTable,
+      ByteArrayOutputStream chunkData,
+      String filePath)
+      throws IOException {
+    List<ChannelMetadata> channelsMetadataList = new ArrayList<>();
+    long rowCount = 0L;
+    SnowflakeStreamingIngestChannelInternal<ParquetChunkData> firstChannel = null;
+    Map<String, RowBufferStats> columnEpStatsMapCombined = null;
+    List<List<Object>> rows = null;
+
+    for (ChannelData<ParquetChunkData> data : channelsDataPerTable) {
+      // Create channel metadata
+      ChannelMetadata channelMetadata =
+          ChannelMetadata.builder()
+              .setOwningChannel(data.getChannel())
+              .setRowSequencer(data.getRowSequencer())
+              .setOffsetToken(data.getOffsetToken())
+              .build();
+      // Add channel metadata to the metadata list
+      channelsMetadataList.add(channelMetadata);
+
+      logger.logDebug(
+          "Parquet Flusher: Start building channel={}, rowCount={}, bufferSize={} in blob={}",
+          data.getChannel().getFullyQualifiedName(),
+          data.getRowCount(),
+          data.getBufferSize(),
+          filePath);
+
+      if (rows == null) {
+        columnEpStatsMapCombined = data.getColumnEps();
+        rows = new ArrayList<>();
+        firstChannel = data.getChannel();
+      } else {
+        // This method assumes that channelsDataPerTable is grouped by table. We double check
+        // here and throw an error if the assumption is violated
+        if (!data.getChannel()
+            .getFullyQualifiedTableName()
+            .equals(firstChannel.getFullyQualifiedTableName())) {
+          throw new SFException(ErrorCode.INVALID_DATA_IN_CHUNK);
+        }
+
+        columnEpStatsMapCombined =
+            ChannelData.getCombinedColumnStatsMap(columnEpStatsMapCombined, data.getColumnEps());
+      }
+      rows.addAll(data.getVectors().rows);
+
+      rowCount += data.getRowCount();
+
+      logger.logDebug(
+          "Parquet Flusher: Finish building channel={}, rowCount={}, bufferSize={} in blob={}",
+          data.getChannel().getFullyQualifiedName(),
+          data.getRowCount(),
+          data.getBufferSize(),
+          filePath);
+    }
+
+    Map<String, String> metadata = channelsDataPerTable.get(0).getVectors().metadata;
+
+    flushToParquetBdecChunk(chunkData, rows, metadata, channelsMetadataList);
+    return new SerializationResult(channelsMetadataList, columnEpStatsMapCombined, rowCount);
+  }
+
+  /**
+   * Flushes a parquet row chunk to the given BDEC output stream.
+   *
+   * @param bdecOutput BDEC output stream
+   * @param chunkRows chunk rows
+   * @param metadata chunk metadata
+   * @param channelsMetadataList metadata of the channels the chunk rows belong to
+   * @throws IOException thrown from Parquet library in case of writing problems
+   */
+  private void flushToParquetBdecChunk(
+      ByteArrayOutputStream bdecOutput,
+      List<List<Object>> chunkRows,
+      Map<String, String> metadata,
+      List<ChannelMetadata> channelsMetadataList)
+      throws IOException {
+    try {
+      ParquetWriter<List<Object>> writer =
+          new BdecParquetWriterBuilder(bdecOutput, schema, metadata, channelsMetadataList)
+              // PARQUET_2_0 uses Encoding.DELTA_BYTE_ARRAY for byte arrays (e.g. SF sb16)
+              // server side does not support it TODO: SNOW-657238
+              .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0)
+
+              // the dictionary encoding (Encoding.*_DICTIONARY) is not supported by server side
+              // scanner yet
+              .withDictionaryEncoding(false)
+
+              // Historically server side scanner supports only the case when the row number in all
+              // pages is the same.
+              // The quick fix is to effectively disable the page size/row limit
+              // to always have one page per chunk until server side is generalised.
+              .withPageSize((int) Constants.MAX_CHUNK_SIZE_IN_BYTES * 2)
+              .withPageRowCountLimit(chunkRows.size() + 1)
+              .enableValidation()
+              .withCompressionCodec(CompressionCodecName.GZIP)
+              .withWriteMode(ParquetFileWriter.Mode.CREATE)
+              .build();
+
+      // We can use lower level column writers and custom ValuesWriterFactory that uses plain byte
+      // array encoding used by PARQUET_1_0 and supported by server side
+      // TODO: SNOW-672143
+      for (List<Object> row : chunkRows) {
+        writer.write(row);
+      }
+      writer.close();
+    } catch (Throwable t) {
+      logger.logError("Parquet Flusher: failed to write", t);
+      throw t;
+    }
+  }
+
+  /**
+   * A parquet specific write builder.
+   *
+   * <p>This class is implemented as parquet library API requires, mostly to provide {@link
+   * BdecWriteSupport} implementation.
+   */
+  private static class BdecParquetWriterBuilder
+      extends ParquetWriter.Builder<List<Object>, BdecParquetWriterBuilder> {
+    private final MessageType schema;
+    private final Map<String, String> extraMetaData;
+    private final List<ChannelMetadata> channelsMetadataList;
+
+    protected BdecParquetWriterBuilder(
+        ByteArrayOutputStream stream,
+        MessageType schema,
+        Map<String, String> extraMetaData,
+        List<ChannelMetadata> channelsMetadataList) {
+      super(new ByteArrayOutputFile(stream));
+      this.schema = schema;
+      this.extraMetaData = extraMetaData;
+      this.channelsMetadataList = channelsMetadataList;
+    }
+
+    @Override
+    protected BdecParquetWriterBuilder self() {
+      return this;
+    }
+
+    @Override
+    protected WriteSupport<List<Object>> getWriteSupport(Configuration conf) {
+      return new BdecWriteSupport(schema, extraMetaData, channelsMetadataList);
+    }
+  }
+
+  /**
+   * A parquet specific file output implementation.
+   *
+   * <p>This class is implemented as parquet library API requires, mostly to create our {@link
+   * ByteArrayDelegatingPositionOutputStream} implementation.
+   */
+  private static class ByteArrayOutputFile implements OutputFile {
+    private final ByteArrayOutputStream stream;
+
+    private ByteArrayOutputFile(ByteArrayOutputStream stream) {
+      this.stream = stream;
+    }
+
+    @Override
+    public PositionOutputStream create(long blockSizeHint) throws IOException {
+      stream.reset();
+      return new ByteArrayDelegatingPositionOutputStream(stream);
+    }
+
+    @Override
+    public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
+      return create(blockSizeHint);
+    }
+
+    @Override
+    public boolean supportsBlockSize() {
+      return false;
+    }
+
+    @Override
+    public long defaultBlockSize() {
+      return (int) MAX_CHUNK_SIZE_IN_BYTES;
+    }
+  }
+
+  /**
+   * A parquet specific output stream implementation.
+   *
+   * <p>This class is implemented as parquet library API requires, mostly to wrap our BDEC output
+   * {@link ByteArrayOutputStream}.
+   */
+  private static class ByteArrayDelegatingPositionOutputStream
+      extends DelegatingPositionOutputStream {
+    private final ByteArrayOutputStream stream;
+
+    public ByteArrayDelegatingPositionOutputStream(ByteArrayOutputStream stream) {
+      super(stream);
+      this.stream = stream;
+    }
+
+    @Override
+    public long getPos() {
+      return stream.size();
+    }
+  }
+
+  /**
+   * A parquet specific write support implementation.
+   *
+   * <p>This class is implemented as parquet library API requires, mostly to serialize user column
+   * values depending on type into Parquet {@link RecordConsumer} in {@link
+   * BdecWriteSupport#write(List)}.
+   */
+  private static class BdecWriteSupport extends WriteSupport<List<Object>> {
+    MessageType schema;
+    RecordConsumer recordConsumer;
+    Map<String, String> extraMetadata;
+    List<ChannelMetadata> channelsMetadataList;
+
+    // TODO SNOW-672156: support specifying encodings and compression
+    BdecWriteSupport(
+        MessageType schema,
+        Map<String, String> extraMetadata,
+        List<ChannelMetadata> channelsMetadataList) {
+      this.schema = schema;
+      this.extraMetadata = extraMetadata;
+      this.channelsMetadataList = channelsMetadataList;
+    }
+
+    @Override
+    public WriteContext init(Configuration config) {
+      return new WriteContext(schema, extraMetadata);
+    }
+
+    @Override
+    public void prepareForWrite(RecordConsumer recordConsumer) {
+      this.recordConsumer = recordConsumer;
+    }
+
+    @Override
+    public void write(List<Object> values) {
+      List<ColumnDescriptor> cols = schema.getColumns();
+      if (values.size() != cols.size()) {
+        List<String> channelNames =
+            this.channelsMetadataList.stream()
+                .map(ChannelMetadata::getChannelName)
+                .collect(Collectors.toList());
+        throw new ParquetEncodingException(
+            "Invalid input data in channels "
+                + channelNames
+                + ". Expecting "
+                + cols.size()
+                + " columns. Input had "
+                + values.size()
+                + " columns ("
+                + cols
+                + ") : "
+                + values);
+      }
+
+      recordConsumer.startMessage();
+      for (int i = 0; i < cols.size(); ++i) {
+        Object val = values.get(i);
+        // val.length() == 0 indicates a NULL value.
+        if (val != null) {
+          String fieldName = cols.get(i).getPath()[0];
+          recordConsumer.startField(fieldName, i);
+          PrimitiveType.PrimitiveTypeName typeName =
+              cols.get(i).getPrimitiveType().getPrimitiveTypeName();
+          switch (typeName) {
+            case BOOLEAN:
+              recordConsumer.addBoolean((boolean) val);
+              break;
+            case FLOAT:
+              recordConsumer.addFloat((float) val);
+              break;
+            case DOUBLE:
+              recordConsumer.addDouble((double) val);
+              break;
+            case INT32:
+              recordConsumer.addInteger((int) val);
+              break;
+            case INT64:
+              recordConsumer.addLong((long) val);
+              break;
+            case BINARY:
+              recordConsumer.addBinary(Binary.fromString((String) val));
+              break;
+            case FIXED_LEN_BYTE_ARRAY:
+              Binary binary = Binary.fromConstantByteArray((byte[]) val);
+              recordConsumer.addBinary(binary);
+              break;
+            default:
+              throw new ParquetEncodingException(
+                  "Unsupported column type: " + cols.get(i).getPrimitiveType());
+          }
+          recordConsumer.endField(fieldName, i);
+        }
+      }
+      recordConsumer.endMessage();
+    }
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import net.snowflake.client.jdbc.internal.google.common.collect.Sets;
+import net.snowflake.ingest.streaming.OpenChannelRequest;
+import net.snowflake.ingest.utils.Constants;
+import net.snowflake.ingest.utils.Logging;
+import net.snowflake.ingest.utils.Pair;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+/**
+ * The buffer in the Streaming Ingest channel that holds the un-flushed rows, these rows will be
+ * converted to Parquet format for faster processing
+ */
+public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
+  private static final Logging logger = new Logging(ParquetRowBuffer.class);
+
+  private static final String PARQUET_MESSAGE_TYPE_NAME = "bdec";
+
+  private final Map<String, Pair<ColumnMetadata, Integer>> fieldIndex;
+  private final Map<String, String> metadata;
+  private final List<List<Object>> data;
+  private final List<List<Object>> tempData;
+
+  private MessageType schema;
+
+  /**
+   * Construct a ParquetRowBuffer object
+   *
+   * @param channel client channel
+   */
+  ParquetRowBuffer(SnowflakeStreamingIngestChannelInternal<ParquetChunkData> channel) {
+    super(channel);
+    fieldIndex = new HashMap<>();
+    metadata = new HashMap<>();
+    data = new ArrayList<>();
+    tempData = new ArrayList<>();
+  }
+
+  @Override
+  public void setupSchema(List<ColumnMetadata> columns) {
+    fieldIndex.clear();
+    metadata.clear();
+    List<Type> parquetTypes = new ArrayList<>();
+    // Snowflake column id that corresponds to the order in 'columns' received from server
+    // id is required to pack column metadata for the server scanner, e.g. decimal scale and
+    // precision
+    int id = 1;
+    for (ColumnMetadata column : columns) {
+      ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+          ParquetTypeGenerator.generateColumnParquetTypeInfo(column, id);
+      parquetTypes.add(typeInfo.getParquetType());
+      this.metadata.putAll(typeInfo.getMetadata());
+      fieldIndex.put(column.getName(), new Pair<>(column, parquetTypes.size() - 1));
+      if (!column.getNullable()) {
+        addNonNullableFieldName(column.getName());
+      }
+      this.statsMap.put(column.getName(), new RowBufferStats(column.getCollation()));
+
+      if (this.owningChannel.getOnErrorOption() == OpenChannelRequest.OnErrorOption.ABORT) {
+        this.tempStatsMap.put(column.getName(), new RowBufferStats(column.getCollation()));
+      }
+
+      id++;
+    }
+    schema = new MessageType(PARQUET_MESSAGE_TYPE_NAME, parquetTypes);
+  }
+
+  @Override
+  boolean hasColumn(String name) {
+    return fieldIndex.containsKey(name);
+  }
+
+  @Override
+  float addRow(
+      Map<String, Object> row,
+      int curRowIndex,
+      Map<String, RowBufferStats> statsMap,
+      Set<String> formattedInputColumnNames) {
+    return addRow(row, data, statsMap, formattedInputColumnNames);
+  }
+
+  @Override
+  float addTempRow(
+      Map<String, Object> row,
+      int curRowIndex,
+      Map<String, RowBufferStats> statsMap,
+      Set<String> formattedInputColumnNames) {
+    return addRow(row, tempData, statsMap, formattedInputColumnNames);
+  }
+
+  /**
+   * Adds a row to the parquet buffer.
+   *
+   * @param row row to add
+   * @param out internal buffer to add to
+   * @param statsMap column stats map
+   * @param inputColumnNames list of input column names after formatting
+   * @return row size
+   */
+  private float addRow(
+      Map<String, Object> row,
+      List<List<Object>> out,
+      Map<String, RowBufferStats> statsMap,
+      Set<String> inputColumnNames) {
+    Object[] indexedRow = new Object[fieldIndex.size()];
+    float size = 0F;
+    for (Map.Entry<String, Object> entry : row.entrySet()) {
+      String key = entry.getKey();
+      Object value = entry.getValue();
+      String columnName = formatColumnName(key);
+      int colIndex = fieldIndex.get(columnName).getSecond();
+      RowBufferStats stats = statsMap.get(columnName);
+      ColumnMetadata column = fieldIndex.get(columnName).getFirst();
+      ColumnDescriptor columnDescriptor = schema.getColumns().get(colIndex);
+      PrimitiveType.PrimitiveTypeName typeName =
+          columnDescriptor.getPrimitiveType().getPrimitiveTypeName();
+      ParquetValueParser.ParquetBufferValue valueWithSize =
+          ParquetValueParser.parseColumnValueToParquet(value, column, typeName, stats);
+      indexedRow[colIndex] = valueWithSize.getValue();
+      size += valueWithSize.getSize();
+    }
+    out.add(Arrays.asList(indexedRow));
+
+    for (String columnName : Sets.difference(this.fieldIndex.keySet(), inputColumnNames)) {
+      statsMap.get(columnName).incCurrentNullCount();
+    }
+    return size;
+  }
+
+  @Override
+  void moveTempRowsToActualBuffer(int tempRowCount) {
+    data.addAll(tempData);
+  }
+
+  @Override
+  void clearTempRows() {
+    tempData.clear();
+  }
+
+  @Override
+  boolean hasColumns() {
+    return !fieldIndex.isEmpty();
+  }
+
+  @Override
+  Optional<ParquetChunkData> getSnapshot() {
+    List<List<Object>> oldData = new ArrayList<>();
+    data.forEach(r -> oldData.add(new ArrayList<>(r)));
+    return oldData.isEmpty()
+        ? Optional.empty()
+        : Optional.of(new ParquetChunkData(oldData, metadata));
+  }
+
+  /** Used only for testing. */
+  @Override
+  Object getVectorValueAt(String column, int index) {
+    int colIndex = fieldIndex.get(column).getSecond();
+    Object value = data.get(index).get(colIndex);
+    ColumnMetadata columnMetadata = fieldIndex.get(column).getFirst();
+    String physicalTypeStr = columnMetadata.getPhysicalType();
+    ColumnPhysicalType physicalType = ColumnPhysicalType.valueOf(physicalTypeStr);
+    String logicalTypeStr = columnMetadata.getLogicalType();
+    ColumnLogicalType logicalType = ColumnLogicalType.valueOf(logicalTypeStr);
+    if (logicalType == ColumnLogicalType.FIXED) {
+      if (physicalType == ColumnPhysicalType.SB1) {
+        value = ((Integer) value).byteValue();
+      }
+      if (physicalType == ColumnPhysicalType.SB2) {
+        value = ((Integer) value).shortValue();
+      }
+      if (physicalType == ColumnPhysicalType.SB16) {
+        value = new BigDecimal(new BigInteger((byte[]) value), columnMetadata.getScale());
+      }
+    }
+    if (logicalType == ColumnLogicalType.BINARY && value != null) {
+      value = ((String) value).getBytes(StandardCharsets.UTF_8);
+    }
+    return value;
+  }
+
+  @Override
+  int getTempRowCount() {
+    return tempData.size();
+  }
+
+  @Override
+  void reset() {
+    super.reset();
+    data.clear();
+  }
+
+  @Override
+  public void close(String name) {
+    this.fieldIndex.clear();
+    logger.logInfo(
+        "Trying to close parquet buffer for channel={} from function={}",
+        this.owningChannel.getName(),
+        name);
+  }
+
+  @Override
+  public Flusher<ParquetChunkData> createFlusher(Constants.BdecVersion bdecVerion) {
+    return new ParquetFlusher(schema);
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.SFException;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
+
+/** Generates the Parquet types for the Snowflake's column types */
+public class ParquetTypeGenerator {
+
+  /**
+   * Util class that contains Parquet type and other metadata for that type needed by the Snowflake
+   * server side scanner
+   */
+  static class ParquetTypeInfo {
+    private Type parquetType;
+    private Map<String, String> metadata;
+
+    public Type getParquetType() {
+      return this.parquetType;
+    }
+
+    public Map<String, String> getMetadata() {
+      return this.metadata;
+    }
+
+    public void setParquetType(Type parquetType) {
+      this.parquetType = parquetType;
+    }
+
+    public void setMetadata(Map<String, String> metadata) {
+      this.metadata = metadata;
+    }
+  }
+
+  private static final Set<AbstractRowBuffer.ColumnPhysicalType> TIME_SUPPORTED_PHYSICAL_TYPES =
+      new HashSet<>(
+          Arrays.asList(
+              AbstractRowBuffer.ColumnPhysicalType.SB4, AbstractRowBuffer.ColumnPhysicalType.SB8));
+  private static final Set<AbstractRowBuffer.ColumnPhysicalType>
+      TIMESTAMP_SUPPORTED_PHYSICAL_TYPES =
+          new HashSet<>(
+              Arrays.asList(
+                  AbstractRowBuffer.ColumnPhysicalType.SB8,
+                  AbstractRowBuffer.ColumnPhysicalType.SB16));
+
+  /**
+   * Generate the column parquet type and metadata from the column metadata received from server
+   * side.
+   *
+   * @param column column metadata as received from server side
+   * @param id column id
+   * @return column parquet type
+   */
+  static ParquetTypeInfo generateColumnParquetTypeInfo(ColumnMetadata column, int id) {
+    ParquetTypeInfo res = new ParquetTypeInfo();
+    Type parquetType;
+    Map<String, String> metadata = new HashMap<>();
+    String name = column.getName();
+
+    AbstractRowBuffer.ColumnPhysicalType physicalType;
+    AbstractRowBuffer.ColumnLogicalType logicalType;
+    try {
+      physicalType = AbstractRowBuffer.ColumnPhysicalType.valueOf(column.getPhysicalType());
+      logicalType = AbstractRowBuffer.ColumnLogicalType.valueOf(column.getLogicalType());
+    } catch (IllegalArgumentException e) {
+      throw new SFException(
+          ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
+    }
+
+    metadata.put(Integer.toString(id), logicalType.getOrdinal() + "," + physicalType.getOrdinal());
+
+    // Parquet Type.Repetition in general supports repeated values for the same row column, like a
+    // list of values.
+    // This generator uses only either 0 or 1 value for nullable data type (OPTIONAL: 0 or none
+    // value if it is null)
+    // or exactly 1 value for non-nullable data type (REQUIRED)
+    Type.Repetition repetition =
+        column.getNullable() ? Type.Repetition.OPTIONAL : Type.Repetition.REQUIRED;
+
+    // Handle differently depends on the column logical and physical types
+    switch (logicalType) {
+      case FIXED:
+        parquetType = getFixedColumnParquetType(column, id, physicalType, repetition);
+        break;
+      case ARRAY:
+      case OBJECT:
+      case VARIANT:
+        // mark the column metadata as being an object json for the server side scanner
+        metadata.put(id + ":obj_enc", "1");
+        // parquetType is same as the next one
+      case ANY:
+      case CHAR:
+      case TEXT:
+      case BINARY:
+        parquetType =
+            Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition)
+                .as(LogicalTypeAnnotation.stringType())
+                .id(id)
+                .named(name);
+        break;
+      case TIMESTAMP_LTZ:
+      case TIMESTAMP_NTZ:
+      case TIMESTAMP_TZ:
+        parquetType =
+            getTimeColumnParquetType(
+                column.getScale(),
+                physicalType,
+                logicalType,
+                TIMESTAMP_SUPPORTED_PHYSICAL_TYPES,
+                repetition,
+                id,
+                name);
+        break;
+      case DATE:
+        parquetType =
+            Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
+                .as(LogicalTypeAnnotation.dateType())
+                .id(id)
+                .named(name);
+        break;
+      case TIME:
+        parquetType =
+            getTimeColumnParquetType(
+                column.getScale(),
+                physicalType,
+                logicalType,
+                TIME_SUPPORTED_PHYSICAL_TYPES,
+                repetition,
+                id,
+                name);
+        break;
+      case BOOLEAN:
+        parquetType =
+            Types.primitive(PrimitiveType.PrimitiveTypeName.BOOLEAN, repetition).id(id).named(name);
+        break;
+      case REAL:
+        parquetType =
+            Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, repetition).id(id).named(name);
+        break;
+      default:
+        throw new SFException(
+            ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
+    }
+    res.setParquetType(parquetType);
+    res.setMetadata(metadata);
+    return res;
+  }
+
+  /**
+   * Get the parquet type for column of Snowflake FIXED logical type.
+   *
+   * @param column column metadata
+   * @param id column id in Snowflake table schema
+   * @param physicalType Snowflake physical type of column
+   * @param repetition parquet repetition type of column
+   * @return column parquet type
+   */
+  private static Type getFixedColumnParquetType(
+      ColumnMetadata column,
+      int id,
+      AbstractRowBuffer.ColumnPhysicalType physicalType,
+      Type.Repetition repetition) {
+    String name = column.getName();
+    // the LogicalTypeAnnotation.DecimalLogicalTypeAnnotation is used by server side scanner
+    // to discover data type scale and precision
+    LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimalLogicalTypeAnnotation =
+        column.getScale() != null && column.getPrecision() != null
+            ? LogicalTypeAnnotation.DecimalLogicalTypeAnnotation.decimalType(
+                column.getScale(), column.getPrecision())
+            : null;
+    Type parquetType;
+    if ((column.getScale() != null && column.getScale() != 0)
+        || physicalType == AbstractRowBuffer.ColumnPhysicalType.SB16) {
+      parquetType =
+          Types.primitive(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, repetition)
+              .length(16)
+              .as(decimalLogicalTypeAnnotation)
+              .id(id)
+              .named(name);
+    } else {
+      switch (physicalType) {
+        case SB1:
+        case SB2:
+        case SB4:
+          parquetType =
+              Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition)
+                  .as(decimalLogicalTypeAnnotation)
+                  .id(id)
+                  .length(4)
+                  .named(name);
+          break;
+        case SB8:
+          parquetType =
+              Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition)
+                  .as(decimalLogicalTypeAnnotation)
+                  .id(id)
+                  .length(8)
+                  .named(name);
+          break;
+        default:
+          throw new SFException(
+              ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
+      }
+    }
+    return parquetType;
+  }
+
+  /**
+   * Get the parquet type for column of a Snowflake time logical type.
+   *
+   * @param scale column scale
+   * @param physicalType Snowflake physical type of column
+   * @param logicalType Snowflake logical type of column
+   * @param supportedPhysicalTypes supported Snowflake physical types for the given column
+   * @param repetition parquet repetition type of column
+   * @param id column id in Snowflake table schema
+   * @param name column name
+   * @return column parquet type
+   */
+  private static Type getTimeColumnParquetType(
+      Integer scale,
+      AbstractRowBuffer.ColumnPhysicalType physicalType,
+      AbstractRowBuffer.ColumnLogicalType logicalType,
+      Set<AbstractRowBuffer.ColumnPhysicalType> supportedPhysicalTypes,
+      Type.Repetition repetition,
+      int id,
+      String name) {
+    if (scale == null || scale > 9 || scale < 0 || !supportedPhysicalTypes.contains(physicalType)) {
+      throw new SFException(
+          ErrorCode.UNKNOWN_DATA_TYPE,
+          "Data type: " + logicalType + ", " + physicalType + ", scale: " + scale);
+    }
+
+    PrimitiveType.PrimitiveTypeName type = getTimePrimitiveType(physicalType);
+    LogicalTypeAnnotation typeAnnotation;
+    int length;
+    switch (physicalType) {
+      case SB4:
+        typeAnnotation = LogicalTypeAnnotation.decimalType(scale, 9);
+        length = 4;
+        break;
+      case SB8:
+        typeAnnotation = LogicalTypeAnnotation.decimalType(scale, 18);
+        length = 8;
+        break;
+      case SB16:
+        typeAnnotation = LogicalTypeAnnotation.decimalType(scale, 38);
+        length = 16;
+        break;
+      default:
+        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
+    }
+    return Types.primitive(type, repetition).as(typeAnnotation).length(length).id(id).named(name);
+  }
+
+  /**
+   * Get the parquet primitive type name for column of a Snowflake time logical type.
+   *
+   * @param physicalType Snowflake physical type of column
+   * @return column parquet primitive type name
+   */
+  private static PrimitiveType.PrimitiveTypeName getTimePrimitiveType(
+      AbstractRowBuffer.ColumnPhysicalType physicalType) {
+    PrimitiveType.PrimitiveTypeName type;
+    switch (physicalType) {
+      case SB4:
+        type = PrimitiveType.PrimitiveTypeName.INT32;
+        break;
+      case SB8:
+        type = PrimitiveType.PrimitiveTypeName.INT64;
+        break;
+      case SB16:
+        type = PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+        break;
+      default:
+        throw new UnsupportedOperationException("Time physical type: " + physicalType);
+    }
+    return type;
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.SFException;
+import net.snowflake.ingest.utils.Utils;
+import org.apache.parquet.schema.PrimitiveType;
+
+/** Parses a user column value into Parquet internal representation for buffering. */
+class ParquetValueParser {
+  /** Parquet internal value representation for buffering. */
+  static class ParquetBufferValue {
+    private final Object value;
+    private final float size;
+
+    ParquetBufferValue(Object value, float size) {
+      this.value = value;
+      this.size = size;
+    }
+
+    Object getValue() {
+      return value;
+    }
+
+    float getSize() {
+      return size;
+    }
+  }
+
+  /**
+   * Parses a user column value into Parquet internal representation for buffering.
+   *
+   * @param value column value provided by user in a row
+   * @param columnMetadata column metadata
+   * @param typeName Parquet primitive type name
+   * @param stats column stats to update
+   * @return parsed value and byte size of Parquet internal representation
+   */
+  static ParquetBufferValue parseColumnValueToParquet(
+      Object value,
+      ColumnMetadata columnMetadata,
+      PrimitiveType.PrimitiveTypeName typeName,
+      RowBufferStats stats) {
+    Utils.assertNotNull("Parquet column stats", stats);
+    float size = 0F;
+    if (value != null) {
+      AbstractRowBuffer.ColumnLogicalType logicalType =
+          AbstractRowBuffer.ColumnLogicalType.valueOf(columnMetadata.getLogicalType());
+      AbstractRowBuffer.ColumnPhysicalType physicalType =
+          AbstractRowBuffer.ColumnPhysicalType.valueOf(columnMetadata.getPhysicalType());
+      switch (typeName) {
+        case BOOLEAN:
+          int intValue = DataValidationUtil.validateAndParseBoolean(value);
+          value = intValue > 0;
+          stats.addIntValue(BigInteger.valueOf(intValue));
+          size = 1;
+          break;
+        case INT32:
+          int intVal =
+              getInt32Value(
+                  value,
+                  columnMetadata.getScale(),
+                  Optional.ofNullable(columnMetadata.getPrecision()).orElse(0),
+                  logicalType,
+                  physicalType);
+          value = intVal;
+          stats.addIntValue(BigInteger.valueOf(intVal));
+          size = 4;
+          break;
+        case INT64:
+          long longValue =
+              getInt64Value(
+                  value,
+                  columnMetadata.getScale(),
+                  Optional.ofNullable(columnMetadata.getPrecision()).orElse(0),
+                  logicalType,
+                  physicalType);
+          value = longValue;
+          stats.addIntValue(BigInteger.valueOf(longValue));
+          size = 8;
+          break;
+        case DOUBLE:
+          double doubleValue = DataValidationUtil.validateAndParseReal(value);
+          value = doubleValue;
+          stats.addRealValue(doubleValue);
+          size = 8;
+          break;
+        case BINARY:
+          String str = getBinaryValue(value, stats, columnMetadata);
+          value = str;
+          size = str.getBytes().length;
+          break;
+        case FIXED_LEN_BYTE_ARRAY:
+          BigInteger intRep =
+              getSb16Value(
+                  value,
+                  columnMetadata.getScale(),
+                  Optional.ofNullable(columnMetadata.getPrecision()).orElse(0),
+                  logicalType,
+                  physicalType);
+          stats.addIntValue(intRep);
+          value = getSb16Bytes(intRep);
+          size += 16;
+          break;
+        default:
+          throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
+      }
+    } else {
+      if (!columnMetadata.getNullable()) {
+        throw new SFException(
+            ErrorCode.INVALID_ROW, columnMetadata.getName(), "Passed null to non nullable field");
+      }
+      stats.incCurrentNullCount();
+    }
+    return new ParquetBufferValue(value, size);
+  }
+
+  /**
+   * Parses an int32 value based on Snowflake logical type.
+   *
+   * @param value column value provided by user in a row
+   * @param scale data type scale
+   * @param precision data type precision
+   * @param logicalType Snowflake logical type
+   * @param physicalType Snowflake physical type
+   * @return parsed int32 value
+   */
+  private static int getInt32Value(
+      Object value,
+      @Nullable Integer scale,
+      Integer precision,
+      AbstractRowBuffer.ColumnLogicalType logicalType,
+      AbstractRowBuffer.ColumnPhysicalType physicalType) {
+    int intVal;
+    switch (logicalType) {
+      case DATE:
+        intVal = DataValidationUtil.validateAndParseDate(value);
+        break;
+      case TIME:
+        Utils.assertNotNull("Unexpected null scale for TIME data type", scale);
+        intVal = DataValidationUtil.validateAndParseTime(value, scale).intValue();
+        break;
+      case FIXED:
+        BigDecimal bigDecimalValue = DataValidationUtil.validateAndParseBigDecimal(value);
+        bigDecimalValue = bigDecimalValue.setScale(scale, RoundingMode.HALF_UP);
+        DataValidationUtil.checkValueInRange(bigDecimalValue, scale, precision);
+        intVal = bigDecimalValue.intValue();
+        break;
+      default:
+        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
+    }
+    return intVal;
+  }
+
+  /**
+   * Parses an int64 value based on Snowflake logical type.
+   *
+   * @param value column value provided by user in a row
+   * @param scale data type scale
+   * @param precision data type precision
+   * @param logicalType Snowflake logical type
+   * @param physicalType Snowflake physical type
+   * @return parsed int64 value
+   */
+  private static long getInt64Value(
+      Object value,
+      int scale,
+      int precision,
+      AbstractRowBuffer.ColumnLogicalType logicalType,
+      AbstractRowBuffer.ColumnPhysicalType physicalType) {
+    long longValue;
+    switch (logicalType) {
+      case TIME:
+        Utils.assertNotNull("Unexpected null scale for TIME data type", scale);
+        longValue = DataValidationUtil.validateAndParseTime(value, scale).longValue();
+        break;
+      case TIMESTAMP_LTZ:
+      case TIMESTAMP_NTZ:
+        boolean ignoreTimezone = logicalType == AbstractRowBuffer.ColumnLogicalType.TIMESTAMP_NTZ;
+        longValue =
+            DataValidationUtil.validateAndParseTimestampNtzSb16(value, scale, ignoreTimezone)
+                .getTimeInScale()
+                .longValue();
+        break;
+      case TIMESTAMP_TZ:
+        longValue =
+            DataValidationUtil.validateAndParseTimestampTz(value, scale)
+                .getSfTimestamp()
+                .orElseThrow(
+                    () ->
+                        new SFException(
+                            ErrorCode.INVALID_ROW,
+                            value,
+                            "Unable to parse timestamp for TIMESTAMP_TZ column"))
+                .toBinary(scale, true)
+                .longValue();
+        break;
+      case FIXED:
+        BigDecimal bigDecimalValue = DataValidationUtil.validateAndParseBigDecimal(value);
+        bigDecimalValue = bigDecimalValue.setScale(scale, RoundingMode.HALF_UP);
+        DataValidationUtil.checkValueInRange(bigDecimalValue, scale, precision);
+        longValue = bigDecimalValue.longValue();
+        break;
+      default:
+        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
+    }
+    return longValue;
+  }
+
+  /**
+   * Parses an int128 value based on Snowflake logical type.
+   *
+   * @param value column value provided by user in a row
+   * @param scale data type scale
+   * @param precision data type precision
+   * @param logicalType Snowflake logical type
+   * @param physicalType Snowflake physical type
+   * @return parsed int64 value
+   */
+  private static BigInteger getSb16Value(
+      Object value,
+      int scale,
+      int precision,
+      AbstractRowBuffer.ColumnLogicalType logicalType,
+      AbstractRowBuffer.ColumnPhysicalType physicalType) {
+    switch (logicalType) {
+      case TIMESTAMP_TZ:
+        return DataValidationUtil.validateAndParseTimestampTz(value, scale)
+            .getSfTimestamp()
+            .orElseThrow(
+                () ->
+                    new SFException(
+                        ErrorCode.INVALID_ROW,
+                        value,
+                        "Unable to parse timestamp for TIMESTAMP_TZ column"))
+            .toBinary(scale, true);
+      case TIMESTAMP_LTZ:
+      case TIMESTAMP_NTZ:
+        boolean ignoreTimezone = logicalType == AbstractRowBuffer.ColumnLogicalType.TIMESTAMP_NTZ;
+        return DataValidationUtil.validateAndParseTimestampNtzSb16(value, scale, ignoreTimezone)
+            .getTimeInScale();
+      case FIXED:
+        BigDecimal bigDecimalValue = DataValidationUtil.validateAndParseBigDecimal(value);
+        // explicitly match the BigDecimal input scale with the Snowflake data type scale
+        bigDecimalValue = bigDecimalValue.setScale(scale, RoundingMode.HALF_UP);
+        DataValidationUtil.checkValueInRange(bigDecimalValue, scale, precision);
+        return bigDecimalValue.unscaledValue();
+      default:
+        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
+    }
+  }
+
+  /**
+   * Converts an int128 value to its byte array representation.
+   *
+   * @param intRep int128 value
+   * @return byte array representation
+   */
+  static byte[] getSb16Bytes(BigInteger intRep) {
+    byte[] bytes = intRep.toByteArray();
+    byte padByte = (byte) (bytes[0] < 0 ? -1 : 0);
+    byte[] bytesBE = new byte[16];
+    for (int i = 0; i < 16 - bytes.length; i++) {
+      bytesBE[i] = padByte;
+    }
+    System.arraycopy(bytes, 0, bytesBE, 16 - bytes.length, bytes.length);
+    return bytesBE;
+  }
+
+  /**
+   * Converts an object, string or binary value to its byte array representation.
+   *
+   * @param value value to parse
+   * @param stats column stats to update
+   * @param columnMetadata column metadata
+   * @return string (byte array) representation
+   */
+  private static String getBinaryValue(
+      Object value, RowBufferStats stats, ColumnMetadata columnMetadata) {
+    AbstractRowBuffer.ColumnLogicalType logicalType =
+        AbstractRowBuffer.ColumnLogicalType.valueOf(columnMetadata.getLogicalType());
+    String str;
+    if (logicalType.isObject()) {
+      switch (logicalType) {
+        case OBJECT:
+          str = DataValidationUtil.validateAndParseObject(value);
+          break;
+        case VARIANT:
+          str = DataValidationUtil.validateAndParseVariant(value);
+          break;
+        case ARRAY:
+          str = DataValidationUtil.validateAndParseArray(value);
+          break;
+        default:
+          throw new SFException(
+              ErrorCode.UNKNOWN_DATA_TYPE, logicalType, columnMetadata.getPhysicalType());
+      }
+    } else if (logicalType == AbstractRowBuffer.ColumnLogicalType.BINARY) {
+      String maxLengthString = columnMetadata.getLength().toString();
+      byte[] bytes =
+          DataValidationUtil.validateAndParseBinary(
+              value, Optional.of(maxLengthString).map(Integer::parseInt));
+      str = new String(bytes, StandardCharsets.UTF_8);
+      stats.addStrValue(str);
+    } else {
+      String maxLengthString = columnMetadata.getLength().toString();
+      str =
+          DataValidationUtil.validateAndParseString(
+              value, Optional.of(maxLengthString).map(Integer::parseInt));
+      stats.addStrValue(str);
+    }
+    return str;
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
@@ -25,7 +25,8 @@ import net.snowflake.ingest.utils.Utils;
  * Register one or more blobs to the targeted Snowflake table, it will be done using the dedicated
  * thread in order to maintain ordering per channel
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 class RegisterService<T> {
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBuffer.java
@@ -13,7 +13,8 @@ import net.snowflake.ingest.utils.Constants;
  * Interface for the buffer in the Streaming Ingest channel that holds the un-flushed rows, these
  * rows will be converted to the underlying format implementation for faster processing
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 interface RowBuffer<T> {
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -30,7 +30,8 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 /**
  * The first version of implementation for SnowflakeStreamingIngestChannel
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIngestChannel {
 
@@ -148,9 +149,20 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
     // TODO: The circular dependency SnowflakeStreamingIngestChannelInternal <-> RowBuffer
     // (SNOW-657667)
     // can be probably reconsidered
-    //noinspection unchecked
-    return (RowBuffer<T>)
-        new ArrowRowBuffer((SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot>) this);
+    switch (bdecVersion) {
+      case ONE:
+      case TWO:
+        //noinspection unchecked
+        return (RowBuffer<T>)
+            new ArrowRowBuffer((SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot>) this);
+      case THREE:
+        //noinspection unchecked
+        return (RowBuffer<T>)
+            new ParquetRowBuffer((SnowflakeStreamingIngestChannelInternal<ParquetChunkData>) this);
+      default:
+        throw new SFException(
+            ErrorCode.INTERNAL_ERROR, "Unsupported BDEC format version: " + bdecVersion);
+    }
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -82,7 +82,8 @@ import org.apache.arrow.memory.RootAllocator;
  * <li>the channel cache, which contains all the channels that belong to this account
  * <li>the flush service, which schedules and coordinates the flush to Snowflake tables
  *
- * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot})
+ * @param <T> type of column data (Arrow {@link org.apache.arrow.vector.VectorSchemaRoot} or {@link
+ *     ParquetChunkData})
  */
 public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStreamingIngestClient {
 
@@ -553,7 +554,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
                   .collect(Collectors.toList());
           if (!relevantChunks.isEmpty()) {
             retryBlobs.add(
-                new BlobMetadata(
+                BlobMetadata.createBlobMetadata(
                     blobMetadata.getPath(),
                     blobMetadata.getMD5(),
                     blobMetadata.getVersion(),

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -83,7 +83,14 @@ public class Constants {
     ONE(1),
 
     /** Uses Arrow to generate BDEC chunks with {@link ArrowBatchWriteMode#FILE}. */
-    TWO(2);
+    TWO(2),
+
+    /**
+     * Uses Parquet to generate BDEC chunks with {@link
+     * net.snowflake.ingest.streaming.internal.ParquetRowBuffer} (page-level compression). This
+     * version is experimental and WIP at the moment.
+     */
+    THREE(3);
 
     private final byte version;
 

--- a/src/test/java/net/snowflake/ingest/TestUtils.java
+++ b/src/test/java/net/snowflake/ingest/TestUtils.java
@@ -14,7 +14,6 @@ import static net.snowflake.ingest.utils.Constants.SSL;
 import static net.snowflake.ingest.utils.Constants.USER;
 import static net.snowflake.ingest.utils.Constants.WAREHOUSE;
 import static net.snowflake.ingest.utils.ParameterProvider.BLOB_FORMAT_VERSION;
-import static net.snowflake.ingest.utils.ParameterProvider.BLOB_FORMAT_VERSION_DEFAULT;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -35,6 +34,7 @@ import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMappe
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.Utils;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Assert;
@@ -180,7 +180,7 @@ public class TestUtils {
     return keyPair;
   }
 
-  public static Properties getProperties() throws Exception {
+  public static Properties getProperties(Constants.BdecVersion bdecVersion) throws Exception {
     if (profile == null) {
       init();
     }
@@ -195,14 +195,8 @@ public class TestUtils {
     props.put(PRIVATE_KEY, privateKeyPem);
     props.put(ROLE, role);
     props.put(ACCOUNT_URL, getAccountURL());
-    props.put(BLOB_FORMAT_VERSION, getBlobFormatVersion());
+    props.put(BLOB_FORMAT_VERSION, bdecVersion.toByte());
     return props;
-  }
-
-  private static byte getBlobFormatVersion() {
-    return profile.has(BLOB_FORMAT_VERSION)
-        ? (byte) profile.get(BLOB_FORMAT_VERSION).asInt()
-        : BLOB_FORMAT_VERSION_DEFAULT.toByte();
   }
 
   /**

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
@@ -57,15 +57,13 @@ public class ArrowBufferTest {
   @Test
   public void buildFieldFixedSB1() {
     // FIXED, SB1
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB1");
-    testCol.setNullable(true);
-    testCol.setLogicalType("FIXED");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB1")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -80,15 +78,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldFixedSB2() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB2");
-    testCol.setNullable(false);
-    testCol.setLogicalType("FIXED");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB2")
+            .nullable(false)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -103,15 +99,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldFixedSB4() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB4");
-    testCol.setNullable(true);
-    testCol.setLogicalType("FIXED");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB4")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -125,15 +119,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldFixedSB8() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB8");
-    testCol.setNullable(true);
-    testCol.setLogicalType("FIXED");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -147,15 +139,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldFixedSB16() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB16");
-    testCol.setNullable(true);
-    testCol.setLogicalType("FIXED");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     ArrowType expectedType =
@@ -172,15 +162,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldLobVariant() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("LOB");
-    testCol.setNullable(true);
-    testCol.setLogicalType("VARIANT");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("VARIANT")
+            .physicalType("LOB")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -194,15 +182,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldTimestampNtzSB8() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB8");
-    testCol.setNullable(true);
-    testCol.setLogicalType("TIMESTAMP_NTZ");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -216,15 +202,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldTimestampNtzSB16() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB16");
-    testCol.setNullable(true);
-    testCol.setLogicalType("TIMESTAMP_NTZ");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -242,15 +226,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldTimestampTzSB8() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB8");
-    testCol.setNullable(true);
-    testCol.setLogicalType("TIMESTAMP_TZ");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_TZ")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -268,15 +250,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldTimestampTzSB16() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB16");
-    testCol.setNullable(true);
-    testCol.setLogicalType("TIMESTAMP_TZ");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_TZ")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -295,16 +275,14 @@ public class ArrowBufferTest {
   }
 
   @Test
-  public void buildFieldDate() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB8");
-    testCol.setNullable(true);
-    testCol.setLogicalType("DATE");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+  public void buildFieldTimestampDate() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("DATE")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -318,15 +296,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldTimeSB4() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB4");
-    testCol.setNullable(true);
-    testCol.setLogicalType("TIME");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB4")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -340,15 +316,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldTimeSB8() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB8");
-    testCol.setNullable(true);
-    testCol.setLogicalType("TIME");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -362,15 +336,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldBoolean() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("BINARY");
-    testCol.setNullable(true);
-    testCol.setLogicalType("BOOLEAN");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("BOOLEAN")
+            .physicalType("BINARY")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());
@@ -384,15 +356,13 @@ public class ArrowBufferTest {
 
   @Test
   public void buildFieldRealSB16() {
-    ColumnMetadata testCol = new ColumnMetadata();
-    testCol.setName("testCol");
-    testCol.setPhysicalType("SB16");
-    testCol.setNullable(true);
-    testCol.setLogicalType("REAL");
-    testCol.setByteLength(14);
-    testCol.setLength(11);
-    testCol.setScale(0);
-    testCol.setPrecision(4);
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("REAL")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
     Assert.assertEquals("testCol", result.getName());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ColumnMetadataBuilder.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ColumnMetadataBuilder.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+/** Helper class to build ColumnMetadata */
+public class ColumnMetadataBuilder {
+  private String name;
+  private String type;
+  private String logicalType;
+  private String physicalType;
+  private Integer precision;
+  private Integer scale;
+  private Integer byteLength;
+  private Integer length;
+  private boolean nullable;
+  private String collation;
+
+  /**
+   * Returns a new ColumnMetadata builder
+   *
+   * @return builder
+   */
+  public static ColumnMetadataBuilder newBuilder() {
+    ColumnMetadataBuilder mb = new ColumnMetadataBuilder();
+    mb.name = "testCol";
+    mb.byteLength = 14;
+    mb.length = 11;
+    mb.scale = 0;
+    mb.precision = 4;
+    return mb;
+  }
+
+  /**
+   * Set name
+   *
+   * @param name column name
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Set type
+   *
+   * @param type type (as defined in ColumnMetadata)
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder type(String type) {
+    this.type = type;
+    return this;
+  }
+
+  /**
+   * Set column logical type
+   *
+   * @param logicalType logical type
+   * @return columnMetadata object
+   */
+  public ColumnMetadataBuilder logicalType(String logicalType) {
+    this.logicalType = logicalType;
+    return this;
+  }
+
+  /**
+   * Set column physical type
+   *
+   * @param physicalType physical type
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder physicalType(String physicalType) {
+    this.physicalType = physicalType;
+    return this;
+  }
+
+  /**
+   * Set column precision
+   *
+   * @param precision precision
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder precision(int precision) {
+    this.precision = precision;
+    return this;
+  }
+
+  /**
+   * Set column scale
+   *
+   * @param scale scale
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder scale(int scale) {
+    this.scale = scale;
+    return this;
+  }
+
+  /**
+   * Set column length in bytes
+   *
+   * @param byteLength length in bytes
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder byteLength(int byteLength) {
+    this.byteLength = byteLength;
+    return this;
+  }
+
+  /**
+   * Set column length (in chars)
+   *
+   * @param length length
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder length(int length) {
+    this.length = length;
+    return this;
+  }
+
+  /**
+   * Set column nullability
+   *
+   * @param nullable nullable
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder nullable(boolean nullable) {
+    this.nullable = nullable;
+    return this;
+  }
+
+  /**
+   * Set column collation
+   *
+   * @param collation collation
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder collation(String collation) {
+    this.collation = collation;
+    return this;
+  }
+
+  /**
+   * Build a columnMetadata object from the set values
+   *
+   * @return columnMetadata object
+   */
+  public ColumnMetadata build() {
+    ColumnMetadata colMetadata = new ColumnMetadata();
+    colMetadata.setName(name);
+    colMetadata.setType(type);
+    colMetadata.setPhysicalType(physicalType);
+    colMetadata.setNullable(nullable);
+    colMetadata.setLogicalType(logicalType);
+    colMetadata.setByteLength(byteLength);
+    colMetadata.setLength(length);
+    colMetadata.setScale(scale);
+    colMetadata.setPrecision(precision);
+    colMetadata.setCollation(collation);
+    return colMetadata;
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -55,7 +55,8 @@ import org.mockito.Mockito;
 public class FlushServiceTest {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> testContextFactory() {
-    return Arrays.asList(new Object[][] {{ArrowTestContext.createFactory()}});
+    return Arrays.asList(
+        new Object[][] {{ArrowTestContext.createFactory()}, {ParquetTestContext.createFactory()}});
   }
 
   public FlushServiceTest(TestContextFactory<?> testContextFactory) {
@@ -182,11 +183,6 @@ public class FlushServiceTest {
         return this;
       }
 
-      ChannelBuilder setOnErrorOption(OpenChannelRequest.OnErrorOption onErrorOption) {
-        this.onErrorOption = onErrorOption;
-        return this;
-      }
-
       SnowflakeStreamingIngestChannelInternal<T> buildAndAdd() {
         SnowflakeStreamingIngestChannelInternal<T> channel =
             createChannel(
@@ -280,6 +276,48 @@ public class FlushServiceTest {
         @Override
         TestContext<VectorSchemaRoot> create() {
           return new ArrowTestContext();
+        }
+      };
+    }
+  }
+
+  private static class ParquetTestContext extends TestContext<List<List<Object>>> {
+
+    SnowflakeStreamingIngestChannelInternal<List<List<Object>>> createChannel(
+        String name,
+        String dbName,
+        String schemaName,
+        String tableName,
+        String offsetToken,
+        Long channelSequencer,
+        Long rowSequencer,
+        String encryptionKey,
+        Long encryptionKeyId,
+        OpenChannelRequest.OnErrorOption onErrorOption) {
+      return new SnowflakeStreamingIngestChannelInternal<>(
+          name,
+          dbName,
+          schemaName,
+          tableName,
+          offsetToken,
+          channelSequencer,
+          rowSequencer,
+          client,
+          encryptionKey,
+          encryptionKeyId,
+          onErrorOption,
+          Constants.BdecVersion.THREE,
+          null);
+    }
+
+    @Override
+    public void close() {}
+
+    static TestContextFactory<List<List<Object>>> createFactory() {
+      return new TestContextFactory<List<List<Object>>>("Parquet") {
+        @Override
+        TestContext<List<List<Object>>> create() {
+          return new ParquetTestContext();
         }
       };
     }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetTypeGeneratorTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetTypeGeneratorTest.java
@@ -1,0 +1,480 @@
+package net.snowflake.ingest.streaming.internal;
+
+import java.util.Map;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ParquetTypeGeneratorTest {
+
+  @Test
+  public void buildFieldFixedSB1() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB1")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(4)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
+        .expectedLogicalTypeAnnotation(
+            LogicalTypeAnnotation.decimalType(testCol.getScale(), testCol.getPrecision()))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.FIXED.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB1.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldFixedSB2() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB2")
+            .nullable(false)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(4)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
+        .expectedLogicalTypeAnnotation(
+            LogicalTypeAnnotation.decimalType(testCol.getScale(), testCol.getPrecision()))
+        .expectedRepetition(Type.Repetition.REQUIRED)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.FIXED.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB2.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldFixedSB4() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB4")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(4)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
+        .expectedLogicalTypeAnnotation(
+            LogicalTypeAnnotation.decimalType(testCol.getScale(), testCol.getPrecision()))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.FIXED.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB4.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldFixedSB8() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(8)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
+        .expectedLogicalTypeAnnotation(
+            LogicalTypeAnnotation.decimalType(testCol.getScale(), testCol.getPrecision()))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.FIXED.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB8.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldFixedSB16() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(16)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+        .expectedLogicalTypeAnnotation(
+            LogicalTypeAnnotation.decimalType(testCol.getScale(), testCol.getPrecision()))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.FIXED.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB16.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldLobVariant() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("VARIANT")
+            .physicalType("LOB")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(0)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.BINARY)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.stringType())
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.VARIANT.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.LOB.getOrdinal())
+        .assertMatches();
+
+    Assert.assertEquals("1", typeInfo.getMetadata().get(0 + ":obj_enc"));
+  }
+
+  @Test
+  public void buildFieldTimestampNtzSB8() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(8)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 18))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.TIMESTAMP_NTZ.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB8.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldTimestampNtzSB16() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(16)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 38))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.TIMESTAMP_NTZ.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB16.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldTimestampTzSB8() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_TZ")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(8)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 18))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.TIMESTAMP_TZ.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB8.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldTimestampTzSB16() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_TZ")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(16)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 38))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.TIMESTAMP_TZ.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB16.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldDate() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("DATE")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(0)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.dateType())
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.DATE.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB8.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldTimeSB4() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB4")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(4)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 9))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.TIME.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB4.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldTimeSB8() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB8")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(8)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
+        .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 18))
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.TIME.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB8.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldBoolean() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("BOOLEAN")
+            .physicalType("BINARY")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(0)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.BOOLEAN)
+        .expectedLogicalTypeAnnotation(null)
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.BOOLEAN.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.BINARY.getOrdinal())
+        .assertMatches();
+  }
+
+  @Test
+  public void buildFieldRealSB16() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("REAL")
+            .physicalType("SB16")
+            .nullable(true)
+            .build();
+
+    ParquetTypeGenerator.ParquetTypeInfo typeInfo =
+        ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
+    ParquetTypeInfoAssertionBuilder.newBuilder()
+        .typeInfo(typeInfo)
+        .expectedFieldName("testCol")
+        .expectedFieldId(0)
+        .expectedTypeLength(0)
+        .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.DOUBLE)
+        .expectedLogicalTypeAnnotation(null)
+        .expectedRepetition(Type.Repetition.OPTIONAL)
+        .expectedColMetaData(
+            AbstractRowBuffer.ColumnLogicalType.REAL.getOrdinal()
+                + ","
+                + AbstractRowBuffer.ColumnPhysicalType.SB16.getOrdinal())
+        .assertMatches();
+  }
+
+  /** Builder that helps to assert parquet type info */
+  private static class ParquetTypeInfoAssertionBuilder {
+    private String fieldName;
+    private int fieldId;
+    private PrimitiveType.PrimitiveTypeName primitiveTypeName;
+    private LogicalTypeAnnotation logicalTypeAnnotation;
+    private Type.Repetition repetition;
+    private int typeLength;
+    private String colMetadata;
+    private ParquetTypeGenerator.ParquetTypeInfo typeInfo;
+
+    static ParquetTypeInfoAssertionBuilder newBuilder() {
+      ParquetTypeInfoAssertionBuilder builder = new ParquetTypeInfoAssertionBuilder();
+      return builder;
+    }
+
+    ParquetTypeInfoAssertionBuilder typeInfo(ParquetTypeGenerator.ParquetTypeInfo typeInfo) {
+      this.typeInfo = typeInfo;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedFieldName(String fieldName) {
+      this.fieldName = fieldName;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedFieldId(int fieldId) {
+      this.fieldId = fieldId;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedPrimitiveTypeName(
+        PrimitiveType.PrimitiveTypeName primitiveTypeName) {
+      this.primitiveTypeName = primitiveTypeName;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedLogicalTypeAnnotation(
+        LogicalTypeAnnotation logicalTypeAnnotation) {
+      this.logicalTypeAnnotation = logicalTypeAnnotation;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedRepetition(Type.Repetition repetition) {
+      this.repetition = repetition;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedTypeLength(int typeLength) {
+      this.typeLength = typeLength;
+      return this;
+    }
+
+    ParquetTypeInfoAssertionBuilder expectedColMetaData(String colMetaData) {
+      this.colMetadata = colMetaData;
+      return this;
+    }
+
+    void assertMatches() {
+      Type type = typeInfo.getParquetType();
+      Map<String, String> metadata = typeInfo.getMetadata();
+      Assert.assertEquals(fieldName, type.getName());
+      Assert.assertEquals(typeLength, type.asPrimitiveType().getTypeLength());
+      Assert.assertEquals(fieldId, type.asPrimitiveType().getId().intValue());
+
+      Assert.assertEquals(primitiveTypeName, type.asPrimitiveType().getPrimitiveTypeName());
+      Assert.assertEquals(logicalTypeAnnotation, type.getLogicalTypeAnnotation());
+      Assert.assertEquals(repetition, type.getRepetition());
+      Assert.assertEquals(colMetadata, metadata.get(type.getId().toString()));
+    }
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
@@ -1,0 +1,570 @@
+package net.snowflake.ingest.streaming.internal;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+import net.snowflake.ingest.utils.SFException;
+import org.apache.parquet.schema.PrimitiveType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ParquetValueParserTest {
+
+  @Test
+  public void parseValueFixedSB1ToInt32() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB1")
+            .scale(0)
+            .precision(2)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            12, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Integer.class)
+        .expectedParsedValue(12)
+        .expectedSize(4.0f)
+        .expectedMinMax(BigInteger.valueOf(12))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueFixedSB2ToInt32() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB2")
+            .scale(0)
+            .precision(4)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            1234, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Integer.class)
+        .expectedParsedValue(1234)
+        .expectedSize(4.0f)
+        .expectedMinMax(BigInteger.valueOf(1234))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueFixedSB4ToInt32() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB4")
+            .scale(0)
+            .precision(9)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            123456789, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Integer.class)
+        .expectedParsedValue(123456789)
+        .expectedSize(4.0f)
+        .expectedMinMax(BigInteger.valueOf(123456789))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueFixedSB8ToInt64() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB8")
+            .scale(0)
+            .precision(18)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            123456789987654321L, testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Long.class)
+        .expectedParsedValue(123456789987654321L)
+        .expectedSize(8.0f)
+        .expectedMinMax(BigInteger.valueOf(123456789987654321L))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueFixedSB16ToByteArray() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB16")
+            .scale(0)
+            .precision(38)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            new BigDecimal("91234567899876543219876543211234567891"),
+            testCol,
+            PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+            rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(byte[].class)
+        .expectedParsedValue(
+            ParquetValueParser.getSb16Bytes(
+                new BigInteger("91234567899876543219876543211234567891")))
+        .expectedSize(16.0f)
+        .expectedMinMax(new BigInteger("91234567899876543219876543211234567891"))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueFixedDecimalToInt32() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("FIXED")
+            .physicalType("SB8")
+            .scale(5)
+            .precision(10)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            new BigDecimal("12345.54321"),
+            testCol,
+            PrimitiveType.PrimitiveTypeName.DOUBLE,
+            rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Double.class)
+        .expectedParsedValue(Double.valueOf("12345.54321"))
+        .expectedSize(8.0f)
+        .expectedMinMax(Double.valueOf("12345.54321"))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueDouble() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("REAL")
+            .physicalType("DOUBLE")
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            12345.54321d, testCol, PrimitiveType.PrimitiveTypeName.DOUBLE, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Double.class)
+        .expectedParsedValue(Double.valueOf(12345.54321))
+        .expectedSize(8.0f)
+        .expectedMinMax(Double.valueOf(12345.54321))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueBoolean() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("BOOLEAN")
+            .physicalType("SB1")
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            true, testCol, PrimitiveType.PrimitiveTypeName.BOOLEAN, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Boolean.class)
+        .expectedParsedValue(true)
+        .expectedSize(1.0f)
+        .expectedMinMax(BigInteger.valueOf(1))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueBinary() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("BINARY")
+            .physicalType("LOB")
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "Length7".getBytes(), testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(String.class)
+        .expectedParsedValue("Length7")
+        .expectedSize(7.0f)
+        .expectedMinMax("Length7")
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueVariantToBinary() {
+    testJsonWithLogicalType("VARIANT");
+  }
+
+  @Test
+  public void parseValueObjectToBinary() {
+    testJsonWithLogicalType("OBJECT");
+  }
+
+  private void testJsonWithLogicalType(String logicalType) {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType(logicalType)
+            .physicalType("BINARY")
+            .nullable(true)
+            .build();
+
+    String var =
+        "{\"key1\":-879869596,\"key2\":\"value2\",\"key3\":null,"
+            + "\"key4\":{\"key41\":0.032437,\"key42\":\"value42\",\"key43\":null}}";
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(String.class)
+        .expectedParsedValue(var)
+        .expectedSize(var.getBytes().length)
+        .expectedMinMax(null)
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueArrayToBinary() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("ARRAY")
+            .physicalType("BINARY")
+            .nullable(true)
+            .build();
+
+    Map<String, String> input = new HashMap<>();
+    input.put("a", "1");
+    input.put("b", "2");
+    input.put("c", "3");
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            input, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
+
+    String resultArray = "[{\"a\":\"1\",\"b\":\"2\",\"c\":\"3\"}]";
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(String.class)
+        .expectedParsedValue(resultArray)
+        .expectedSize(resultArray.length())
+        .expectedMinMax(null)
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueTimestampNtzSB4Error() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB4")
+            .scale(0) // seconds
+            .precision(9)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    SFException exception =
+        Assert.assertThrows(
+            SFException.class,
+            () ->
+                ParquetValueParser.parseColumnValueToParquet(
+                    "2013-04-28 20:57:00",
+                    testCol,
+                    PrimitiveType.PrimitiveTypeName.INT32,
+                    rowBufferStats));
+    Assert.assertEquals(
+        "Unknown data type for logical: TIMESTAMP_NTZ, physical: SB4.", exception.getMessage());
+  }
+
+  @Test
+  public void parseValueTimestampNtzSB8ToINT64() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB8")
+            .scale(3) // millis
+            .precision(18)
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "2013-04-28 20:57:01.000",
+            testCol,
+            PrimitiveType.PrimitiveTypeName.INT64,
+            rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Long.class)
+        .expectedParsedValue(1367182621000L)
+        .expectedSize(8.0f)
+        .expectedMinMax(BigInteger.valueOf(1367182621000L))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueTimestampNtzSB16ToByteArray() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIMESTAMP_NTZ")
+            .physicalType("SB16")
+            .nullable(true)
+            .scale(9) // nanos
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "2022-09-18 22:05:07.123456789",
+            testCol,
+            PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+            rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(byte[].class)
+        .expectedParsedValue(
+            ParquetValueParser.getSb16Bytes(BigInteger.valueOf(1663538707123456789L)))
+        .expectedSize(16.0f)
+        .expectedMinMax(BigInteger.valueOf(1663538707123456789L))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueDateToInt32() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("DATE")
+            .physicalType("SB4")
+            .scale(0) // seconds
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "2021-01-01", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Integer.class)
+        .expectedParsedValue(Integer.valueOf(18628))
+        .expectedSize(4.0f)
+        .expectedMinMax(BigInteger.valueOf(18628))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueTimeSB4ToInt32() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB4")
+            .scale(0) // seconds
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "01:00:00", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Integer.class)
+        .expectedParsedValue(3600)
+        .expectedSize(4.0f)
+        .expectedMinMax(BigInteger.valueOf(3600))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueTimeSB8ToInt64() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB8")
+            .scale(3) // milliseconds
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    ParquetValueParser.ParquetBufferValue pv =
+        ParquetValueParser.parseColumnValueToParquet(
+            "01:00:00.123", testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats);
+
+    ParquetValueParserAssertionBuilder.newBuilder()
+        .parquetBufferValue(pv)
+        .rowBufferStats(rowBufferStats)
+        .expectedValueClass(Long.class)
+        .expectedParsedValue(3600123L)
+        .expectedSize(8.0f)
+        .expectedMinMax(BigInteger.valueOf(3600123))
+        .assertMatches();
+  }
+
+  @Test
+  public void parseValueTimeSB16Error() {
+    ColumnMetadata testCol =
+        ColumnMetadataBuilder.newBuilder()
+            .logicalType("TIME")
+            .physicalType("SB16")
+            .scale(9) // nanos
+            .nullable(true)
+            .build();
+
+    RowBufferStats rowBufferStats = new RowBufferStats();
+    SFException exception =
+        Assert.assertThrows(
+            SFException.class,
+            () ->
+                ParquetValueParser.parseColumnValueToParquet(
+                    "11:00:00.12345678",
+                    testCol,
+                    PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+                    rowBufferStats));
+    Assert.assertEquals(
+        "Unknown data type for logical: TIME, physical: SB16.", exception.getMessage());
+  }
+
+  /** Builder that helps to assert parsing of values to parquet types */
+  private static class ParquetValueParserAssertionBuilder {
+    private ParquetValueParser.ParquetBufferValue parquetBufferValue;
+    private RowBufferStats rowBufferStats;
+    private Class valueClass;
+    private Object value;
+    private float size;
+    private Object minMaxStat;
+
+    static ParquetValueParserAssertionBuilder newBuilder() {
+      ParquetValueParserAssertionBuilder builder = new ParquetValueParserAssertionBuilder();
+      return builder;
+    }
+
+    ParquetValueParserAssertionBuilder parquetBufferValue(
+        ParquetValueParser.ParquetBufferValue parquetBufferValue) {
+      this.parquetBufferValue = parquetBufferValue;
+      return this;
+    }
+
+    ParquetValueParserAssertionBuilder rowBufferStats(RowBufferStats rowBufferStats) {
+      this.rowBufferStats = rowBufferStats;
+      return this;
+    }
+
+    ParquetValueParserAssertionBuilder expectedValueClass(Class valueClass) {
+      this.valueClass = valueClass;
+      return this;
+    }
+
+    ParquetValueParserAssertionBuilder expectedParsedValue(Object value) {
+      this.value = value;
+      return this;
+    }
+
+    ParquetValueParserAssertionBuilder expectedSize(float size) {
+      this.size = size;
+      return this;
+    }
+
+    public ParquetValueParserAssertionBuilder expectedMinMax(Object minMaxStat) {
+      this.minMaxStat = minMaxStat;
+      return this;
+    }
+
+    void assertMatches() {
+      Assert.assertEquals(valueClass, parquetBufferValue.getValue().getClass());
+      System.out.println("parquetBufferValue = " + parquetBufferValue.getValue().toString());
+      if (valueClass.equals(byte[].class)) {
+        Assert.assertArrayEquals((byte[]) value, (byte[]) parquetBufferValue.getValue());
+      } else {
+        Assert.assertEquals(value, parquetBufferValue.getValue());
+      }
+      Assert.assertEquals(size, parquetBufferValue.getSize(), 0);
+      if (minMaxStat instanceof BigInteger) {
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMinIntValue());
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMaxIntValue());
+        return;
+      } else if (minMaxStat instanceof String || valueClass.equals(String.class)) {
+        // String can have null min/max stats for variant data types
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMinColStrValue());
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMaxColStrValue());
+        return;
+      } else if (minMaxStat instanceof Double || minMaxStat instanceof BigDecimal) {
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMinRealValue());
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMaxRealValue());
+        return;
+      }
+      throw new IllegalArgumentException("Unknown data type for min stat");
+    }
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -26,7 +26,11 @@ import org.junit.runners.Parameterized;
 public class RowBufferTest {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> bdecVersion() {
-    return Arrays.asList(new Object[][] {{"Arrow", Constants.BdecVersion.ONE}});
+    return Arrays.asList(
+        new Object[][] {
+          {"Arrow", Constants.BdecVersion.ONE},
+          {"Parquet", Constants.BdecVersion.THREE}
+        });
   }
 
   private final Constants.BdecVersion bdecVersion;
@@ -1029,6 +1033,7 @@ public class RowBufferTest {
     colBinary.setPhysicalType("LOB");
     colBinary.setNullable(true);
     colBinary.setLogicalType("BINARY");
+    colBinary.setLength(32);
     colBinary.setScale(0);
 
     innerBuffer.setupSchema(Collections.singletonList(colBinary));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -9,6 +9,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -19,12 +21,27 @@ import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.SFException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public abstract class AbstractDataTypeTest {
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> bdecVersion() {
+    return Arrays.asList(
+        new Object[][] {
+          {"Arrow", Constants.BdecVersion.ONE},
+          // TODO: uncomment once SNOW-659721 is deployed and we set the parameter
+          // DISABLE_PARQUET_CACHE to true for the test account
+          // {"Parquet", Constants.BdecVersion.THREE}
+        });
+  }
+
   private static final String SOURCE_COLUMN_NAME = "source";
   private static final String VALUE_COLUMN_NAME = "value";
 
@@ -52,6 +69,13 @@ public abstract class AbstractDataTypeTest {
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
+  private final Constants.BdecVersion bdecVersion;
+
+  public AbstractDataTypeTest(
+      @SuppressWarnings("unused") String name, Constants.BdecVersion bdecVersion) {
+    this.bdecVersion = bdecVersion;
+  }
+
   @Before
   public void before() throws Exception {
     databaseName = String.format("SDK_DATATYPE_COMPATIBILITY_IT_%s", randomString());
@@ -65,7 +89,13 @@ public abstract class AbstractDataTypeTest {
 
     conn.createStatement().execute(String.format("use warehouse %s;", TestUtils.getWarehouse()));
 
-    Properties props = TestUtils.getProperties();
+    if (bdecVersion == Constants.BdecVersion.THREE) {
+      // TODO: encryption and interleaved mode are not yet supported by server side's Parquet
+      // scanner if local file cache is enabled (SNOW-656500)
+      conn.createStatement().execute("alter session set disable_parquet_cache=true;");
+    }
+
+    Properties props = TestUtils.getProperties(bdecVersion);
     if (props.getProperty(ROLE).equals("DEFAULT_ROLE")) {
       props.setProperty(ROLE, "ACCOUNTADMIN");
     }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/BinaryIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/BinaryIT.java
@@ -1,9 +1,14 @@
 package net.snowflake.ingest.streaming.internal.datatypes;
 
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Ignore;
 import org.junit.Test;
 
 public class BinaryIT extends AbstractDataTypeTest {
+
+  public BinaryIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
 
   @Test
   public void testBinarySimple() throws Exception {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
@@ -8,6 +8,7 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -16,6 +17,10 @@ import org.junit.Test;
  * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats
  */
 public class DateTimeIT extends AbstractDataTypeTest {
+
+  public DateTimeIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
 
   @Test
   public void testTimestampWithTimeZone() throws Exception {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/LogicalTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/LogicalTypesIT.java
@@ -2,9 +2,15 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Test;
 
 public class LogicalTypesIT extends AbstractDataTypeTest {
+
+  public LogicalTypesIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
+
   @Test
   public void testLogicalTypes() throws Exception {
     // Test booleans

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NullIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NullIT.java
@@ -1,9 +1,15 @@
 package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.util.Arrays;
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Test;
 
 public class NullIT extends AbstractDataTypeTest {
+
+  public NullIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
+
   @Test
   public void testNullIngestion() throws Exception {
     for (String type :

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NumericTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NumericTypesIT.java
@@ -2,9 +2,15 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Test;
 
 public class NumericTypesIT extends AbstractDataTypeTest {
+
+  public NumericTypesIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
+
   @Test
   public void testIntegers() throws Exception {
     // test bytes

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -23,6 +24,10 @@ public class SemiStructuredIT extends AbstractDataTypeTest {
   // TODO SNOW-664249: There is a few-byte mismatch between the value sent by the user and its
   // server-side representation. Validation leaves a small buffer for this difference.
   private static final int MAX_ALLOWED_LENGTH = 16 * 1024 * 1024 - 64;
+
+  public SemiStructuredIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
 
   @Test
   public void testVariant() throws Exception {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
@@ -2,10 +2,16 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import net.snowflake.ingest.utils.Constants;
 import org.junit.Ignore;
 import org.junit.Test;
 
 public class StringsIT extends AbstractDataTypeTest {
+
+  public StringsIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
+
   @Test
   public void testStrings() throws Exception {
     testJdbcTypeCompatibility("VARCHAR", "", new StringProvider());


### PR DESCRIPTION
This PR re-introduces the Parquet generator. This time we use a build where `Hadoop 3` is patched in stable `parquet release 1.10` by Cloudera.

(Draft PR to test Snyk gates)