### PR TITLE
SNOW-663621 SNOW-682477 Fix incorrect strlen of non-ascii strings

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -454,7 +454,7 @@ class DataValidationUtil {
     }
     int maxLength = maxLengthOptional.orElse(BYTES_16_MB);
 
-    if (output.length() > maxLength) {
+    if (output.getBytes(StandardCharsets.UTF_8).length > maxLength) {
       throw valueFormatNotAllowedException(
           input,
           "STRING",

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -391,7 +391,7 @@ class RowBufferStats {
   }
 
   void addStrValue(String inputValue) {
-    this.setCurrentMaxLength(inputValue.getBytes().length);
+    this.setCurrentMaxLength(inputValue.getBytes(StandardCharsets.UTF_8).length);
     String value =
         inputValue.length() > MAX_LOB_LEN ? inputValue.substring(0, MAX_LOB_LEN) : inputValue;
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -391,7 +391,7 @@ class RowBufferStats {
   }
 
   void addStrValue(String inputValue) {
-    this.setCurrentMaxLength(inputValue.length());
+    this.setCurrentMaxLength(inputValue.getBytes().length);
     String value =
         inputValue.length() > MAX_LOB_LEN ? inputValue.substring(0, MAX_LOB_LEN) : inputValue;
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -325,7 +325,7 @@ public class DataValidationUtilTest {
     // Check max String length
     StringBuilder longBuilder = new StringBuilder();
     for (int i = 0; i < BYTES_16_MB; i++) {
-      longBuilder.append("č"); // max string length is measured in chars, not bytes
+      longBuilder.append("a");
     }
     String maxString = longBuilder.toString();
     Assert.assertEquals(maxString, validateAndParseString(maxString, Optional.empty()));
@@ -352,6 +352,28 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW, () -> validateAndParseString(new Object(), Optional.empty()));
     expectError(ErrorCode.INVALID_ROW, () -> validateAndParseString(new byte[] {}, Optional.of(4)));
     expectError(ErrorCode.INVALID_ROW, () -> validateAndParseString(new char[] {}, Optional.of(4)));
+  }
+
+  @Test
+  public void testValidateMultiByteString() {
+    // Test multi-byte string, total max allowed size is in bytes, not in characters
+    StringBuilder longBuilder = new StringBuilder();
+    for (int i = 0; i < BYTES_8_MB; i++) {
+      longBuilder.append("š"); // š is 2-byte unicode character
+    }
+    String maxString = longBuilder.toString();
+    Assert.assertEquals(maxString, validateAndParseString(maxString, Optional.empty()));
+
+    // max length - 1 should also succeed
+    longBuilder.setLength(BYTES_8_MB - 1);
+    String maxStringMinusOne = longBuilder.toString();
+    Assert.assertEquals(
+        maxStringMinusOne, validateAndParseString(maxStringMinusOne, Optional.empty()));
+
+    // max length + 1 should fail
+    expectError(
+        ErrorCode.INVALID_ROW,
+        () -> validateAndParseString(longBuilder.append("šš").toString(), Optional.empty()));
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -74,7 +74,9 @@ public abstract class AbstractDataTypeTest {
 
   @After
   public void after() throws Exception {
-    conn.createStatement().executeQuery(String.format("drop database %s", databaseName));
+    if (!debugMode()) {
+      conn.createStatement().executeQuery(String.format("drop database %s", databaseName));
+    }
     if (client != null) {
       client.close();
     }
@@ -92,7 +94,9 @@ public abstract class AbstractDataTypeTest {
             .replace(')', '_')
             .replace(',', '_');
 
-    //    System.out.printf("Creating table %s.%s.%s%n", databaseName, schemaName, tableName);
+    if (debugMode()) {
+      System.out.printf("Creating table %s.%s.%s%n", databaseName, schemaName, tableName);
+    }
     conn.createStatement()
         .execute(
             String.format(
@@ -309,5 +313,9 @@ public abstract class AbstractDataTypeTest {
     Assert.assertEquals(1, counter);
     Assert.assertEquals(objectMapper.readTree(expectedValue), objectMapper.readTree(value));
     Assert.assertEquals(expectedType, typeof);
+  }
+
+  protected boolean debugMode() {
+    return false;
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
@@ -2,7 +2,6 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class StringsIT extends AbstractDataTypeTest {
@@ -59,6 +58,13 @@ public class StringsIT extends AbstractDataTypeTest {
   public void testNonAsciiStrings() throws Exception {
     testIngestion(
         "VARCHAR", "ž, š, č, ř, c, j, ď, ť, ň", "ž, š, č, ř, c, j, ď, ť, ň", new StringProvider());
+    String times16 = "čččččččččččččččč";
+    String times17 = "ččččččččččččččččč";
+    testIngestion("VARCHAR", times16, times16, new StringProvider());
+    testIngestion("VARCHAR", times17, times17, new StringProvider());
+
+    String input = "❄❄❄öüß0öüä++ěšíáýšěčíáýřž+šáříé+ýšěáéíščžýříéě+ž❄❄❄";
+    testIngestion("VARCHAR", input, input, new StringProvider());
   }
 
   @Test
@@ -70,14 +76,14 @@ public class StringsIT extends AbstractDataTypeTest {
   }
 
   @Test
-  @Ignore("SNOW-663621")
-  public void testMaxAllowedMultibyteString() throws Exception {
-    String times16 = "čččččččččččččččč";
-    String times17 = "ččččččččččččččččč";
-    testIngestion("VARCHAR", times16, times16, new StringProvider()); // works fine
-    testIngestion("VARCHAR", times17, times17, new StringProvider()); // fails
-    //    expectArrowNotSupported("VARCHAR",
-    // maxAllowedMultibyteStringBuilder.append('a').toString());
+  public void testMaxAllowedMultiByteString() throws Exception {
+    // 'š' is a 2-byte unicode character
+    StringBuilder maxAllowedMultiByteStringBuilder = buildString('š', 8 * 1024 * 1024);
+    String maxAllowedMultiByteString = maxAllowedMultiByteStringBuilder.toString();
+    testIngestion(
+        "VARCHAR", maxAllowedMultiByteString, maxAllowedMultiByteString, new StringProvider());
+
+    expectArrowNotSupported("VARCHAR", maxAllowedMultiByteStringBuilder.append('a').toString());
   }
 
   private StringBuilder buildString(char character, int count) {


### PR DESCRIPTION
Snowflake expects the length of non-ascii strings to be the number of bytes, not the number of characters.