### PR TITLE
SNOW-637237 Thread-safe HTTP client initialisation

### DIFF
--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -51,6 +51,7 @@ public class HttpUtil {
   public static final String HTTP_PROXY_PASSWORD = "http.proxyPassword";
 
   private static final String PROXY_SCHEME = "http";
+  private static final Duration RETRY_INTERVAL = Duration.of(3, ChronoUnit.SECONDS);
   private static final int MAX_RETRIES = 3;
   private static volatile CloseableHttpClient httpClient;
 
@@ -198,7 +199,6 @@ public class HttpUtil {
       final int REQUEST_TIMEOUT = 408;
       final int TOO_MANY_REQUESTS = 429;
       final int SERVER_ERRORS = 500;
-      final Duration RETRY_INTERVAL = Duration.of(3, ChronoUnit.SECONDS);
 
       @Override
       public boolean retryRequest(

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -7,6 +7,8 @@ package net.snowflake.ingest.utils;
 import static net.snowflake.ingest.utils.Utils.isNullOrEmpty;
 
 import java.security.Security;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -196,6 +198,7 @@ public class HttpUtil {
       final int REQUEST_TIMEOUT = 408;
       final int TOO_MANY_REQUESTS = 429;
       final int SERVER_ERRORS = 500;
+      final Duration RETRY_INTERVAL = Duration.of(3, ChronoUnit.SECONDS);
 
       @Override
       public boolean retryRequest(
@@ -223,7 +226,7 @@ public class HttpUtil {
 
       @Override
       public long getRetryInterval() {
-        return 3000;
+        return RETRY_INTERVAL.toMillis();
       }
     };
   }


### PR DESCRIPTION
* Use double checked locking for HTTP client initialisation. 
* Remove state from `ServiceUnavailableRetryStrategy`