### PR TITLE
SNOW-684044 Fix nullability mismatch incidents

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -339,7 +339,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
 
     // Create the corresponding column field base on the column data type
     fieldType = new FieldType(column.getNullable(), arrowType, null, metadata);
-    return new Field(column.getName(), fieldType, children);
+    return new Field(column.normalizedName(), fieldType, children);
   }
 
   @Override

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ColumnMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ColumnMetadata.java
@@ -125,4 +125,12 @@ class ColumnMetadata {
     map.put("nullable", this.nullable);
     return map.toString();
   }
+
+  public String normalizedName() {
+    if (name.length() >= 2 && name.charAt(0) == '"' && name.charAt(name.length() - 1) == '"') {
+      return name.substring(1, name.length() - 1).replace("\"\"", "\"");
+    } else {
+      return name;
+    }
+  }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -534,7 +534,7 @@ public class RowBufferTest {
     InsertValidationResponse response = rowBuffer.insertRows(Collections.singletonList(row1), null);
     Assert.assertFalse(response.hasErrors());
 
-    Assert.assertEquals((byte) 10, rowBuffer.getVectorValueAt("\"colTinyInt\"", 0));
+    Assert.assertEquals((byte) 10, rowBuffer.getVectorValueAt("colTinyInt", 0));
     Assert.assertEquals((byte) 1, rowBuffer.getVectorValueAt("COLTINYINT", 0));
     Assert.assertEquals((short) 2, rowBuffer.getVectorValueAt("COLSMALLINT", 0));
     Assert.assertEquals(3, rowBuffer.getVectorValueAt("COLINT", 0));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -142,6 +142,10 @@ public abstract class AbstractDataTypeTest {
     }
   }
 
+  protected void migrateTable(String tableName) throws SQLException {
+    conn.createStatement().execute(String.format("alter table %s migrate;", tableName));
+  }
+
   protected <T> void expectNumberOutOfRangeError(
       String dataType, T value, int maxPowerOf10Exclusive) throws Exception {
     expectError(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/ColumnNameIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/ColumnNameIT.java
@@ -1,0 +1,63 @@
+package net.snowflake.ingest.streaming.internal.datatypes;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import net.snowflake.ingest.TestUtils;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests that it is possible to ingest into tables and columns, which have special and non-standard
+ * characters in their names.
+ */
+public class ColumnNameIT extends AbstractDataTypeTest {
+
+  @Test
+  public void testNonstandardTableAneColumnNames() throws Exception {
+    testName("foo");
+    testName("\"foo\"");
+    testName("\"fo o\"");
+    testName("\"alter\"");
+    testName("\"table\"");
+    testName("\"  \"");
+    testName("\"\"");
+    testName("\"a\"\"b\"");
+    testName("\"\"\"\"");
+    testName("\"  \"\"  \"\"  \"");
+    testName("\"  \"\" Ť \"\"  \"");
+  }
+
+  private void testName(String name) throws Exception {
+
+    conn.createStatement().execute(String.format("create table %s (%s int)", name, name));
+
+    String offset = UUID.randomUUID().toString();
+    int ingestedValue = 1;
+    SnowflakeStreamingIngestChannel channel = openChannel(name);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put(name, ingestedValue);
+    channel.insertRow(row, offset);
+
+    TestUtils.waitForOffset(channel, offset);
+    assertSingleRow(name, ingestedValue);
+
+    migrateTable(name);
+    assertSingleRow(name, ingestedValue);
+
+    channel.close().get();
+  }
+
+  private void assertSingleRow(String name, int value) throws SQLException {
+    ResultSet resultSet =
+        conn.createStatement()
+            .executeQuery(
+                String.format("select count(*) from %s where %s = %s", name, name, value));
+    Assert.assertTrue(resultSet.next());
+    Assert.assertEquals(1, resultSet.getInt(1));
+  }
+}


### PR DESCRIPTION
Nullability mismatch incidents were happening for columns with quoted names like "id". These fields were being stored in Arrow as "id", which XP did not understand, it expects just id.