### PR TITLE
SNOW-684474: Support adding a memory limit through the config file

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -271,7 +271,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
             error.setException(e);
             response.addError(error);
           } catch (Throwable e) {
-            logger.logWarn("Unexpected error happens during insertRows: {}", e.getMessage());
+            logger.logWarn("Unexpected error happens during insertRows: {}", e);
             error.setException(new SFException(e, ErrorCode.INTERNAL_ERROR, e.getMessage()));
             response.addError(error);
           }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -8,6 +8,7 @@ import static net.snowflake.ingest.utils.Constants.INSERT_THROTTLE_MAX_RETRY_COU
 import static net.snowflake.ingest.utils.Constants.LOW_RUNTIME_MEMORY_THRESHOLD_IN_BYTES;
 import static net.snowflake.ingest.utils.Constants.MAX_CHUNK_SIZE_IN_BYTES;
 import static net.snowflake.ingest.utils.Constants.RESPONSE_SUCCESS;
+import static net.snowflake.ingest.utils.ParameterProvider.MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT;
 
 import java.util.Collections;
 import java.util.List;
@@ -445,16 +446,29 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
         throw new SFException(ErrorCode.INTERNAL_ERROR, "Insert throttle get interrupted");
       }
     }
+    if (retry > 0) {
+      logger.logInfo(
+          "Insert throttled for a total of {} milliseconds, retryCount={}, client={}, channel={}",
+          retry * insertThrottleIntervalInMs,
+          retry,
+          this.owningClient.getName(),
+          getFullyQualifiedName());
+    }
   }
 
   /** Check whether we have a low runtime memory condition */
   private boolean hasLowRuntimeMemory(Runtime runtime) {
     int insertThrottleThresholdInPercentage =
         this.owningClient.getParameterProvider().getInsertThrottleThresholdInPercentage();
+    long maxMemoryLimitInBytes =
+        this.owningClient.getParameterProvider().getMaxMemoryLimitInBytes();
+    long maxMemory =
+        maxMemoryLimitInBytes == MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT
+            ? runtime.maxMemory()
+            : maxMemoryLimitInBytes;
     boolean hasLowRuntimeMemory =
         runtime.freeMemory() < LOW_RUNTIME_MEMORY_THRESHOLD_IN_BYTES
-            && runtime.freeMemory() * 100 / runtime.totalMemory()
-                < insertThrottleThresholdInPercentage;
+            && runtime.freeMemory() * 100 / maxMemory < insertThrottleThresholdInPercentage;
     if (hasLowRuntimeMemory) {
       logger.logWarn(
           "Throttled due to memory pressure, client={}, channel={}.",

--- a/src/main/java/net/snowflake/ingest/utils/Cryptor.java
+++ b/src/main/java/net/snowflake/ingest/utils/Cryptor.java
@@ -103,7 +103,7 @@ public class Cryptor {
     // Generate the derived key
     SecretKey derivedKey = deriveKey(encryptionKey, diversifier);
 
-    // Encrypt with zero IV
+    // Encrypt with the corresponding IV
     Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
     byte[] ivBytes = ByteBuffer.allocate(2 * Long.BYTES).putLong(0).putLong(iv).array();
     cipher.init(Cipher.ENCRYPT_MODE, derivedKey, new IvParameterSpec(ivBytes));

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -20,6 +20,7 @@ public class ParameterProvider {
   public static final String IO_TIME_CPU_RATIO = "IO_TIME_CPU_RATIO".toLowerCase();
   public static final String BLOB_UPLOAD_MAX_RETRY_COUNT =
       "BLOB_UPLOAD_MAX_RETRY_COUNT".toLowerCase();
+  public static final String MAX_MEMORY_LIMIT_IN_BYTES = "MAX_MEMORY_LIMIT_IN_BYTES".toLowerCase();
 
   // Default values
   public static final long BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT = 1000;
@@ -30,6 +31,7 @@ public class ParameterProvider {
   public static final Constants.BdecVersion BLOB_FORMAT_VERSION_DEFAULT = Constants.BdecVersion.ONE;
   public static final int IO_TIME_CPU_RATIO_DEFAULT = 2;
   public static final int BLOB_UPLOAD_MAX_RETRY_COUNT_DEFAULT = 24;
+  public static final int MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT = -1;
 
   /** Map of parameter name to parameter value. This will be set by client/configure API Call. */
   private final Map<String, Object> parameterMap = new HashMap<>();
@@ -108,6 +110,9 @@ public class ParameterProvider {
         BLOB_UPLOAD_MAX_RETRY_COUNT_DEFAULT,
         parameterOverrides,
         props);
+
+    this.updateValue(
+        MAX_MEMORY_LIMIT_IN_BYTES, MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT, parameterOverrides, props);
   }
 
   /** @return Longest interval in milliseconds between buffer flushes */
@@ -204,6 +209,17 @@ public class ParameterProvider {
       return Integer.parseInt(val.toString());
     }
     return (int) val;
+  }
+
+  /** @return The max memory limit in bytes */
+  public long getMaxMemoryLimitInBytes() {
+    Object val =
+        this.parameterMap.getOrDefault(
+            MAX_MEMORY_LIMIT_IN_BYTES, MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT);
+    if (val instanceof String) {
+      return Long.parseLong(val.toString());
+    }
+    return (long) val;
   }
 
   @Override

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -19,6 +19,7 @@ public class ParameterProviderTest {
     parameterMap.put(ParameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS, 7L);
     parameterMap.put(ParameterProvider.IO_TIME_CPU_RATIO, 10);
     parameterMap.put(ParameterProvider.BLOB_UPLOAD_MAX_RETRY_COUNT, 100);
+    parameterMap.put(ParameterProvider.MAX_MEMORY_LIMIT_IN_BYTES, 1000);
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
 
     Assert.assertEquals(3, parameterProvider.getBufferFlushIntervalInMs());
@@ -27,6 +28,7 @@ public class ParameterProviderTest {
     Assert.assertEquals(7, parameterProvider.getInsertThrottleIntervalInMs());
     Assert.assertEquals(10, parameterProvider.getIOTimeCpuRatio());
     Assert.assertEquals(100, parameterProvider.getBlobUploadMaxRetryCount());
+    Assert.assertEquals(1000, parameterProvider.getMaxMemoryLimitInBytes());
   }
 
   @Test
@@ -100,5 +102,8 @@ public class ParameterProviderTest {
     Assert.assertEquals(
         ParameterProvider.BLOB_UPLOAD_MAX_RETRY_COUNT_DEFAULT,
         parameterProvider.getBlobUploadMaxRetryCount());
+    Assert.assertEquals(
+        ParameterProvider.MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT,
+        parameterProvider.getMaxMemoryLimitInBytes());
   }
 }


### PR DESCRIPTION
- Support adding a memory limit per client through the config file
- Comparing the free memory with the max memory now instead of total memory for the throttling logic, assuming that the memory could grow to max memory