### PR TITLE
@snow SNOW-657667 Streaming ingest: factor out channel from the buffer

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -13,13 +13,16 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.Utils;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.VisibleForTesting;
 
 /**
@@ -147,14 +150,35 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
   // Current buffer size
   private volatile float bufferSize;
 
-  // Reference to the Streaming Ingest channel that owns this buffer
-  @VisibleForTesting final SnowflakeStreamingIngestChannelInternal<T> owningChannel;
-
   // Names of non-nullable columns
   private final Set<String> nonNullableFieldNames;
 
-  AbstractRowBuffer(SnowflakeStreamingIngestChannelInternal<T> channel) {
-    this.owningChannel = channel;
+  // buffer's channel fully qualified name with database, schema and table
+  final String channelFullyQualifiedName;
+
+  // metric callback to report size of inserted rows
+  private final Consumer<Float> rowSizeMetric;
+
+  // Allocator used to allocate the buffers
+  final BufferAllocator allocator;
+
+  // State of the owning channel
+  final ChannelRuntimeState channelState;
+
+  // ON_ERROR option for this channel
+  final OpenChannelRequest.OnErrorOption onErrorOption;
+
+  AbstractRowBuffer(
+      OpenChannelRequest.OnErrorOption onErrorOption,
+      BufferAllocator allocator,
+      String fullyQualifiedChannelName,
+      Consumer<Float> rowSizeMetric,
+      ChannelRuntimeState channelRuntimeState) {
+    this.onErrorOption = onErrorOption;
+    this.rowSizeMetric = rowSizeMetric;
+    this.channelState = channelRuntimeState;
+    this.channelFullyQualifiedName = fullyQualifiedChannelName;
+    this.allocator = allocator;
     this.nonNullableFieldNames = new HashSet<>();
     this.flushLock = new ReentrantLock();
     this.rowCount = 0;
@@ -256,7 +280,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
     InsertValidationResponse response = new InsertValidationResponse();
     this.flushLock.lock();
     try {
-      if (this.owningChannel.getOnErrorOption() == OpenChannelRequest.OnErrorOption.CONTINUE) {
+      if (onErrorOption == OpenChannelRequest.OnErrorOption.CONTINUE) {
         // Used to map incoming row(nth row) to InsertError(for nth row) in response
         long rowIndex = 0;
         for (Map<String, Object> row : rows) {
@@ -305,8 +329,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
                     RowBufferStats.getCombinedStats(stats, this.tempStatsMap.get(colName))));
       }
 
-      this.owningChannel.setOffsetToken(offsetToken);
-      this.owningChannel.collectRowSize(rowSize);
+      this.channelState.setOffsetToken(offsetToken);
+      this.rowSizeMetric.accept(rowSize);
     } finally {
       this.tempStatsMap.values().forEach(RowBufferStats::reset);
       clearTempRows();
@@ -324,7 +348,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
    */
   @Override
   public ChannelData<T> flush() {
-    logger.logDebug("Start get data for channel={}", this.owningChannel.getFullyQualifiedName());
+    logger.logDebug("Start get data for channel={}", channelFullyQualifiedName);
     if (this.rowCount > 0) {
       Optional<T> oldData = Optional.empty();
       int oldRowCount = 0;
@@ -334,8 +358,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       Map<String, RowBufferStats> oldColumnEps = null;
 
       logger.logDebug(
-          "Arrow buffer flush about to take lock on channel={}",
-          this.owningChannel.getFullyQualifiedName());
+          "Arrow buffer flush about to take lock on channel={}", channelFullyQualifiedName);
 
       this.flushLock.lock();
       try {
@@ -344,8 +367,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
           oldData = getSnapshot();
           oldRowCount = this.rowCount;
           oldBufferSize = this.bufferSize;
-          oldRowSequencer = this.owningChannel.incrementAndGetRowSequencer();
-          oldOffsetToken = this.owningChannel.getOffsetToken();
+          oldRowSequencer = this.channelState.incrementAndGetRowSequencer();
+          oldOffsetToken = this.channelState.getOffsetToken();
           oldColumnEps = new HashMap<>(this.statsMap);
           // Reset everything in the buffer once we save all the info
           reset();
@@ -356,7 +379,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
 
       logger.logDebug(
           "Arrow buffer flush released lock on channel={}, rowCount={}, bufferSize={}",
-          this.owningChannel.getFullyQualifiedName(),
+          channelFullyQualifiedName,
           oldRowCount,
           oldBufferSize);
 
@@ -365,10 +388,10 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
         data.setVectors(oldData.get());
         data.setRowCount(oldRowCount);
         data.setBufferSize(oldBufferSize);
-        data.setChannel(owningChannel);
         data.setRowSequencer(oldRowSequencer);
         data.setOffsetToken(oldOffsetToken);
         data.setColumnEps(oldColumnEps);
+        data.setFlusherFactory(this::createFlusher);
         return data;
       }
     }
@@ -462,5 +485,38 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       epInfo.getColumnEps().put(colName, dto);
     }
     return epInfo;
+  }
+
+  /** Row buffer factory. */
+  static <T> AbstractRowBuffer<T> createRowBuffer(
+      OpenChannelRequest.OnErrorOption onErrorOption,
+      BufferAllocator allocator,
+      Constants.BdecVersion bdecVersion,
+      String fullyQualifiedChannelName,
+      Consumer<Float> rowSizeMetric,
+      ChannelRuntimeState channelRuntimeState) {
+    switch (bdecVersion) {
+      case ONE:
+        //noinspection unchecked
+        return (AbstractRowBuffer<T>)
+            new ArrowRowBuffer(
+                onErrorOption,
+                allocator,
+                fullyQualifiedChannelName,
+                rowSizeMetric,
+                channelRuntimeState);
+      case THREE:
+        //noinspection unchecked
+        return (AbstractRowBuffer<T>)
+            new ParquetRowBuffer(
+                onErrorOption,
+                allocator,
+                fullyQualifiedChannelName,
+                rowSizeMetric,
+                channelRuntimeState);
+      default:
+        throw new SFException(
+            ErrorCode.INTERNAL_ERROR, "Unsupported BDEC format version: " + bdecVersion);
+    }
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowFlusher.java
@@ -37,7 +37,7 @@ public class ArrowFlusher implements Flusher<VectorSchemaRoot> {
     VectorSchemaRoot root = null;
     ArrowWriter arrowWriter = null;
     VectorLoader loader = null;
-    SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> firstChannel = null;
+    String firstChannelFullyQualifiedTableName = null;
     Map<String, RowBufferStats> columnEpStatsMapCombined = null;
 
     try {
@@ -45,7 +45,7 @@ public class ArrowFlusher implements Flusher<VectorSchemaRoot> {
         // Create channel metadata
         ChannelMetadata channelMetadata =
             ChannelMetadata.builder()
-                .setOwningChannel(data.getChannel())
+                .setOwningChannelFromContext(data.getChannelContext())
                 .setRowSequencer(data.getRowSequencer())
                 .setOffsetToken(data.getOffsetToken())
                 .build();
@@ -54,7 +54,7 @@ public class ArrowFlusher implements Flusher<VectorSchemaRoot> {
 
         logger.logDebug(
             "Start building channel={}, rowCount={}, bufferSize={} in blob={}",
-            data.getChannel().getFullyQualifiedName(),
+            data.getChannelContext().getFullyQualifiedName(),
             data.getRowCount(),
             data.getBufferSize(),
             filePath);
@@ -64,14 +64,15 @@ public class ArrowFlusher implements Flusher<VectorSchemaRoot> {
           root = data.getVectors();
           arrowWriter = new ArrowStreamWriter(root, null, chunkData);
           loader = new VectorLoader(root);
-          firstChannel = data.getChannel();
+          firstChannelFullyQualifiedTableName =
+              data.getChannelContext().getFullyQualifiedTableName();
           arrowWriter.start();
         } else {
           // This method assumes that channelsDataPerTable is grouped by table. We double check
           // here and throw an error if the assumption is violated
-          if (!data.getChannel()
+          if (!data.getChannelContext()
               .getFullyQualifiedTableName()
-              .equals(firstChannel.getFullyQualifiedTableName())) {
+              .equals(firstChannelFullyQualifiedTableName)) {
             throw new SFException(ErrorCode.INVALID_DATA_IN_CHUNK);
           }
 
@@ -91,7 +92,7 @@ public class ArrowFlusher implements Flusher<VectorSchemaRoot> {
 
         logger.logDebug(
             "Finish building channel={}, rowCount={}, bufferSize={} in blob={}",
-            data.getChannel().getFullyQualifiedName(),
+            data.getChannelContext().getFullyQualifiedName(),
             data.getRowCount(),
             data.getBufferSize(),
             filePath);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelData.java
@@ -6,6 +6,7 @@ package net.snowflake.ingest.streaming.internal;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 
@@ -21,8 +22,9 @@ class ChannelData<T> {
   private T vectors;
   private float bufferSize;
   private int rowCount;
-  private SnowflakeStreamingIngestChannelInternal<T> channel;
   private Map<String, RowBufferStats> columnEps;
+  private ChannelFlushContext channelFlushContext;
+  private Supplier<Flusher<T>> flusherFactory;
 
   // TODO performance test this vs in place update
   /**
@@ -104,16 +106,36 @@ class ChannelData<T> {
     this.bufferSize = bufferSize;
   }
 
-  SnowflakeStreamingIngestChannelInternal<T> getChannel() {
-    return this.channel;
+  public ChannelFlushContext getChannelContext() {
+    return channelFlushContext;
   }
 
-  void setChannel(SnowflakeStreamingIngestChannelInternal<T> channel) {
-    this.channel = channel;
+  public void setChannelContext(ChannelFlushContext channelFlushContext) {
+    this.channelFlushContext = channelFlushContext;
+  }
+
+  public Flusher<T> createFlusher() {
+    return flusherFactory.get();
+  }
+
+  public void setFlusherFactory(Supplier<Flusher<T>> flusherFactory) {
+    this.flusherFactory = flusherFactory;
   }
 
   @Override
   public String toString() {
-    return this.channel.toString();
+    return "ChannelData{"
+        + "rowSequencer="
+        + rowSequencer
+        + ", offsetToken='"
+        + offsetToken
+        + '\''
+        + ", bufferSize="
+        + bufferSize
+        + ", rowCount="
+        + rowCount
+        + ", channelContext="
+        + channelFlushContext
+        + '}';
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelFlushContext.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelFlushContext.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+/**
+ * Channel immutable identification and encryption attributes.
+ *
+ * <p>It is shared with the {@link ChannelData} and used for BDEC flush as well.
+ */
+class ChannelFlushContext {
+  private final String name;
+  private final String fullyQualifiedName;
+  private final String dbName;
+  private final String schemaName;
+  private final String tableName;
+  private final String fullyQualifiedTableName;
+
+  // Sequencer for this channel, corresponding to client sequencer at server side because each
+  // connection to a channel at server side will be seen as a connection from a new client
+  private final Long channelSequencer;
+
+  // Data encryption key
+  private final String encryptionKey;
+
+  // Data encryption key id
+  private final Long encryptionKeyId;
+
+  ChannelFlushContext(
+      String name,
+      String dbName,
+      String schemaName,
+      String tableName,
+      Long channelSequencer,
+      String encryptionKey,
+      Long encryptionKeyId) {
+    this.name = name;
+    this.fullyQualifiedName = String.format("%s.%s.%s.%s", dbName, schemaName, tableName, name);
+    this.dbName = dbName;
+    this.schemaName = schemaName;
+    this.tableName = tableName;
+    this.fullyQualifiedTableName =
+        String.format("%s.%s.%s", this.getDbName(), this.getSchemaName(), this.getTableName());
+    this.channelSequencer = channelSequencer;
+    this.encryptionKey = encryptionKey;
+    this.encryptionKeyId = encryptionKeyId;
+  }
+
+  @Override
+  public String toString() {
+    return "ChannelContext{"
+        + "name='"
+        + getName()
+        + '\''
+        + ", fullyQualifiedName='"
+        + getFullyQualifiedName()
+        + '\''
+        + ", dbName='"
+        + getDbName()
+        + '\''
+        + ", schemaName='"
+        + getSchemaName()
+        + '\''
+        + ", tableName='"
+        + getTableName()
+        + '\''
+        + ", fullyQualifiedTableName='"
+        + getFullyQualifiedTableName()
+        + '\''
+        + ", channelSequencer="
+        + getChannelSequencer()
+        + ", encryptionKey='"
+        + getEncryptionKey()
+        + '\''
+        + ", encryptionKeyId="
+        + getEncryptionKeyId()
+        + '}';
+  }
+
+  String getName() {
+    return name;
+  }
+
+  String getFullyQualifiedName() {
+    return fullyQualifiedName;
+  }
+
+  String getDbName() {
+    return dbName;
+  }
+
+  String getSchemaName() {
+    return schemaName;
+  }
+
+  String getTableName() {
+    return tableName;
+  }
+
+  String getFullyQualifiedTableName() {
+    return fullyQualifiedTableName;
+  }
+
+  Long getChannelSequencer() {
+    return channelSequencer;
+  }
+
+  String getEncryptionKey() {
+    return encryptionKey;
+  }
+
+  Long getEncryptionKeyId() {
+    return encryptionKeyId;
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelMetadata.java
@@ -29,9 +29,9 @@ class ChannelMetadata {
     private Long rowSequencer;
     @Nullable private String offsetToken; // offset token could be null
 
-    Builder setOwningChannel(SnowflakeStreamingIngestChannelInternal<?> channel) {
-      this.channelName = channel.getName();
-      this.clientSequencer = channel.getChannelSequencer();
+    Builder setOwningChannelFromContext(ChannelFlushContext channelFlushContext) {
+      this.channelName = channelFlushContext.getName();
+      this.clientSequencer = channelFlushContext.getChannelSequencer();
       return this;
     }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelRuntimeState.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelRuntimeState.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Internal state of channel that is used and mutated by both channel and its buffer. */
+class ChannelRuntimeState {
+  // Indicates whether the channel is still valid
+  private volatile boolean isValid;
+
+  // the channel's current offset token
+  private volatile String offsetToken;
+
+  // the channel's current row sequencer
+  private final AtomicLong rowSequencer;
+
+  ChannelRuntimeState(String offsetToken, long rowSequencer, boolean isValid) {
+    this.offsetToken = offsetToken;
+    this.rowSequencer = new AtomicLong(rowSequencer);
+    this.isValid = isValid;
+  }
+
+  /**
+   * Returns whether the channel is in a valid state.
+   *
+   * @return whether the channel is valid
+   */
+  boolean isValid() {
+    return isValid;
+  }
+
+  /** Invalidate the channel that has this state object. */
+  void invalidate() {
+    isValid = false;
+  }
+
+  /** @return current offset token */
+  String getOffsetToken() {
+    return offsetToken;
+  }
+
+  /** @return current offset token after first incrementing it by one. */
+  long incrementAndGetRowSequencer() {
+    return rowSequencer.incrementAndGet();
+  }
+
+  /** @return row sequencer of the channel. */
+  long getRowSequencer() {
+    return rowSequencer.get();
+  }
+
+  /**
+   * Updates the channel's offset token.
+   *
+   * @param offsetToken new offset token
+   */
+  void setOffsetToken(String offsetToken) {
+    this.offsetToken = offsetToken;
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChunkMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChunkMetadata.java
@@ -36,10 +36,10 @@ class ChunkMetadata {
     private EpInfo epInfo;
     private Long encryptionKeyId;
 
-    Builder setOwningTable(SnowflakeStreamingIngestChannelInternal channel) {
-      this.dbName = channel.getDBName();
-      this.schemaName = channel.getSchemaName();
-      this.tableName = channel.getTableName();
+    Builder setOwningTableFromChannelContext(ChannelFlushContext channelFlushContext) {
+      this.dbName = channelFlushContext.getDbName();
+      this.schemaName = channelFlushContext.getSchemaName();
+      this.tableName = channelFlushContext.getTableName();
       return this;
     }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -12,7 +12,6 @@ import static net.snowflake.ingest.utils.Constants.THREAD_SHUTDOWN_TIMEOUT_IN_SE
 import static net.snowflake.ingest.utils.Utils.getStackTrace;
 
 import com.codahale.metrics.Timer;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.security.InvalidAlgorithmParameterException;
@@ -34,14 +33,12 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.zip.CRC32;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
 import net.snowflake.client.jdbc.internal.google.common.util.concurrent.ThreadFactoryBuilder;
 import net.snowflake.ingest.utils.Constants;
-import net.snowflake.ingest.utils.Cryptor;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.Pair;
@@ -437,95 +434,12 @@ class FlushService<T> {
       throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException,
           NoSuchPaddingException, IllegalBlockSizeException, BadPaddingException,
           InvalidKeyException {
-    List<ChunkMetadata> chunksMetadataList = new ArrayList<>();
-    List<byte[]> chunksDataList = new ArrayList<>();
-    long curDataSize = 0L;
-    CRC32 crc = new CRC32();
     Timer.Context buildContext = Utils.createTimerContext(this.owningClient.buildLatency);
-
-    // TODO: channels with different schema can't be combined even if they belongs to same table
-    for (List<ChannelData<T>> channelsDataPerTable : blobData) {
-      ByteArrayOutputStream chunkData = new ByteArrayOutputStream();
-      SnowflakeStreamingIngestChannelInternal<T> firstChannel =
-          channelsDataPerTable.get(0).getChannel();
-
-      Flusher<T> flusher = firstChannel.getRowBuffer().createFlusher();
-      Flusher.SerializationResult result =
-          flusher.serialize(channelsDataPerTable, chunkData, filePath);
-
-      if (!result.channelsMetadataList.isEmpty()) {
-        Pair<byte[], Integer> compressionResult =
-            BlobBuilder.compressIfNeededAndPadChunk(
-                filePath,
-                chunkData,
-                Constants.ENCRYPTION_ALGORITHM_BLOCK_SIZE_BYTES,
-                bdecVersion == Constants.BdecVersion.ONE);
-        byte[] compressedAndPaddedChunkData = compressionResult.getFirst();
-        int compressedChunkLength = compressionResult.getSecond();
-
-        // Encrypt the compressed chunk data, the encryption key is derived using the key from
-        // server with the full blob path.
-        // We need to maintain IV as a block counter for the whole file, even interleaved,
-        // to align with decryption on the Snowflake query path.
-        // TODO: address alignment for the header SNOW-557866
-        long iv = curDataSize / Constants.ENCRYPTION_ALGORITHM_BLOCK_SIZE_BYTES;
-        byte[] encryptedCompressedChunkData =
-            Cryptor.encrypt(
-                compressedAndPaddedChunkData, firstChannel.getEncryptionKey(), filePath, iv);
-
-        // Compute the md5 of the chunk data
-        String md5 = BlobBuilder.computeMD5(encryptedCompressedChunkData, compressedChunkLength);
-        int encryptedCompressedChunkDataSize = encryptedCompressedChunkData.length;
-
-        // Create chunk metadata
-        long startOffset = curDataSize;
-        ChunkMetadata chunkMetadata =
-            ChunkMetadata.builder()
-                .setOwningTable(firstChannel)
-                // The start offset will be updated later in BlobBuilder#build to include the blob
-                // header
-                .setChunkStartOffset(startOffset)
-                // The compressedChunkLength is used because it is the actual data size used for
-                // decompression and md5 calculation on server side.
-                .setChunkLength(compressedChunkLength)
-                .setChannelList(result.channelsMetadataList)
-                .setChunkMD5(md5)
-                .setEncryptionKeyId(firstChannel.getEncryptionKeyId())
-                .setEpInfo(
-                    AbstractRowBuffer.buildEpInfoFromStats(
-                        result.rowCount, result.columnEpStatsMapCombined))
-                .build();
-
-        // Add chunk metadata and data to the list
-        chunksMetadataList.add(chunkMetadata);
-        chunksDataList.add(encryptedCompressedChunkData);
-        curDataSize += encryptedCompressedChunkDataSize;
-        crc.update(encryptedCompressedChunkData, 0, encryptedCompressedChunkDataSize);
-
-        logger.logInfo(
-            "Finish building chunk in blob={}, table={}, rowCount={}, startOffset={},"
-                + " uncompressedSize={}, compressedChunkLength={}, encryptedCompressedSize={},"
-                + " bdecVersion={}",
-            filePath,
-            firstChannel.getFullyQualifiedTableName(),
-            result.rowCount,
-            startOffset,
-            chunkData.size(),
-            compressedChunkLength,
-            encryptedCompressedChunkDataSize,
-            bdecVersion);
-      }
-    }
-
-    // Build blob file, and then upload to streaming ingest dedicated stage
-    byte[] blob =
-        BlobBuilder.build(
-            chunksMetadataList, chunksDataList, crc.getValue(), curDataSize, bdecVersion);
+    BlobBuilder.Blob blob = BlobBuilder.constructBlobAndMetadata(filePath, blobData, bdecVersion);
     if (buildContext != null) {
       buildContext.stop();
     }
-
-    return upload(filePath, blob, chunksMetadataList);
+    return upload(filePath, blob.blobBytes, blob.chunksMetadataList);
   }
 
   /**
@@ -647,11 +561,11 @@ class FlushService<T> {
                   this.owningClient
                       .getChannelCache()
                       .invalidateChannelIfSequencersMatch(
-                          channelData.getChannel().getDBName(),
-                          channelData.getChannel().getSchemaName(),
-                          channelData.getChannel().getTableName(),
-                          channelData.getChannel().getName(),
-                          channelData.getChannel().getChannelSequencer());
+                          channelData.getChannelContext().getDbName(),
+                          channelData.getChannelContext().getSchemaName(),
+                          channelData.getChannelContext().getTableName(),
+                          channelData.getChannelContext().getName(),
+                          channelData.getChannelContext().getChannelSequencer());
                 }));
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -53,7 +53,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       throws IOException {
     List<ChannelMetadata> channelsMetadataList = new ArrayList<>();
     long rowCount = 0L;
-    SnowflakeStreamingIngestChannelInternal<ParquetChunkData> firstChannel = null;
+    String firstChannelFullyQualifiedTableName = null;
     Map<String, RowBufferStats> columnEpStatsMapCombined = null;
     List<List<Object>> rows = null;
 
@@ -61,7 +61,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       // Create channel metadata
       ChannelMetadata channelMetadata =
           ChannelMetadata.builder()
-              .setOwningChannel(data.getChannel())
+              .setOwningChannelFromContext(data.getChannelContext())
               .setRowSequencer(data.getRowSequencer())
               .setOffsetToken(data.getOffsetToken())
               .build();
@@ -70,7 +70,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
 
       logger.logDebug(
           "Parquet Flusher: Start building channel={}, rowCount={}, bufferSize={} in blob={}",
-          data.getChannel().getFullyQualifiedName(),
+          data.getChannelContext().getFullyQualifiedName(),
           data.getRowCount(),
           data.getBufferSize(),
           filePath);
@@ -78,13 +78,13 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       if (rows == null) {
         columnEpStatsMapCombined = data.getColumnEps();
         rows = new ArrayList<>();
-        firstChannel = data.getChannel();
+        firstChannelFullyQualifiedTableName = data.getChannelContext().getFullyQualifiedTableName();
       } else {
         // This method assumes that channelsDataPerTable is grouped by table. We double check
         // here and throw an error if the assumption is violated
-        if (!data.getChannel()
+        if (!data.getChannelContext()
             .getFullyQualifiedTableName()
-            .equals(firstChannel.getFullyQualifiedTableName())) {
+            .equals(firstChannelFullyQualifiedTableName)) {
           throw new SFException(ErrorCode.INVALID_DATA_IN_CHUNK);
         }
 
@@ -97,7 +97,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
 
       logger.logDebug(
           "Parquet Flusher: Finish building channel={}, rowCount={}, bufferSize={} in blob={}",
-          data.getChannel().getFullyQualifiedName(),
+          data.getChannelContext().getFullyQualifiedName(),
           data.getRowCount(),
           data.getBufferSize(),
           filePath);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -693,19 +693,20 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
       for (int idx = 0; idx < channelsStatus.size(); idx++) {
         ChannelsStatusResponse.ChannelStatusResponseDTO channelStatus = channelsStatus.get(idx);
         SnowflakeStreamingIngestChannelInternal<?> channel = channels.get(idx);
+        long rowSequencer = channel.getChannelState().getRowSequencer();
         logger.logInfo(
             "Get channel status name={}, status={}, clientSequencer={}, rowSequencer={},"
                 + " offsetToken={}, persistedRowSequencer={}, persistedOffsetToken={}",
             channel.getName(),
             channelStatus.getStatusCode(),
             channel.getChannelSequencer(),
-            channel.getRowSequencer(),
-            channel.getOffsetToken(),
+            rowSequencer,
+            channel.getChannelState().getOffsetToken(),
             channelStatus.getPersistedRowSequencer(),
             channelStatus.getPersistedOffsetToken());
         if (channelStatus.getStatusCode() != RESPONSE_SUCCESS) {
           channelsWithError.add(channel);
-        } else if (!channelStatus.getPersistedRowSequencer().equals(channel.getRowSequencer())) {
+        } else if (!channelStatus.getPersistedRowSequencer().equals(rowSequencer)) {
           tempChannels.add(channel);
           tempChannelsStatus.add(channelStatus);
         }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
+import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -26,12 +27,9 @@ public class ArrowBufferTest {
   }
 
   ArrowRowBuffer createTestBuffer(OpenChannelRequest.OnErrorOption onErrorOption) {
-    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
-        new SnowflakeStreamingIngestClientInternal<>("client");
-    SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel =
-        new SnowflakeStreamingIngestChannelInternal<>(
-            "channel", "db", "schema", "table", "0", 0L, 0L, client, "key", 1234L, onErrorOption);
-    return new ArrowRowBuffer(channel);
+    ChannelRuntimeState initialState = new ChannelRuntimeState("0", 0L, true);
+    return new ArrowRowBuffer(
+        onErrorOption, new RootAllocator(), "test.buffer", rs -> {}, initialState);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -100,7 +100,9 @@ public class FlushServiceTest {
     }
 
     ChannelData<T> flushChannel(String name) {
-      ChannelData<T> channelData = channels.get(name).getRowBuffer().flush();
+      SnowflakeStreamingIngestChannelInternal<T> channel = channels.get(name);
+      ChannelData<T> channelData = channel.getRowBuffer().flush();
+      channelData.setChannelContext(channel.getChannelContext());
       this.channelData.add(channelData);
       return channelData;
     }
@@ -324,15 +326,13 @@ public class FlushServiceTest {
   }
 
   TestContextFactory<?> testContextFactory;
-  TestContext<?> testContext;
 
   @Before
   public void setup() {
     java.security.Security.addProvider(new BouncyCastleProvider());
-    testContext = testContextFactory.create();
   }
 
-  private SnowflakeStreamingIngestChannelInternal<?> addChannel1() {
+  private SnowflakeStreamingIngestChannelInternal<?> addChannel1(TestContext<?> testContext) {
     return testContext
         .channelBuilder("channel1")
         .setDBName("db1")
@@ -344,7 +344,7 @@ public class FlushServiceTest {
         .buildAndAdd();
   }
 
-  private SnowflakeStreamingIngestChannelInternal<?> addChannel2() {
+  private SnowflakeStreamingIngestChannelInternal<?> addChannel2(TestContext<?> testContext) {
     return testContext
         .channelBuilder("channel2")
         .setDBName("db1")
@@ -356,7 +356,7 @@ public class FlushServiceTest {
         .buildAndAdd();
   }
 
-  private SnowflakeStreamingIngestChannelInternal<?> addChannel3() {
+  private SnowflakeStreamingIngestChannelInternal<?> addChannel3(TestContext<?> testContext) {
     return testContext
         .channelBuilder("channel3")
         .setDBName("db2")
@@ -394,6 +394,7 @@ public class FlushServiceTest {
 
   @Test
   public void testGetFilePath() {
+    TestContext<?> testContext = testContextFactory.create();
     FlushService<?> flushService = testContext.flushService;
     Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
     String clientPrefix = "honk";
@@ -427,6 +428,7 @@ public class FlushServiceTest {
 
   @Test
   public void testFlush() throws Exception {
+    TestContext<?> testContext = testContextFactory.create();
     FlushService<?> flushService = testContext.flushService;
 
     // Nothing to flush
@@ -453,8 +455,9 @@ public class FlushServiceTest {
 
   @Test
   public void testBuildAndUpload() throws Exception {
-    SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1();
-    SnowflakeStreamingIngestChannelInternal<?> channel2 = addChannel2();
+    TestContext<?> testContext = testContextFactory.create();
+    SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1(testContext);
+    SnowflakeStreamingIngestChannelInternal<?> channel2 = addChannel2(testContext);
 
     List<ColumnMetadata> schema = Arrays.asList(createTestIntegerColumn(), createTestTextColumn());
     channel1.getRowBuffer().setupSchema(schema);
@@ -508,19 +511,19 @@ public class FlushServiceTest {
 
     ChannelMetadata expectedChannel1Metadata =
         ChannelMetadata.builder()
-            .setOwningChannel(channel1)
+            .setOwningChannelFromContext(channel1.getChannelContext())
             .setRowSequencer(1L)
             .setOffsetToken("offset1")
             .build();
     ChannelMetadata expectedChannel2Metadata =
         ChannelMetadata.builder()
-            .setOwningChannel(channel2)
+            .setOwningChannelFromContext(channel2.getChannelContext())
             .setRowSequencer(10L)
             .setOffsetToken("offset2")
             .build();
     ChunkMetadata expectedChunkMetadata =
         ChunkMetadata.builder()
-            .setOwningTable(channel1)
+            .setOwningTableFromChannelContext(channel1.getChannelContext())
             .setChunkStartOffset(0L)
             .setChunkLength(248)
             .setChannelList(Arrays.asList(expectedChannel1Metadata, expectedChannel2Metadata))
@@ -580,8 +583,9 @@ public class FlushServiceTest {
 
   @Test
   public void testBuildErrors() throws Exception {
-    SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1();
-    SnowflakeStreamingIngestChannelInternal<?> channel3 = addChannel3();
+    TestContext<?> testContext = testContextFactory.create();
+    SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1(testContext);
+    SnowflakeStreamingIngestChannelInternal<?> channel3 = addChannel3(testContext);
 
     List<ColumnMetadata> schema = Arrays.asList(createTestIntegerColumn(), createTestTextColumn());
     channel1.getRowBuffer().setupSchema(schema);
@@ -658,16 +662,18 @@ public class FlushServiceTest {
 
     ChannelData<StubChunkData> channel1Data = new ChannelData<>();
     ChannelData<StubChunkData> channel2Data = new ChannelData<>();
-    channel1Data.setChannel(channel1);
-    channel2Data.setChannel(channel1);
+    channel1Data.setChannelContext(channel1.getChannelContext());
+    channel2Data.setChannelContext(channel1.getChannelContext());
 
     channel1Data.setVectors(new StubChunkData());
     channel2Data.setVectors(new StubChunkData());
     innerData.add(channel1Data);
     innerData.add(channel2Data);
 
+    StreamingIngestStage stage = Mockito.mock(StreamingIngestStage.class);
+    Mockito.when(stage.getClientPrefix()).thenReturn("client_prefix");
     FlushService<StubChunkData> flushService =
-        new FlushService<>(client, channelCache, testContext.stage, false);
+        new FlushService<>(client, channelCache, stage, false);
     flushService.invalidateAllChannelsInBlob(blobData);
 
     Assert.assertFalse(channel1.isValid());
@@ -676,7 +682,8 @@ public class FlushServiceTest {
 
   @Test
   public void testBlobBuilder() throws Exception {
-    SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1();
+    TestContext<?> testContext = testContextFactory.create();
+    SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1(testContext);
 
     ObjectMapper mapper = new ObjectMapper();
     List<ChunkMetadata> chunksMetadataList = new ArrayList<>();
@@ -699,13 +706,13 @@ public class FlushServiceTest {
 
     ChannelMetadata channelMetadata =
         ChannelMetadata.builder()
-            .setOwningChannel(channel1)
+            .setOwningChannelFromContext(channel1.getChannelContext())
             .setRowSequencer(0L)
             .setOffsetToken("offset1")
             .build();
     ChunkMetadata chunkMetadata =
         ChunkMetadata.builder()
-            .setOwningTable(channel1)
+            .setOwningTableFromChannelContext(channel1.getChannelContext())
             .setChunkStartOffset(0L)
             .setChunkLength(dataSize)
             .setChannelList(Collections.singletonList(channelMetadata))
@@ -718,7 +725,7 @@ public class FlushServiceTest {
 
     final Constants.BdecVersion bdecVersion = ParameterProvider.BLOB_FORMAT_VERSION_DEFAULT;
     byte[] blob =
-        BlobBuilder.build(chunksMetadataList, chunksDataList, checksum, dataSize, bdecVersion);
+        BlobBuilder.buildBlob(chunksMetadataList, chunksDataList, checksum, dataSize, bdecVersion);
 
     // Read the blob byte array back to valid the behavior
     InputStream input = new ByteArrayInputStream(blob);
@@ -770,6 +777,7 @@ public class FlushServiceTest {
 
   @Test
   public void testShutDown() throws Exception {
+    TestContext<?> testContext = testContextFactory.create();
     FlushService<?> flushService = testContext.flushService;
 
     Assert.assertFalse(flushService.buildUploadWorkers.isShutdown());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -114,22 +114,9 @@ public class RowBufferTest {
   }
 
   private AbstractRowBuffer<?> createTestBuffer(OpenChannelRequest.OnErrorOption onErrorOption) {
-    return (AbstractRowBuffer<?>)
-        new SnowflakeStreamingIngestChannelInternal<>(
-                "channel",
-                "db",
-                "schema",
-                "table",
-                "0",
-                0L,
-                0L,
-                new SnowflakeStreamingIngestClientInternal<>("client"),
-                "key",
-                1234L,
-                onErrorOption,
-                bdecVersion,
-                new RootAllocator())
-            .getRowBuffer();
+    ChannelRuntimeState initialState = new ChannelRuntimeState("0", 0L, true);
+    return AbstractRowBuffer.createRowBuffer(
+        onErrorOption, new RootAllocator(), bdecVersion, "test.buffer", rs -> {}, initialState);
   }
 
   @Test
@@ -300,7 +287,7 @@ public class RowBufferTest {
     row.put("colDecimal", 1.23);
     row.put("colChar", "1111111111111111111111"); // too big
 
-    if (rowBuffer.owningChannel.getOnErrorOption() == OpenChannelRequest.OnErrorOption.CONTINUE) {
+    if (rowBuffer.onErrorOption == OpenChannelRequest.OnErrorOption.CONTINUE) {
       response = rowBuffer.insertRows(Collections.singletonList(row), null);
       Assert.assertTrue(response.hasErrors());
       Assert.assertEquals(1, response.getErrorRowCount());
@@ -568,7 +555,7 @@ public class RowBufferTest {
     row.put("COLTIMESTAMPLTZ_SB8", "1621899220");
     row.put("COLTIMESTAMPLTZ_SB16", "1621899220.1234567");
 
-    if (innerBuffer.owningChannel.getOnErrorOption() == OpenChannelRequest.OnErrorOption.CONTINUE) {
+    if (innerBuffer.onErrorOption == OpenChannelRequest.OnErrorOption.CONTINUE) {
       InsertValidationResponse response =
           innerBuffer.insertRows(Collections.singletonList(row), null);
       Assert.assertTrue(response.hasErrors());
@@ -882,7 +869,7 @@ public class RowBufferTest {
     Assert.assertFalse(response.hasErrors());
 
     row.put("COLBOOLEAN", null);
-    if (innerBuffer.owningChannel.getOnErrorOption() == OpenChannelRequest.OnErrorOption.CONTINUE) {
+    if (innerBuffer.onErrorOption == OpenChannelRequest.OnErrorOption.CONTINUE) {
       response = innerBuffer.insertRows(Collections.singletonList(row), "1");
       Assert.assertTrue(response.hasErrors());
       Assert.assertEquals(
@@ -929,7 +916,7 @@ public class RowBufferTest {
 
     Map<String, Object> row2 = new HashMap<>();
     row2.put("COLBOOLEAN2", true);
-    if (innerBuffer.owningChannel.getOnErrorOption() == OpenChannelRequest.OnErrorOption.CONTINUE) {
+    if (innerBuffer.onErrorOption == OpenChannelRequest.OnErrorOption.CONTINUE) {
       response = innerBuffer.insertRows(Collections.singletonList(row2), "2");
       Assert.assertTrue(response.hasErrors());
       InsertValidationResponse.InsertError error = response.getInsertErrors().get(0);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -111,9 +111,9 @@ public class SnowflakeStreamingIngestChannelTest {
     Assert.assertEquals(dbName, channel.getDBName());
     Assert.assertEquals(schemaName, channel.getSchemaName());
     Assert.assertEquals(tableName, channel.getTableName());
-    Assert.assertEquals(offsetToken, channel.getOffsetToken());
+    Assert.assertEquals(offsetToken, channel.getChannelState().getOffsetToken());
     Assert.assertEquals(channelSequencer, channel.getChannelSequencer());
-    Assert.assertEquals(rowSequencer + 1L, channel.incrementAndGetRowSequencer());
+    Assert.assertEquals(rowSequencer + 1L, channel.getChannelState().incrementAndGetRowSequencer());
     Assert.assertEquals(
         String.format("%s.%s.%s.%s", dbName, schemaName, tableName, name),
         channel.getFullyQualifiedName());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -454,9 +454,9 @@ public class SnowflakeStreamingIngestClientTest {
 
     ChannelMetadata channelMetadata =
         ChannelMetadata.builder()
-            .setOwningChannel(channel)
-            .setRowSequencer(channel.incrementAndGetRowSequencer())
-            .setOffsetToken(channel.getOffsetToken())
+            .setOwningChannelFromContext(channel.getChannelContext())
+            .setRowSequencer(channel.getChannelState().incrementAndGetRowSequencer())
+            .setOffsetToken(channel.getChannelState().getOffsetToken())
             .build();
 
     Map<String, RowBufferStats> columnEps = new HashMap<>();
@@ -465,7 +465,7 @@ public class SnowflakeStreamingIngestClientTest {
 
     ChunkMetadata chunkMetadata =
         ChunkMetadata.builder()
-            .setOwningTable(channel)
+            .setOwningTableFromChannelContext(channel.getChannelContext())
             .setChunkStartOffset(0L)
             .setChunkLength(100)
             .setChannelList(Collections.singletonList(channelMetadata))
@@ -506,27 +506,27 @@ public class SnowflakeStreamingIngestClientTest {
 
     ChannelMetadata channelMetadata1 =
         ChannelMetadata.builder()
-            .setOwningChannel(channel1)
-            .setRowSequencer(channel1.incrementAndGetRowSequencer())
-            .setOffsetToken(channel1.getOffsetToken())
+            .setOwningChannelFromContext(channel1.getChannelContext())
+            .setRowSequencer(channel1.getChannelState().incrementAndGetRowSequencer())
+            .setOffsetToken(channel1.getChannelState().getOffsetToken())
             .build();
     ChannelMetadata channelMetadata2 =
         ChannelMetadata.builder()
-            .setOwningChannel(channel2)
-            .setRowSequencer(channel2.incrementAndGetRowSequencer())
-            .setOffsetToken(channel2.getOffsetToken())
+            .setOwningChannelFromContext(channel2.getChannelContext())
+            .setRowSequencer(channel2.getChannelState().incrementAndGetRowSequencer())
+            .setOffsetToken(channel2.getChannelState().getOffsetToken())
             .build();
     ChannelMetadata channelMetadata3 =
         ChannelMetadata.builder()
-            .setOwningChannel(channel3)
-            .setRowSequencer(channel3.incrementAndGetRowSequencer())
-            .setOffsetToken(channel3.getOffsetToken())
+            .setOwningChannelFromContext(channel3.getChannelContext())
+            .setRowSequencer(channel3.getChannelState().incrementAndGetRowSequencer())
+            .setOffsetToken(channel3.getChannelState().getOffsetToken())
             .build();
     ChannelMetadata channelMetadata4 =
         ChannelMetadata.builder()
-            .setOwningChannel(channel4)
-            .setRowSequencer(channel4.incrementAndGetRowSequencer())
-            .setOffsetToken(channel4.getOffsetToken())
+            .setOwningChannelFromContext(channel4.getChannelContext())
+            .setRowSequencer(channel4.getChannelState().incrementAndGetRowSequencer())
+            .setOffsetToken(channel4.getChannelState().getOffsetToken())
             .build();
 
     List<BlobMetadata> blobs = new ArrayList<>();
@@ -538,7 +538,7 @@ public class SnowflakeStreamingIngestClientTest {
     channels1.add(channelMetadata2);
     ChunkMetadata chunkMetadata1 =
         ChunkMetadata.builder()
-            .setOwningTable(channel1)
+            .setOwningTableFromChannelContext(channel1.getChannelContext())
             .setChunkStartOffset(0L)
             .setChunkLength(100)
             .setChannelList(channels1)
@@ -548,7 +548,7 @@ public class SnowflakeStreamingIngestClientTest {
             .build();
     ChunkMetadata chunkMetadata2 =
         ChunkMetadata.builder()
-            .setOwningTable(channel2)
+            .setOwningTableFromChannelContext(channel2.getChannelContext())
             .setChunkStartOffset(0L)
             .setChunkLength(100)
             .setChannelList(Collections.singletonList(channelMetadata3))
@@ -558,7 +558,7 @@ public class SnowflakeStreamingIngestClientTest {
             .build();
     ChunkMetadata chunkMetadata3 =
         ChunkMetadata.builder()
-            .setOwningTable(channel3)
+            .setOwningTableFromChannelContext(channel3.getChannelContext())
             .setChunkStartOffset(0L)
             .setChunkLength(100)
             .setChannelList(Collections.singletonList(channelMetadata4))


### PR DESCRIPTION
[SNOW-657667](https://snowflakecomputing.atlassian.net/browse/SNOW-657667)

clean up refactoring of the circular dependencies:
channel -> buffer -> channel
channel -> chunk data -> channel
this allows to use buffer independently from channel and client, e.g. in tests and test file generator