### PR TITLE
SNOW-682477 Unicode and collations support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,8 @@
     <!-- Arifact name and version information -->
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-ingest-sdk</artifactId>
-    <version>1.0.2-beta.6</version>
+    <!-- TODO remove right before merge, must be here for now to trigger the new code path on the server -->
+    <version>1.0.2-beta.7</version>
     <packaging>jar</packaging>
     <name>Snowflake Ingest SDK</name>
     <description>Snowflake Ingest SDK</description>
@@ -201,7 +202,7 @@
         <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
-            <version>70.1</version>
+            <version>61.2</version> <!-- Must be the same as in GS and XP! -->
         </dependency>
 
         <!-- jwt token for key pair authentication with GS -->

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,17 @@
     <description>Snowflake Ingest SDK</description>
     <url>https://www.snowflake.net/</url>
 
+    <repositories>
+        <repository>
+            <id>Central</id>
+            <name>Internal Central Repo2</name>
+            <layout>default</layout>
+            <url>https://nexus.int.snowflakecomputing.com/repository/maven-central/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <licenses>
       <license>
@@ -198,13 +209,6 @@
             <version>3.13.15</version>
         </dependency>
 
-        <!-- String collation-->
-        <dependency>
-            <groupId>com.ibm.icu</groupId>
-            <artifactId>icu4j</artifactId>
-            <version>61.2</version> <!-- Must be the same as in GS and XP! -->
-        </dependency>
-
         <!-- jwt token for key pair authentication with GS -->
         <dependency>
             <groupId>com.nimbusds</groupId>
@@ -274,6 +278,18 @@
             <artifactId>powermock-core</artifactId>
             <version>2.0.2</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.snowflake</groupId>
+            <artifactId>snowflake-common</artifactId>
+            <version>5.1.6-lse2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.amazonaws</groupId>
+                    <artifactId>aws-java-sdk-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Apache Arrow -->

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -127,7 +127,8 @@ public class RequestBuilder {
   // Don't change!
   public static final String CLIENT_NAME = "SnowpipeJavaSDK";
 
-  public static final String DEFAULT_VERSION = "1.0.2-beta.6";
+  // TODO remove right before merge, must be here for now to trigger the new code path on the server
+  public static final String DEFAULT_VERSION = "1.0.2-beta.7";
 
   public static final String JAVA_USER_AGENT = "JAVA";
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -453,12 +453,13 @@ class DataValidationUtil {
           input.getClass(), "STRING", new String[] {"String", "Number", "boolean", "char"});
     }
     int maxLength = maxLengthOptional.orElse(BYTES_16_MB);
+    int byteLength = output.getBytes(StandardCharsets.UTF_8).length;
 
-    if (output.length() > maxLength) {
+    if (byteLength > maxLength) {
       throw valueFormatNotAllowedException(
           input,
           "STRING",
-          String.format("String too long: length=%d maxLength=%d", output.length(), maxLength));
+          String.format("String too long: length=%d maxLength=%d", byteLength, maxLength));
     }
     return output;
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
@@ -2,7 +2,10 @@ package net.snowflake.ingest.streaming.internal;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import org.apache.commons.codec.binary.Hex;
 
 /** Audit register endpoint/FileColumnPropertyDTO property list. */
 class FileColumnProperties {
@@ -41,6 +44,8 @@ class FileColumnProperties {
   // Default value to use for min/max real when all data in the given column is NULL
   public static final Double DEFAULT_MIN_MAX_REAL_VAL_FOR_EP = 0d;
 
+  private static final int MAX_LOB_LEN = 32;
+
   FileColumnProperties(RowBufferStats stats) {
     this.setCollation(stats.getCollationDefinitionString());
     this.setMaxIntValue(
@@ -61,12 +66,34 @@ class FileColumnProperties {
             : stats.getCurrentMaxRealValue());
     this.setMaxLength(stats.getCurrentMaxLength());
 
-    // Collated and non-collated strings are intentionally equal here as required by Snowflake
-    this.setMaxStrNonCollated(stats.getCurrentMaxColStrValue());
-    this.setMinStrNonCollated(stats.getCurrentMinColStrValue());
+    // current hex-encoded non-collated min value. If it is longer than 32 bytes, it is null.
+    // No truncation is happening here.
+    if (stats.getCurrentMinNonColStrValue() != null) {
+      byte[] minNonCollated = stats.getCurrentMinNonColStrValue().getBytes(StandardCharsets.UTF_8);
+      this.setMinStrNonCollated(
+          minNonCollated.length > 32 ? null : truncateBytesAsHex(minNonCollated, false));
+    }
 
-    this.setMaxStrValue(stats.getCurrentMaxColStrValue());
-    this.setMinStrValue(stats.getCurrentMinColStrValue());
+    // current hex-encoded non-collated max value. If it is longer than 32 bytes, it is null.
+    // No truncation is happening here.
+    if (stats.getCurrentMaxNonColStrValue() != null) {
+      byte[] maxNonCollated = stats.getCurrentMaxNonColStrValue().getBytes(StandardCharsets.UTF_8);
+      this.setMaxStrNonCollated(
+          maxNonCollated.length > 32 ? null : truncateBytesAsHex(maxNonCollated, true));
+    }
+
+    // current hex-encoded collated min value, truncated down to 32 bytes
+    if (stats.getCurrentMinColStrValueInBytes() != null) {
+      String truncatedAsHex = truncateBytesAsHex(stats.getCurrentMinColStrValueInBytes(), false);
+      this.setMinStrValue(truncatedAsHex);
+    }
+
+    // current hex-encoded collated max value, truncated up to 32 bytes
+    if (stats.getCurrentMaxColStrValueInBytes() != null) {
+      String truncatedAsHex = truncateBytesAsHex(stats.getCurrentMaxColStrValueInBytes(), true);
+      this.setMaxStrValue(truncatedAsHex);
+    }
+
     this.setNullCount(stats.getCurrentNullCount());
     this.setDistinctValues(stats.getDistinctValues());
   }
@@ -237,5 +264,32 @@ class FileColumnProperties {
         distinctValues,
         nullCount,
         maxLength);
+  }
+
+  /** XP-compatible string truncation (FdnColDataContainer::Metrics::updateStrMinMax) */
+  static String truncateBytesAsHex(byte[] bytes, boolean truncateUp) {
+    if (bytes.length <= MAX_LOB_LEN) {
+      return Hex.encodeHexString(bytes);
+    }
+
+    // Round the least significant byte(s) up
+    if (truncateUp) {
+      int idx;
+      for (idx = MAX_LOB_LEN - 1; idx >= 0; idx--) {
+        if (++bytes[idx] != 0) {
+          break;
+        }
+      }
+      // Whole prefix overflew, return infinity
+      if (idx == -1) {
+        // Switch full prefix back to 0xff
+        for (int i = 0; i < MAX_LOB_LEN; i++) {
+          bytes[i] = -1;
+        }
+        return Hex.encodeHexString(ByteBuffer.wrap(bytes, 0, MAX_LOB_LEN + 1));
+      }
+    }
+
+    return Hex.encodeHexString(ByteBuffer.wrap(bytes, 0, MAX_LOB_LEN));
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -4,15 +4,9 @@
 
 package net.snowflake.ingest.streaming.internal;
 
-import com.ibm.icu.lang.UCharacter;
-import com.ibm.icu.text.CollationKey;
-import com.ibm.icu.text.Collator;
-import com.ibm.icu.util.ULocale;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Objects;
-
 import net.snowflake.common.core.CollationDefinitionBase;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -7,6 +7,9 @@ package net.snowflake.ingest.streaming.internal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+
+import com.ibm.icu.text.Collator;
+import com.ibm.icu.util.VersionInfo;
 import net.snowflake.common.core.CollationDefinitionBase;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
@@ -14,6 +17,7 @@ import net.snowflake.ingest.utils.SFException;
 /** Keeps track of the active EP stats, used to generate a file EP info */
 class RowBufferStats {
 
+  private static final VersionInfo EXPECTED_ICU_VERSION_INFO = VersionInfo.getInstance(61, 2, 0, 0);
   private String currentMinNonColStrValue;
   private String currentMaxNonColStrValue;
   private byte[] currentMinColStrValueInBytes;
@@ -32,6 +36,9 @@ class RowBufferStats {
   RowBufferStats(String collationDefinitionString) {
     this.collationDefinitionString = collationDefinitionString;
     if (collationDefinitionString != null) {
+      if (VersionInfo.ICU_VERSION.compareTo(EXPECTED_ICU_VERSION_INFO) != 0) {
+        throw new IllegalStateException(String.format("Unexpected version of ICU library found (Found=%s Expected=%s)", VersionInfo.ICU_VERSION, EXPECTED_ICU_VERSION_INFO));
+      }
       this.collationDefinition = new CollationDefinitionBase(collationDefinitionString, true);
     }
     reset();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -12,286 +12,13 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
+
+import net.snowflake.common.core.CollationDefinitionBase;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 
 /** Keeps track of the active EP stats, used to generate a file EP info */
 class RowBufferStats {
-  private static class CollationDefinition {
-    /** The name of this collation */
-    private String name;
-
-    /** Derived ICU collation name */
-    private String icuCollationString = null;
-
-    /** Defines if a given collation trims strings on the left side */
-    private boolean ltrim = false;
-
-    /** Defines if a given collation trims strings on the right side */
-    private boolean rtrim = false;
-
-    /** Defines if a given collation applies "lower" before comparison */
-    private boolean lower = false;
-
-    /** Defines if a given collation applies "upper" before comparison */
-    private boolean upper = false;
-
-    /** If true or null, the collation is case sensitive */
-    private Boolean caseSensitive = null;
-
-    /** If true or null, the collation is accent sensitive */
-    private Boolean accentSensitive = null;
-
-    /** If true or null, the collation is punctuation sensitive */
-    private Boolean punctuationSensitive = null;
-
-    /**
-     * Defines if a given collation is forced, i.e. goes through the full collation pipeline even if
-     * not strictly needed (i.e. UTF8)
-     */
-    private boolean forced = false;
-
-    private static String LANG_UTF8 = "utf8";
-    private static final String LANG_BIN = "bin";
-    private static final String LANG_EMPTY = "";
-
-    /** Language, e.g. "en_EN". LANG_UTF8 is the default */
-    private String language = LANG_UTF8;
-
-    private Collator collator;
-
-    /** Constructor - only called internally */
-    public CollationDefinition(String name) {
-      name = name.toLowerCase();
-      this.name = name;
-
-      // Empty collation is UTF8, treat it as such
-      if (name.isEmpty()) {
-        name = LANG_UTF8;
-      }
-
-      /** Language, e.g. "en_EN". LANG_UTF8 is the default */
-      String lang = LANG_UTF8;
-
-      // Variables used to construct the ICU string
-      boolean firstLower = false;
-      boolean firstLowerIsSet = false;
-
-      // Parse the collation as a sequence of "-" divided options
-      String[] elements = name.split("-");
-      assert (elements.length > 0); // empty string detected earlier
-
-      // Then other options
-      for (int i = 0; i < elements.length; i++) {
-        switch (elements[i]) {
-            // ICU options
-          case "ci":
-            caseSensitive = false;
-            break;
-          case "cs":
-            caseSensitive = true;
-            break;
-          case "ai":
-            accentSensitive = false;
-            break;
-          case "as":
-            accentSensitive = true;
-            break;
-          case "pi":
-            punctuationSensitive = false;
-            break;
-          case "ps":
-            punctuationSensitive = true;
-            break;
-          case "fu":
-            firstLower = false;
-            firstLowerIsSet = true;
-            break;
-          case "fl":
-            firstLower = true;
-            firstLowerIsSet = true;
-            break;
-            // Snowflake-specific options
-          case "lower":
-            lower = true;
-            break;
-          case "upper":
-            upper = true;
-            break;
-          case "rtrim":
-            rtrim = true;
-            break;
-          case "ltrim":
-            ltrim = true;
-            break;
-          case "trim":
-            ltrim = rtrim = true;
-            break;
-          case "forced":
-            forced = true;
-            break;
-          default:
-            // Unknown element can be the language identificator, if it's the first one
-            if (i == 0) {
-              language = elements[0];
-            } else {
-              throw new SFException(
-                  ErrorCode.INVALID_COLLATION_STRING, name, "Unknown option: " + elements[i]);
-            }
-        }
-      }
-
-      /* Sanity checks */
-      if (upper && lower)
-        throw new SFException(
-            ErrorCode.INVALID_COLLATION_STRING,
-            name,
-            "Options 'upper' and 'lower' are mutually exclusive");
-
-      if ((language == null
-          || language.equalsIgnoreCase(LANG_EMPTY)
-          || language.equalsIgnoreCase(LANG_UTF8)
-          || language.equalsIgnoreCase(LANG_BIN))) {
-        // Check we didn't provide any of the ICU-specific options
-        if (caseSensitive != null)
-          throw new SFException(
-              ErrorCode.INVALID_COLLATION_STRING,
-              name,
-              "Case sensitivity option not allowed for the UTF8 collation");
-        if (accentSensitive != null)
-          throw new SFException(
-              ErrorCode.INVALID_COLLATION_STRING,
-              name,
-              "Accent sensitivity option not allowed for the UTF8 collation");
-        if (firstLowerIsSet)
-          throw new SFException(
-              ErrorCode.INVALID_COLLATION_STRING,
-              name,
-              "Upper/lower preference option not allowed for the UTF8 collation");
-        if (punctuationSensitive != null)
-          throw new SFException(
-              ErrorCode.INVALID_COLLATION_STRING,
-              name,
-              "Punctuation sensitivity option not allowed for the UTF8 collation");
-      } else {
-        // Set the defaults
-        // NOTE: firstLower does not have a default value
-        if (caseSensitive == null) caseSensitive = true;
-        if (accentSensitive == null) accentSensitive = true;
-        if (punctuationSensitive == null) punctuationSensitive = true;
-
-        // Construct an ICU string, e.g. "de@colStrength=primary;colCaseFirst=lower"
-        // This string will be used by COLLATE_TO_BINARY and others.
-        // See http://userguide.icu-project.org/collation/concepts#TOC-Collator-naming-scheme
-
-        // We start with the language, and then construct a series of ";option=something".
-        // At the end, we'll switch the first ';' to '@'
-        String icu = language;
-
-        /*
-         * From https://www.unicode.org/reports/tr35/tr35-collation.html#Collation_Element :
-         * 3.4.1 Common settings combinations
-         * Some commonly used parametric collation settings are available via combinations of LDML settings attributes:
-         * - “Ignore accents”: strength=primary
-         * - “Ignore accents” but take case into account: strength=primary caseLevel=on
-         * - “Ignore case”: strength=secondary
-         */
-        if (!accentSensitive) {
-          icu += ";colStrength=primary";
-          // In ICU, "primary" implies case-insensitive.
-          // If we're case sensitive, force it with "colCaseLevel"
-          icu += ";colCaseLevel=" + (caseSensitive ? "yes" : "no");
-        } else if (!caseSensitive) {
-          icu += ";colStrength=secondary";
-        }
-        if (firstLowerIsSet) {
-          icu += ";colCaseFirst=" + (firstLower ? "lower" : "upper");
-        }
-        if (punctuationSensitive != null) {
-          icu += ";colAlternate=" + (punctuationSensitive ? "non-ignorable" : "shifted");
-        }
-
-        // Fix the first ";" to be "@"
-        this.icuCollationString = icu.replaceFirst(";", "@");
-      }
-      if (this.icuCollationString != null) {
-        ULocale locale = new ULocale(icuCollationString);
-        collator = Collator.getInstance(locale);
-      }
-    }
-
-    byte[] performConversion(String input) {
-      /*
-       * WARNING: the logic should be in sync with CollationEvaluator.cpp !!!
-       */
-      if (ltrim || rtrim) {
-        // Apply trim
-        int inputIdx = 0;
-        int inputLen = input.length();
-
-        if (ltrim) {
-          while (inputLen > 0 && input.charAt(inputIdx) == ' ') {
-            inputLen--;
-            inputIdx++;
-          }
-        }
-        if (rtrim) {
-          while (inputLen > 0 && input.charAt(inputIdx + inputLen - 1) == ' ') {
-            inputLen--;
-          }
-        }
-        input = input.substring(inputIdx, inputIdx + inputLen);
-      }
-
-      // Handle upper/lower
-      if (upper) {
-        input = UCharacter.toUpperCase(input);
-      }
-      if (lower) {
-        input = UCharacter.toLowerCase(input);
-      }
-
-      if (icuCollationString == null) {
-        // No need for ICU key generation, convert (modified) input to UTF-8 bytes
-        return input.getBytes(StandardCharsets.UTF_8);
-      }
-
-      // ICU collation is needed
-      // Perform the conversion
-      CollationKey cltKey = collator.getCollationKey(input);
-      byte[] cltKeyBytes = cltKey.toByteArray();
-      int cltKeySize = cltKeyBytes.length;
-
-      if (cltKeySize > 0) {
-        // Get rid of the trailing 0
-        if (cltKeyBytes[cltKeySize - 1] != 0) {
-          throw new SFException(
-              ErrorCode.INTERNAL_ERROR, "unexpected_non_zero_end_of_collated_key");
-        }
-        cltKeySize -= 1;
-
-        // Check if the produced key is all 0x01 - this can happen when we collate to an empty
-        // string,
-        // but the ICU still produces 0x01 dividers between various parts of the collation key.
-        // It's better to just treat these as an empty string.
-        int idx;
-        for (idx = 0; idx < cltKeySize; idx++) {
-          if (cltKeyBytes[idx] != 0x01) {
-            break;
-          }
-        }
-
-        if (idx == cltKeySize) {
-          // Mark as an empty string
-          cltKeySize = 0;
-        }
-
-        cltKeyBytes = Arrays.copyOf(cltKeyBytes, cltKeySize);
-      }
-      // Create an SFBinary
-      return cltKeyBytes;
-    }
-  }
 
   private String currentMinNonColStrValue;
   private String currentMaxNonColStrValue;
@@ -304,14 +31,14 @@ class RowBufferStats {
   private long currentNullCount;
   // for binary or string columns
   private long currentMaxLength;
-  private CollationDefinition collationDefinition;
+  private CollationDefinitionBase collationDefinition;
   private final String collationDefinitionString;
 
   /** Creates empty stats */
   RowBufferStats(String collationDefinitionString) {
     this.collationDefinitionString = collationDefinitionString;
     if (collationDefinitionString != null) {
-      this.collationDefinition = new CollationDefinition(collationDefinitionString);
+      this.collationDefinition = new CollationDefinitionBase(collationDefinitionString, true);
     }
     reset();
   }
@@ -335,7 +62,7 @@ class RowBufferStats {
 
   byte[] getCollatedBytes(String value) {
     if (collationDefinition != null) {
-      return collationDefinition.performConversion(value);
+      return collationDefinition.performConversionToBinary(value).getBytes();
     }
     return value.getBytes(StandardCharsets.UTF_8);
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelDataTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelDataTest.java
@@ -1,6 +1,7 @@
 package net.snowflake.ingest.streaming.internal;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import net.snowflake.ingest.utils.ErrorCode;
@@ -107,13 +108,15 @@ public class ChannelDataTest {
     Assert.assertEquals(new BigInteger("10"), oneCombined.getCurrentMinIntValue());
     Assert.assertEquals(new BigInteger("17"), oneCombined.getCurrentMaxIntValue());
     Assert.assertEquals(-1, oneCombined.getDistinctValues());
-    Assert.assertNull(oneCombined.getCurrentMinColStrValue());
-    Assert.assertNull(oneCombined.getCurrentMaxColStrValue());
+    Assert.assertNull(oneCombined.getCurrentMinColStrValueInBytes());
+    Assert.assertNull(oneCombined.getCurrentMaxColStrValueInBytes());
     Assert.assertNull(oneCombined.getCurrentMinRealValue());
     Assert.assertNull(oneCombined.getCurrentMaxRealValue());
 
-    Assert.assertEquals("10", twoCombined.getCurrentMinColStrValue());
-    Assert.assertEquals("17", twoCombined.getCurrentMaxColStrValue());
+    Assert.assertArrayEquals(
+        "10".getBytes(StandardCharsets.UTF_8), twoCombined.getCurrentMinColStrValueInBytes());
+    Assert.assertArrayEquals(
+        "17".getBytes(StandardCharsets.UTF_8), twoCombined.getCurrentMaxColStrValueInBytes());
     Assert.assertEquals(-1, twoCombined.getDistinctValues());
     Assert.assertNull(twoCombined.getCurrentMinIntValue());
     Assert.assertNull(twoCombined.getCurrentMaxIntValue());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -325,7 +325,7 @@ public class DataValidationUtilTest {
     // Check max String length
     StringBuilder longBuilder = new StringBuilder();
     for (int i = 0; i < BYTES_16_MB; i++) {
-      longBuilder.append("č"); // max string length is measured in chars, not bytes
+      longBuilder.append("a");
     }
     String maxString = longBuilder.toString();
     Assert.assertEquals(maxString, validateAndParseString(maxString, Optional.empty()));
@@ -352,6 +352,28 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW, () -> validateAndParseString(new Object(), Optional.empty()));
     expectError(ErrorCode.INVALID_ROW, () -> validateAndParseString(new byte[] {}, Optional.of(4)));
     expectError(ErrorCode.INVALID_ROW, () -> validateAndParseString(new char[] {}, Optional.of(4)));
+  }
+
+  @Test
+  public void testValidateMultiByteString() {
+    // Test multi-byte string, total max allowed size is in bytes, not in characters
+    StringBuilder longBuilder = new StringBuilder();
+    for (int i = 0; i < BYTES_8_MB; i++) {
+      longBuilder.append("š"); // š is 2-byte unicode character
+    }
+    String maxString = longBuilder.toString();
+    Assert.assertEquals(maxString, validateAndParseString(maxString, Optional.empty()));
+
+    // max length - 1 should also succeed
+    longBuilder.setLength(BYTES_8_MB - 1);
+    String maxStringMinusOne = longBuilder.toString();
+    Assert.assertEquals(
+        maxStringMinusOne, validateAndParseString(maxStringMinusOne, Optional.empty()));
+
+    // max length + 1 should fail
+    expectError(
+        ErrorCode.INVALID_ROW,
+        () -> validateAndParseString(longBuilder.append("šš").toString(), Optional.empty()));
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FileColumnPropertiesTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FileColumnPropertiesTest.java
@@ -1,0 +1,98 @@
+package net.snowflake.ingest.streaming.internal;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FileColumnPropertiesTest {
+  @Test
+  public void testTruncation() throws DecoderException {
+    // Test empty input
+    Assert.assertEquals("", FileColumnProperties.truncateBytesAsHex(new byte[0], false));
+    Assert.assertEquals("", FileColumnProperties.truncateBytesAsHex(new byte[0], true));
+
+    // Test basic case
+    Assert.assertEquals("aa", FileColumnProperties.truncateBytesAsHex(Hex.decodeHex("aa"), false));
+    Assert.assertEquals("aa", FileColumnProperties.truncateBytesAsHex(Hex.decodeHex("aa"), true));
+
+    // Test exactly 32 bytes
+    Assert.assertEquals(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        FileColumnProperties.truncateBytesAsHex(
+            Hex.decodeHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            false));
+    Assert.assertEquals(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        FileColumnProperties.truncateBytesAsHex(
+            Hex.decodeHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            true));
+
+    Assert.assertEquals(
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        FileColumnProperties.truncateBytesAsHex(
+            Hex.decodeHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+            false));
+
+    Assert.assertEquals(
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        FileColumnProperties.truncateBytesAsHex(
+            Hex.decodeHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+            true));
+
+    // Test 1 truncate up
+    Assert.assertEquals(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        FileColumnProperties.truncateBytesAsHex(
+            Hex.decodeHex(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            false));
+
+    Assert.assertEquals(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+        FileColumnProperties.truncateBytesAsHex(
+            Hex.decodeHex(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            true));
+
+    // Test one overflow
+    Assert.assertEquals(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaafffffffffffffffffffffffffffffffaaff",
+        FileColumnProperties.truncateBytesAsHex(
+            Hex.decodeHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaafffffffffffffffffffffffffffffffaaffffffff"),
+            false));
+    Assert.assertEquals(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaafffffffffffffffffffffffffffffffab00",
+        FileColumnProperties.truncateBytesAsHex(
+            Hex.decodeHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaafffffffffffffffffffffffffffffffaaffffffff"),
+            true));
+
+    // Test many overflow
+    Assert.assertEquals(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaafffffffffffffffffffffffffffffffffff",
+        FileColumnProperties.truncateBytesAsHex(
+            Hex.decodeHex(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaafffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+            false));
+    Assert.assertEquals(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaab00000000000000000000000000000000000",
+        FileColumnProperties.truncateBytesAsHex(
+            Hex.decodeHex(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaafffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+            true));
+
+    // Test infinity
+    Assert.assertEquals(
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        FileColumnProperties.truncateBytesAsHex(
+            Hex.decodeHex(
+                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcccccccccccc"),
+            false));
+    Assert.assertEquals(
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcc",
+        FileColumnProperties.truncateBytesAsHex(
+            Hex.decodeHex(
+                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcccccccccccc"),
+            true));
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FileColumnPropertiesTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FileColumnPropertiesTest.java
@@ -27,7 +27,7 @@ public class FileColumnPropertiesTest {
     props = new FileColumnProperties(stats);
     Assert.assertNull(props.getMinStrNonCollated());
     Assert.assertNull(props.getMaxStrNonCollated());
-    Assert.assertEquals(32 * 2, props.getMinStrValue().length());
+    Assert.assertEquals(32 * 2, props.getMinStrValue().length()); // *2 because it is a hex string
     Assert.assertEquals(32 * 2, props.getMaxStrValue().length());
 
     // Test that resulting non collated strings are null if non collated

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import net.snowflake.client.jdbc.internal.org.bouncycastle.util.encoders.Hex;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Constants;
@@ -647,8 +648,12 @@ public class RowBufferTest {
     Assert.assertEquals(0, columnEpStats.get("COLBIGINT").getCurrentNullCount());
     Assert.assertEquals(-1, columnEpStats.get("COLBIGINT").getDistinctValues());
 
-    Assert.assertEquals("alice", columnEpStats.get("COLCHAR").getCurrentMaxColStrValue());
-    Assert.assertEquals("2", columnEpStats.get("COLCHAR").getCurrentMinColStrValue());
+    Assert.assertEquals(
+        Hex.encode("alice".getBytes(StandardCharsets.UTF_8)),
+        columnEpStats.get("COLCHAR").getCurrentMaxColStrValueInBytes());
+    Assert.assertEquals(
+        Hex.encode("2".getBytes(StandardCharsets.UTF_8)),
+        columnEpStats.get("COLCHAR").getCurrentMinColStrValueInBytes());
     Assert.assertEquals(0, columnEpStats.get("COLCHAR").getCurrentNullCount());
     Assert.assertEquals(-1, columnEpStats.get("COLCHAR").getDistinctValues());
 
@@ -1066,9 +1071,9 @@ public class RowBufferTest {
     Assert.assertEquals(3, result.getRowCount());
     Assert.assertEquals(11L, result.getColumnEps().get("COLBINARY").getCurrentMaxLength());
     Assert.assertEquals(
-        "Hello World", result.getColumnEps().get("COLBINARY").getCurrentMinColStrValue());
+        "Hello World", result.getColumnEps().get("COLBINARY").getCurrentMinColStrValueInBytes());
     Assert.assertEquals(
-        "Honk Honk", result.getColumnEps().get("COLBINARY").getCurrentMaxColStrValue());
+        "Honk Honk", result.getColumnEps().get("COLBINARY").getCurrentMaxColStrValueInBytes());
     Assert.assertEquals(1, result.getColumnEps().get("COLBINARY").getCurrentNullCount());
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/RandomizedUnicodeStringsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/RandomizedUnicodeStringsIT.java
@@ -1,0 +1,91 @@
+package net.snowflake.ingest.streaming.internal.datatypes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import net.snowflake.ingest.TestUtils;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.utils.Constants;
+import org.junit.Test;
+
+/**
+ * This test generates batches of random unicode strings, ingests and migrates them. Migration
+ * uncovers any potential inconsistencies between data and metadata. If there is a failure, it
+ * prints the random strings from the batch as a reproducer.
+ */
+public class RandomizedUnicodeStringsIT extends AbstractDataTypeTest {
+  public RandomizedUnicodeStringsIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
+
+  private static final int MAX_STRING_LENGTH = 64;
+
+  private static final int BATCH_COUNT = 1000;
+  private static final int MAX_BATCH_SIZE = 10;
+
+  private static final Random random = new Random();
+
+  @Test
+  public void testStrings() throws Exception {
+    for (int i = 0; i < BATCH_COUNT; i++) {
+      System.out.printf("Running batch %d / %d%n", i, BATCH_COUNT);
+      runBatch();
+    }
+  }
+
+  private void runBatch() throws Exception {
+    String tableName = createTable("VARCHAR");
+    SnowflakeStreamingIngestChannel channel = openChannel(tableName);
+    List<String> strings = new ArrayList<>();
+
+    try {
+      int i = 0;
+      int batchSize = random.nextInt(MAX_BATCH_SIZE) + 1;
+      while (i < batchSize) {
+        i++;
+        String stringInput = randomUnicodeString();
+        strings.add(stringInput);
+        channel.insertRow(createStreamingIngestRow(stringInput), String.valueOf(i));
+      }
+      System.out.println(batchSize);
+      TestUtils.waitForOffset(channel, String.valueOf(i));
+      migrateTable(tableName); // migration should always succeed
+    } catch (Exception e) {
+      System.err.println("StringsRandomizedIT: Failed for the following batch of strings:");
+      for (String input : strings) {
+        char[] z = input.toCharArray();
+        List<String> charCodeList =
+            IntStream.range(0, z.length)
+                .map(id -> z[id])
+                .mapToObj(x -> String.format("\\u%04X", x))
+                .collect(Collectors.toList());
+        System.err.println(String.join("", charCodeList));
+      }
+      throw e;
+    }
+  }
+
+  /** Generate random unicode string of random length between 0 and MAX_STRING_LENGTH. */
+  private String randomUnicodeString() {
+    int targetLength = random.nextInt(MAX_STRING_LENGTH);
+
+    StringBuilder sb = new StringBuilder();
+
+    int length = 0;
+    while (length < targetLength) {
+
+      int codePoint = random.nextInt(Character.MAX_CODE_POINT);
+      int codePointType = Character.getType(codePoint);
+      if (codePointType == Character.UNASSIGNED
+          || codePointType == Character.PRIVATE_USE
+          || codePointType == Character.SURROGATE) {
+        continue;
+      }
+      length++;
+      sb.appendCodePoint(codePoint);
+    }
+    return sb.toString();
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringCollationsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringCollationsIT.java
@@ -1,0 +1,131 @@
+package net.snowflake.ingest.streaming.internal.datatypes;
+
+import net.snowflake.ingest.TestUtils;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.utils.Constants;
+import org.junit.Test;
+
+public class StringCollationsIT extends AbstractDataTypeTest {
+
+  private static final String[] COLLATIONS =
+      new String[] {
+        "en-fl",
+        "en-fu",
+        "en-fu-forced",
+        "trim",
+        "ltrim",
+        "rtrim",
+        "lower",
+        "lower-trim",
+        "upper",
+        "upper-trim",
+        "en",
+        "en-ai",
+        "en-ci",
+        "en-fl",
+        "en-fu",
+        "en-pi",
+        "en-ai-pi-ci",
+        "en-ai-pi-ci-upper-trim",
+        "pl",
+        "pl-ai-ci-pi"
+      };
+
+  public StringCollationsIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
+
+  @Test
+  public void testCollatedStrings() throws Exception {
+    for (String collation : new String[] {"lower", "upper"}) {
+      runCollatedTest(collation, "B", "š");
+      runCollatedTest(collation, "Š", "b");
+    }
+
+    for (String collation : new String[] {"trim", "ltrim", "rtrim"}) {
+      runCollatedTest(collation, "A", " š ");
+      runCollatedTest(collation, "A", "š ");
+      runCollatedTest(collation, "A", " š");
+    }
+
+    for (String collation : new String[] {"en_US-fl", "en_US-fu"}) {
+      runCollatedTest(collation, "Baa", "šaa");
+      runCollatedTest(collation, "Šaa", "baa");
+    }
+
+    for (String collation : new String[] {"es_ES", "es_ES-trim", "es_ES-upper", "es_ES-lower"}) {
+      runCollatedTest(collation, "  piña colada  ", "pinta");
+      runCollatedTest(collation, "  Piña colada  ", "PINTA");
+    }
+  }
+
+  @Test
+  public void testCollatedFFPrefix() throws Exception {
+    String collation = "en_US-ai";
+
+    // 11x \xFFFF
+    runCollatedTest(
+        collation, "\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF");
+
+    // 10x \xFFFF + chars
+    runCollatedTest(
+        collation,
+        "\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFFaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    // chars + 15+ times \uFFFF
+    runCollatedTest(
+        collation,
+        "aaaaaaaaa\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF");
+
+    // chars + 15+ times \uFFFF + chars
+    runCollatedTest(
+        collation,
+        "aaaaaaaaa\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFFaaaaaaaaa");
+
+    // 15+ times \uFFFF
+    runCollatedTest(
+        collation,
+        "\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF");
+
+    // 15+ times \uFFFF + chars
+    runCollatedTest(
+        collation,
+        "\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFFaaaaaaaaa");
+  }
+
+  /** Inspired by t_collations/src/collations-basic.sql */
+  @Test
+  public void basicCollationsTest() throws Exception {
+    String[] values = new String[] {"abc", "Ąbc", "ĄBC", "ABC", " ABC", "a-b-c", "A_b C", "ąbć"};
+
+    for (String collation : COLLATIONS) {
+      runCollatedTest(collation, values);
+    }
+  }
+
+  @Test
+  public void testCollatedStringsWithMultiByteChars() throws Exception {
+    for (String collation : COLLATIONS) {
+      runCollatedTest(
+          collation,
+          // less than 32 bytes
+          "ěéčář",
+          // 32 bytes
+          "ěéčářýíáčšřýěšří",
+          // more than 32 bytes
+          "ěéčářýíáčšřýěšýříěšýčířýěščíéářýíěášýčř=+ýčřáíýěščířáýěščíářýíěáščýšýčěířžě");
+    }
+  }
+
+  private void runCollatedTest(String collation, String... values) throws Exception {
+    String tableName = createTable("VARCHAR", collation);
+    SnowflakeStreamingIngestChannel channel = openChannel(tableName);
+    String offsetToken = null;
+    for (int i = 0; i < values.length; i++) {
+      offsetToken = String.format("foo%d", i);
+      channel.insertRow(createStreamingIngestRow(values[i]), offsetToken);
+    }
+    TestUtils.waitForOffset(channel, offsetToken);
+    migrateTable(tableName); // migration should always succeed
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
@@ -2,6 +2,8 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import net.snowflake.ingest.TestUtils;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.utils.Constants;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -63,34 +65,161 @@ public class StringsIT extends AbstractDataTypeTest {
 
   @Test
   public void testNonAsciiStrings() throws Exception {
+    testIngestion("VARCHAR", "ž, š, č, ř, c, j, ď, ť, ň", new StringProvider());
+    testIngestion("VARCHAR", "čččččččččččččččč", new StringProvider()); // 16x
+    testIngestion("VARCHAR", "ačččččččččččččččč", new StringProvider()); // 1x + 16x
+    testIngestion("VARCHAR", "ččččččččččččččččč", new StringProvider()); // 17x
     testIngestion(
-        "VARCHAR", "ž, š, č, ř, c, j, ď, ť, ň", "ž, š, č, ř, c, j, ď, ť, ň", new StringProvider());
+        "VARCHAR", "❄😃öüß0ö😃üä++ěšíáýšěčí🍞áýřž+šář+🍞ýšš😃čžýříéě+ž❄", new StringProvider());
   }
 
   @Test
   public void testMaxAllowedString() throws Exception {
-    StringBuilder maxAllowedStringBuilder = buildString('a', 16 * 1024 * 1024);
-    String maxString = maxAllowedStringBuilder.toString();
-    testIngestion("VARCHAR", maxString, maxString, new StringProvider());
-    expectArrowNotSupported("VARCHAR", maxAllowedStringBuilder.append('a').toString());
+    // 1-byte chars
+    String maxString = buildString("a", 16 * 1024 * 1024);
+    testIngestion("VARCHAR", maxString, new StringProvider());
+    expectArrowNotSupported("VARCHAR", maxString + "a");
+
+    // 2-byte chars
+    maxString = buildString("š", 8 * 1024 * 1024);
+    testIngestion("VARCHAR", maxString, new StringProvider());
+
+    expectArrowNotSupported("VARCHAR", maxString + "a");
+
+    // 3-byte chars
+    maxString = buildString("❄", (16 * 1024 * 1024 - 1) / 3);
+    testIngestion("VARCHAR", maxString, new StringProvider());
+    expectArrowNotSupported("VARCHAR", maxString + "aa");
+
+    // 4-byte chars
+    maxString = buildString("🍞", 4 * 1024 * 1024);
+    testIngestion("VARCHAR", maxString, new StringProvider());
+    expectArrowNotSupported("VARCHAR", maxString + "a");
   }
 
   @Test
-  @Ignore("SNOW-663621")
-  public void testMaxAllowedMultibyteString() throws Exception {
-    String times16 = "čččččččččččččččč";
-    String times17 = "ččččččččččččččččč";
-    testIngestion("VARCHAR", times16, times16, new StringProvider()); // works fine
-    testIngestion("VARCHAR", times17, times17, new StringProvider()); // fails
-    //    expectArrowNotSupported("VARCHAR",
-    // maxAllowedMultibyteStringBuilder.append('a').toString());
+  public void testPrefixFF() throws Exception {
+
+    // 11x \xFFFF
+    testIngestion(
+        "VARCHAR",
+        "\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF",
+        new StringProvider());
+    // 10x \xFFFF + chars
+    testIngestion(
+        "VARCHAR",
+        "\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFFaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        new StringProvider());
+
+    // chars + 15+ times \uFFFF
+    ingestAndMigrate(
+        "aaaaaaaaa\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF");
+
+    // chars + 15+ times \uFFFF + chars
+    ingestAndMigrate(
+        "aaaaaaaaa\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFFaaaaaaaaa");
+
+    // 15+ times \uFFFF
+    ingestAndMigrate(
+        "\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF");
+
+    // 15+ times \uFFFF + chars
+    ingestAndMigrate(
+        "\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFFaaaaaaaaa");
   }
 
-  private StringBuilder buildString(char character, int count) {
-    StringBuilder maxStringBuilder = new StringBuilder(count);
+  @Test
+  public void testMultiByteCharComparison() throws Exception {
+    ingestAndMigrate("a", "B");
+    ingestAndMigrate("b", "A");
+
+    ingestAndMigrate("a", "❄");
+    ingestAndMigrate("❄", "a");
+
+    ingestAndMigrate(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄");
+    ingestAndMigrate(
+        "❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄❄",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  }
+
+  /**
+   * Ingests string with length around truncation size and assert that both shorter, equal and
+   * longer strings are injected correctly
+   */
+  @Test
+  public void testTruncationAndIncrementation() throws Exception {
+    // Test 1-byte
+    testIngestion("VARCHAR", buildString("a", 31), new StringProvider());
+    testIngestion("VARCHAR", buildString("a", 32), new StringProvider());
+    testIngestion("VARCHAR", buildString("a", 33), new StringProvider());
+
+    // Test 2-byte
+    testIngestion("VARCHAR", buildString("š", 15), new StringProvider());
+    testIngestion("VARCHAR", buildString("š", 16), new StringProvider());
+    testIngestion("VARCHAR", buildString("š", 17), new StringProvider());
+    testIngestion("VARCHAR", buildString("a", 1, "š", 15), new StringProvider());
+    testIngestion("VARCHAR", buildString("a", 1, "š", 16), new StringProvider());
+
+    // Test 3-byte
+    testIngestion("VARCHAR", buildString("❄", 10), new StringProvider());
+    testIngestion("VARCHAR", buildString("❄", 11), new StringProvider());
+    testIngestion("VARCHAR", buildString("❄", 12), new StringProvider());
+
+    // Test 4-byte
+    testIngestion("VARCHAR", buildString("🍞", 6), new StringProvider());
+    testIngestion("VARCHAR", buildString("🍞", 7), new StringProvider());
+    testIngestion("VARCHAR", buildString("🍞", 8), new StringProvider());
+
+    testIngestion("VARCHAR", buildString("a", 1, "🍞", 7), new StringProvider());
+  }
+
+  @Test
+  @Ignore("Failing due to GS SNOW-690281")
+  public void testByteSplit() throws Exception {
+    testIngestion("VARCHAR", buildString("a", 1, "🍞", 8), new StringProvider());
+    testIngestion("VARCHAR", buildString("a", 1, "🍞", 9), new StringProvider());
+  }
+
+  /**
+   * Creates a string from a certain number of concatenated strings e.g. buildString("ab", 2) =>
+   * abab
+   */
+  private String buildString(String str, int count) {
+    StringBuilder sb = new StringBuilder(count);
     for (int i = 0; i < count; i++) {
-      maxStringBuilder.append(character);
+      sb.append(str);
     }
-    return maxStringBuilder;
+    return sb.toString();
+  }
+
+  /**
+   * Creates a string concatenated from two strings, each consisting of a certain number of
+   * concatenated strings e.g. buildString("a", 2, "eb", 3) => aaebebeb
+   */
+  private String buildString(String str1, int count1, String str2, int count2) {
+    String sb1 = buildString(str1, count1);
+    String sb2 = buildString(str2, count2);
+    return sb1 + sb2;
+  }
+
+  /**
+   * Ingest two values, wait for the latest offset to be committed, migrate the table and assert no
+   * errors have been thrown. Useful to test that EP values are generated correctly because if they
+   * weren't, migration would fail and create an incident.
+   */
+  protected <STREAMING_INGEST_WRITE> void ingestAndMigrate(STREAMING_INGEST_WRITE... values)
+      throws Exception {
+    String tableName = createTable("VARCHAR");
+    SnowflakeStreamingIngestChannel channel = openChannel(tableName);
+    String offsetToken = null;
+    for (int i = 0; i < values.length; i++) {
+      offsetToken = String.format("offsetToken%d", i);
+      channel.insertRow(createStreamingIngestRow(values[i]), offsetToken);
+    }
+
+    TestUtils.waitForOffset(channel, offsetToken);
+    migrateTable(tableName); // migration should always succeed
   }
 }


### PR DESCRIPTION
This PR fixes several issues related to handling of strings, particularly related to non ascii characters nad collations. Merging must be postponed until server-side counterpart is deployed.

This PR must be released as the SDK version "1.0.2-beta.7" because since this version the server will interpred EP values differently.

This PR fixes the following issues:

SNOW-686944
Min/Max string values were being trucated to 32 characters, not to 32 bytes, which is what SF expects. For Unicode strings the values were therefore longer, another truncation was being done on server side, which is always truncating down, leading to invalid max values.

SNOW-682477
Max length has to be reported in bytes, not in characters.

SNOW-663621
String comparison and truncation has to be compatible with XP, otherwise metadata checker incidents are raised due to mismatches.

SNOW-693446
Fixed transformation of collated strings. Collated bytes need to be calculated from full string and only then truncated. Min/max non-collated strings should be set to null if the string is longer than 32 bytes. This patch also downgrades the ICU library to behave consistently with XP and GS.

Testing
Tests have been added for all kinds of string comparison and truncation. A randomized testing has been added, which generates random unicode strings, ingests and migrates them, ensuring the data and metadata are consistent. Additional integration tests for collation support have been added.