### PR TITLE
SNOW-647377 Quoted columns support

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -19,7 +19,6 @@ import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.SFException;
-import net.snowflake.ingest.utils.Utils;
 import org.apache.arrow.util.VisibleForTesting;
 
 /**
@@ -198,7 +197,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       Map<String, Object> row, InsertValidationResponse.InsertError error) {
     Map<String, String> inputColNamesMap =
         row.keySet().stream()
-            .collect(Collectors.toMap(AbstractRowBuffer::formatColumnName, value -> value));
+            .collect(Collectors.toMap(LiteralQuoteUtils::formatColumnName, value -> value));
 
     // Check for extra columns in the row
     List<String> extraCols = new ArrayList<>();
@@ -436,14 +435,6 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
 
   @VisibleForTesting
   abstract int getTempRowCount();
-
-  /** Normalize the column name, given with the inserted row, to send to server side. */
-  static String formatColumnName(String columnName) {
-    Utils.assertStringNotNullOrEmpty("invalid column name", columnName);
-    return (columnName.charAt(0) == '"' && columnName.charAt(columnName.length() - 1) == '"')
-        ? columnName
-        : columnName.toUpperCase();
-  }
 
   /**
    * Given a set of col names to stats, build the right ep info

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -105,7 +105,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
       Field field = buildField(column);
       FieldVector vector = field.createVector(this.allocator);
       if (!field.isNullable()) {
-        addNonNullableFieldName(field.getName());
+        addNonNullableFieldName(column.getName());
       }
       this.fields.put(column.getName(), field);
       vectors.add(vector);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -338,7 +338,8 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
 
     // Create the corresponding column field base on the column data type
     fieldType = new FieldType(column.getNullable(), arrowType, null, metadata);
-    return new Field(column.getName(), fieldType, children);
+    String columnName = LiteralQuoteUtils.unquoteColumnName(column.getName());
+    return new Field(columnName, fieldType, children);
   }
 
   @Override
@@ -442,7 +443,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
     float rowBufferSize = 0F;
     for (Map.Entry<String, Object> entry : row.entrySet()) {
       rowBufferSize += 0.125; // 1/8 for null value bitmap
-      String columnName = formatColumnName(entry.getKey());
+      String columnName = LiteralQuoteUtils.formatColumnName(entry.getKey());
       Object value = entry.getValue();
       Field field = this.fields.get(columnName);
       Utils.assertNotNull("Arrow column field", field);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/LiteralQuoteUtils.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/LiteralQuoteUtils.java
@@ -1,0 +1,170 @@
+package net.snowflake.ingest.streaming.internal;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import net.snowflake.ingest.utils.Utils;
+
+/**
+ * Util class to normalise literals to match server side metadata.
+ *
+ * <p>Note: The methods in this class have to be kept in sync with the respective methods on server
+ * side.
+ */
+class LiteralQuoteUtils {
+  private static final String[] reservedKeywords = {
+    // ANSI reserved KW
+    "ALL",
+    "ALTER",
+    "AND",
+    "ANY",
+    "AS",
+    "BETWEEN",
+    "BY",
+    "CHECK",
+    "COLUMN",
+    "CONNECT",
+    "CREATE",
+    "CURRENT",
+    "DELETE",
+    "DISTINCT",
+    "DROP",
+    "ELSE",
+    "EXISTS",
+    "FOLLOWING",
+    "FOR",
+    "FROM",
+    "GRANT",
+    "GROUP",
+    "HAVING",
+    "IN",
+    "INSERT",
+    "INTERSECT",
+    "INTO",
+    "IS",
+    "LIKE",
+    "NOT",
+    "NULL",
+    "OF",
+    "ON",
+    "OR",
+    "ORDER",
+    "REVOKE",
+    "ROW",
+    "ROWS",
+    "SAMPLE",
+    "SELECT",
+    "SET",
+    "START",
+    "TABLE",
+    "TABLESAMPLE",
+    "THEN",
+    "TO",
+    "TRIGGER",
+    "UNION",
+    "UNIQUE",
+    "UPDATE",
+    "VALUES",
+    "WHENEVER",
+    "WHERE",
+    "WITH",
+
+    // oracle reserved KW
+    "INCREMENT",
+    "MINUS",
+
+    // snowflake reserved KW
+    "AGGREGATE",
+    "ILIKE",
+    "REGEXP",
+    "RLIKE",
+    "SOME",
+    "QUALIFY"
+  };
+
+  private static final Set<String> reservedKeywordSet =
+      new HashSet<>(Arrays.asList(reservedKeywords));
+
+  // column names that do not need quoting to match metadata
+  private static final Pattern unquotedIdentifierPattern =
+      Pattern.compile("[$][0-9]+|[_A-Z][_A-Z0-9]*[$]?[_A-Z0-9]*");
+
+  /**
+   * Format the column name, given with the user inserted row, to match column metadata, sent by
+   * server side.
+   */
+  static String formatColumnName(String columnName) {
+    Utils.assertStringNotNullOrEmpty("invalid column name", columnName);
+    // internal server side normalised column name in persistent metadata
+    String normalisedInternalName = unquoteColumnName(columnName);
+    // display name sent by server side to client in open channel column metadata response
+    return quoteColumnNameIfNeeded(normalisedInternalName);
+  }
+
+  /**
+   * Quote user column name to match server side metadata.
+   *
+   * <p>This needs to be in sync with server side to code, until we decide to send the normalised
+   * unquoted column name from server.
+   */
+  private static String quoteColumnNameIfNeeded(String columnName) {
+    if (!unquotedIdentifierPattern.matcher(columnName).matches()
+        || reservedKeywordSet.contains(columnName)) {
+      columnName = '"' + columnName.replace("\"", "\"\"") + '"';
+    }
+    return columnName;
+  }
+
+  /**
+   * Unquote SQL literal.
+   *
+   * <p>Normalises the column name to how it is stored internally. This function needs to keep in
+   * sync with server side normalisation. The reason, we do it here, is to store the normalised
+   * column name in BDEC file metadata.
+   *
+   * @param columnName column name literal to unquote
+   * @return unquoted literal
+   */
+  static String unquoteColumnName(String columnName) {
+    int length = columnName.length();
+
+    if (length == 0) {
+      return columnName;
+    }
+
+    // If this is an identifier that starts and ends with double quotes,
+    // remove them - accounting for escaped double quotes.
+    // Differs from the second condition in that this one allows repeated
+    // double quotes
+    if (columnName.charAt(0) == '"'
+        && (length >= 2
+            && columnName.charAt(length - 1) == '"'
+            &&
+            // Condition that the string contains no single double-quotes
+            // but allows repeated double-quotes
+            !columnName.substring(1, length - 1).replace("\"\"", "").contains("\""))) {
+      // Remove quotes and turn escaped double-quotes to single double-quotes
+      return columnName.substring(1, length - 1).replace("\"\"", "\"");
+    }
+
+    // If this is an identifier that starts and ends with double quotes,
+    // remove them. Internal single double-quotes are not allowed.
+    else if (columnName.charAt(0) == '"'
+        && (length >= 2
+            && columnName.charAt(length - 1) == '"'
+            && !columnName.substring(1, length - 1).contains("\""))) {
+      // Remove the quotes
+      return columnName.substring(1, length - 1);
+    }
+
+    // unquoted string that can have escaped spaces
+    else {
+      // replace escaped spaces in unquoted name
+      if (columnName.contains("\\ ")) {
+        columnName = columnName.replace("\\ ", " ");
+      }
+      return columnName.toUpperCase();
+    }
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/LiteralQuoteUtils.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/LiteralQuoteUtils.java
@@ -105,8 +105,7 @@ class LiteralQuoteUtils {
   /**
    * Quote user column name to match server side metadata.
    *
-   * <p>This needs to be in sync with server side to code, until we decide to send the normalised
-   * unquoted column name from server.
+   * <p>This needs to be in sync with server side to code
    */
   private static String quoteColumnNameIfNeeded(String columnName) {
     if (!unquotedIdentifierPattern.matcher(columnName).matches()

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -124,7 +124,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
     for (Map.Entry<String, Object> entry : row.entrySet()) {
       String key = entry.getKey();
       Object value = entry.getValue();
-      String columnName = formatColumnName(key);
+      String columnName = LiteralQuoteUtils.formatColumnName(key);
       int colIndex = fieldIndex.get(columnName).getSecond();
       RowBufferStats stats = statsMap.get(columnName);
       ColumnMetadata column = fieldIndex.get(columnName).getFirst();
@@ -171,9 +171,10 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   /** Used only for testing. */
   @Override
   Object getVectorValueAt(String column, int index) {
-    int colIndex = fieldIndex.get(column).getSecond();
+    int colIndex = schema.getFieldIndex(column);
     Object value = data.get(index).get(colIndex);
-    ColumnMetadata columnMetadata = fieldIndex.get(column).getFirst();
+    ColumnMetadata columnMetadata =
+        fieldIndex.get(LiteralQuoteUtils.formatColumnName(column)).getFirst();
     String physicalTypeStr = columnMetadata.getPhysicalType();
     ColumnPhysicalType physicalType = ColumnPhysicalType.valueOf(physicalTypeStr);
     String logicalTypeStr = columnMetadata.getLogicalType();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
@@ -67,7 +67,7 @@ public class ParquetTypeGenerator {
     ParquetTypeInfo res = new ParquetTypeInfo();
     Type parquetType;
     Map<String, String> metadata = new HashMap<>();
-    String name = column.getName();
+    String name = LiteralQuoteUtils.unquoteColumnName(column.getName());
 
     AbstractRowBuffer.ColumnPhysicalType physicalType;
     AbstractRowBuffer.ColumnLogicalType logicalType;
@@ -172,7 +172,7 @@ public class ParquetTypeGenerator {
       int id,
       AbstractRowBuffer.ColumnPhysicalType physicalType,
       Type.Repetition repetition) {
-    String name = column.getName();
+    String name = LiteralQuoteUtils.unquoteColumnName(column.getName());
     // the LogicalTypeAnnotation.DecimalLogicalTypeAnnotation is used by server side scanner
     // to discover data type scale and precision
     LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimalLogicalTypeAnnotation =

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
@@ -66,7 +66,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.TINYINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB1");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -87,7 +87,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.SMALLINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB2");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -108,7 +108,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.INT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB4");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -128,7 +128,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIGINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -151,7 +151,7 @@ public class ArrowBufferTest {
     ArrowType expectedType =
         new ArrowType.Decimal(testCol.getPrecision(), testCol.getScale(), DECIMAL_BIT_WIDTH);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), expectedType);
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -171,7 +171,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.VARCHAR.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "LOB");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -191,7 +191,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIGINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -211,7 +211,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.STRUCT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -235,7 +235,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.STRUCT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -259,7 +259,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.STRUCT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -285,7 +285,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.DATEDAY.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -305,7 +305,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.INT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB4");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -325,7 +325,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIGINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -345,7 +345,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "BINARY");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -365,7 +365,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.FLOAT8.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetTypeGeneratorTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetTypeGeneratorTest.java
@@ -22,7 +22,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(4)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
@@ -40,6 +40,7 @@ public class ParquetTypeGeneratorTest {
   public void buildFieldFixedSB2() {
     ColumnMetadata testCol =
         ColumnMetadataBuilder.newBuilder()
+            .name("\"testCol\"")
             .logicalType("FIXED")
             .physicalType("SB2")
             .nullable(false)
@@ -76,7 +77,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(4)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
@@ -103,7 +104,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(8)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
@@ -130,7 +131,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(16)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
@@ -157,7 +158,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(0)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.BINARY)
@@ -185,7 +186,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(8)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
@@ -211,7 +212,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(16)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
@@ -237,7 +238,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(8)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
@@ -263,7 +264,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(16)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
@@ -289,7 +290,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(0)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
@@ -315,7 +316,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(4)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
@@ -341,7 +342,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(8)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
@@ -367,7 +368,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(0)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.BOOLEAN)
@@ -393,7 +394,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(0)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.DOUBLE)

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -153,6 +153,7 @@ public class RowBufferTest {
 
     // Fixed LOB
     testCol = new ColumnMetadata();
+    testCol.setName("COL1");
     testCol.setPhysicalType("LOB");
     testCol.setLogicalType("FIXED");
     try {
@@ -164,6 +165,7 @@ public class RowBufferTest {
 
     // TIMESTAMP_NTZ SB2
     testCol = new ColumnMetadata();
+    testCol.setName("COL1");
     testCol.setPhysicalType("SB2");
     testCol.setLogicalType("TIMESTAMP_NTZ");
     try {
@@ -175,6 +177,7 @@ public class RowBufferTest {
 
     // TIMESTAMP_TZ SB1
     testCol = new ColumnMetadata();
+    testCol.setName("COL1");
     testCol.setPhysicalType("SB1");
     testCol.setLogicalType("TIMESTAMP_TZ");
     try {
@@ -186,6 +189,7 @@ public class RowBufferTest {
 
     // TIME SB16
     testCol = new ColumnMetadata();
+    testCol.setName("COL1");
     testCol.setPhysicalType("SB16");
     testCol.setLogicalType("TIME");
     try {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -538,7 +538,7 @@ public class RowBufferTest {
     InsertValidationResponse response = rowBuffer.insertRows(Collections.singletonList(row1), null);
     Assert.assertFalse(response.hasErrors());
 
-    Assert.assertEquals((byte) 10, rowBuffer.getVectorValueAt("\"colTinyInt\"", 0));
+    Assert.assertEquals((byte) 10, rowBuffer.getVectorValueAt("colTinyInt", 0));
     Assert.assertEquals((byte) 1, rowBuffer.getVectorValueAt("COLTINYINT", 0));
     Assert.assertEquals((short) 2, rowBuffer.getVectorValueAt("COLSMALLINT", 0));
     Assert.assertEquals(3, rowBuffer.getVectorValueAt("COLINT", 0));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -122,6 +122,88 @@ public class StreamingIngestIT {
   }
 
   @Test
+  public void testColumnNameQuotes() throws Exception {
+    final String tableName = "T_COLUMN_WITH_QUOTES";
+    final String unquotedColumn = "c1"; // user name <C1>
+    final String quotedColumn = "\"c 2\""; // user name <c 2>
+    final String doubleQuotedColumn = "\"c\"\"a\\ \"\"\\ 3\""; // user name <c"a\ "\ 3>
+    final String escapedSpacesColumn1 =
+        "c\\ 4"; // space is escaped with '\' in Snowflake SQL, user name <C 4>
+    final String escapedSpacesColumn2 =
+        "c\\ 5"; // space is escaped with '\' in Snowflake SQL, user name <C 5>
+    jdbcConnection
+        .createStatement()
+        .execute(
+            String.format(
+                "create or replace table %s.%s.%s (%s NUMBER(38,0), %s NUMBER(38,0), %s"
+                    + " NUMBER(38,0), %s NUMBER(38,0), %s NUMBER(38,0));",
+                testDb,
+                TEST_SCHEMA,
+                tableName,
+                unquotedColumn,
+                quotedColumn,
+                doubleQuotedColumn,
+                escapedSpacesColumn1,
+                escapedSpacesColumn2));
+
+    OpenChannelRequest request1 =
+        OpenChannelRequest.builder("CHANNEL")
+            .setDBName(testDb)
+            .setSchemaName(TEST_SCHEMA)
+            .setTableName(tableName)
+            .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
+            .build();
+
+    // Open a streaming ingest channel from the given client
+    SnowflakeStreamingIngestChannel channel1 = client.openChannel(request1);
+    for (int val = 0; val < 10; val++) {
+      Map<String, Object> row = new HashMap<>();
+      row.put(unquotedColumn, val);
+      row.put(quotedColumn, val);
+      row.put(doubleQuotedColumn, val);
+      row.put(escapedSpacesColumn1, val);
+      // space escape '\' is not really required, because Java always has its own outer double
+      // quotes.
+      // hence, it happens to also work w/o the space escape after the internal literal
+      // normalisation.
+      String escapedSpacesColumn2NoSpaceEscape = escapedSpacesColumn2.replace("\\", "");
+      row.put(escapedSpacesColumn2NoSpaceEscape, val);
+      verifyInsertValidationResponse(channel1.insertRow(row, Integer.toString(val)));
+    }
+
+    // Close the channel after insertion
+    channel1.close().get();
+
+    for (int i = 1; i < 15; i++) {
+      if (channel1.getLatestCommittedOffsetToken() != null
+          && channel1.getLatestCommittedOffsetToken().equals("9")) {
+        ResultSet result =
+            jdbcConnection
+                .createStatement()
+                .executeQuery(
+                    String.format(
+                        "select %s, %s, %s, %s, %s from %s.%s.%s order by %s",
+                        unquotedColumn,
+                        quotedColumn,
+                        doubleQuotedColumn,
+                        escapedSpacesColumn1,
+                        escapedSpacesColumn2,
+                        testDb,
+                        TEST_SCHEMA,
+                        tableName,
+                        unquotedColumn));
+        for (int val = 0; val < 10; val++) {
+          result.next();
+          for (int index = 1; index <= 5; index++) Assert.assertEquals(val, result.getInt(index));
+        }
+        return;
+      }
+      Thread.sleep(500);
+    }
+    Assert.fail("Row sequencer not updated before timeout");
+  }
+
+  @Test
   public void testSimpleIngest() throws Exception {
     OpenChannelRequest request1 =
         OpenChannelRequest.builder("CHANNEL")

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/ColumnNamesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/ColumnNamesIT.java
@@ -1,0 +1,172 @@
+package net.snowflake.ingest.streaming.internal.datatypes;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import net.snowflake.ingest.TestUtils;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.utils.Constants;
+import net.snowflake.ingest.utils.SFException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ColumnNamesIT extends AbstractDataTypeTest {
+  private static final int INGEST_VALUE = 1;
+
+  public ColumnNamesIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
+
+  @Test
+  public void testColumnNamesSupport() throws Exception {
+    // Test simple case
+    testWorks("FOO", "FOO");
+    testWorks("FOO", "FoO");
+    testWorks("FOO", "\"FOO\"");
+    testDoesNotWork("FOO", "\"Foo\"");
+
+    // Test quoted identifier
+    testWorks("\"FOO\"", "\"FOO\"");
+    testWorks("\"FOO\"", "FOO");
+    testWorks("\"FOO\"", "Foo");
+    testDoesNotWork("\"FOO\"", "\"Foo\"");
+
+    testWorks("\"Foo\"", "\"Foo\"");
+    testDoesNotWork("\"Foo\"", "Foo");
+
+    // Test keyword
+    testWorks("\"CReATE\"", "\"CReATE\"");
+    testWorks("\"CREATE\"", "CReATE");
+    testDoesNotWork("\"CReATE\"", "\"CREATE\"");
+    testDoesNotWork("\"CReATE\"", "CReATE");
+
+    // Test escaped space
+    testWorks("fO\\ O", "fO\\ O");
+    testWorks("fO\\ O", "fO\\ o");
+    testWorks("fO\\ O", "fO O");
+    testWorks("fO\\ O", "fO o");
+    testWorks("fO\\ O", "\"FO O\"");
+    testDoesNotWork("fO\\ O", "\"FO\\ O\"");
+
+    // Test double quotes
+    testWorks("\"\"\"\"", "\"");
+    testWorks("\"\"\"\"", "\"\"\"\"");
+    testDoesNotWork("\"\"\"\"", "\"\"\"\"\"\"");
+
+    // Test quoted column with spaces
+    testWorks("\"FO O\"", "FO O");
+    testWorks("\"FO O\"", "\"FO O\"");
+    testDoesNotWork("\"FO O\"", "\"FO\\ O\"");
+  }
+
+  @Test
+  public void testNonstandardTableAndColumnNames() throws Exception {
+    testWorks("fo\\ o");
+    testWorks("foo");
+    testWorks("\"foo\"");
+    testWorks("\"fo o\"");
+    testWorks("\"alter\"");
+    testWorks("\"table\"");
+    testWorks("\"  \"");
+    testWorks("\"\"");
+    testWorks("\"a\"\"b\"");
+    testWorks("\"\"\"\"");
+    testWorks("\"  \"\"  \"\"  \"");
+    testWorks("\"  \"\" Ť \"\"  \"");
+  }
+
+  /** Tests that quoted columns are correctly resolved for null-backfill */
+  @Test
+  public void testNullableResolution() throws Exception {
+    String tableName = "t1";
+    conn.createStatement()
+        .execute(
+            String.format(
+                "create or replace table %s (\"AbC\" int, \"abC\" int, ab\\ c int, \"Ab c\" int);",
+                tableName));
+    SnowflakeStreamingIngestChannel channel = openChannel(tableName);
+    String offsetToken = "token1";
+    channel.insertRow(new HashMap<>(), offsetToken);
+    TestUtils.waitForOffset(channel, offsetToken);
+
+    ResultSet rs =
+        conn.createStatement().executeQuery(String.format("select * from %s", tableName));
+    rs.next();
+    Assert.assertNull(rs.getObject(1));
+    Assert.assertNull(rs.getObject(2));
+    Assert.assertNull(rs.getObject(3));
+    Assert.assertNull(rs.getObject(4));
+  }
+
+  /** Tests that quoted columns are correctly resolved for not-null checks */
+  @Test
+  public void testNonNullableResolution() throws Exception {
+    String tableName = "t1";
+    conn.createStatement()
+        .execute(
+            String.format(
+                "create or replace table %s (AbC int not null, \"AbC\" int not null);", tableName));
+    SnowflakeStreamingIngestChannel channel = openChannel(tableName);
+    testInsertRowFails(channel, Collections.singletonMap("AbC", 1));
+    testInsertRowFails(channel, Collections.singletonMap("\"AbC\"", 1));
+  }
+
+  private void testWorks(String column) throws SQLException, InterruptedException {
+    testWorks(column, column);
+  }
+
+  /** // Verifies that column names that are not support to work, does not work */
+  private void testDoesNotWork(String createTableColumnName, String ingestColumnName)
+      throws SQLException {
+
+    Map<String, Object> row = new HashMap<>();
+    row.put(ingestColumnName, INGEST_VALUE);
+
+    SnowflakeStreamingIngestChannel channel = openChannel(createSimpleTable(createTableColumnName));
+    testInsertRowFails(channel, row);
+  }
+
+  private void testInsertRowFails(
+      SnowflakeStreamingIngestChannel channel, Map<String, Object> row) {
+    try {
+      channel.insertRow(row, UUID.randomUUID().toString());
+      Assert.fail("Ingest row should not succeed");
+    } catch (SFException e) {
+      // all good, expected exception has been thrown
+    }
+  }
+
+  private void testWorks(String createTableColumnName, String ingestColumnName)
+      throws SQLException, InterruptedException {
+
+    String tableName = createSimpleTable(createTableColumnName);
+    String offsetToken = UUID.randomUUID().toString();
+    SnowflakeStreamingIngestChannel channel = openChannel(tableName);
+    Map<String, Object> row = new HashMap<>();
+    row.put(ingestColumnName, INGEST_VALUE);
+    channel.insertRow(row, offsetToken);
+
+    TestUtils.waitForOffset(channel, offsetToken);
+
+    // Verify that supported columns work
+    ResultSet rs =
+        conn.createStatement().executeQuery(String.format("select * from %s;", tableName));
+    int count = 0;
+    while (rs.next()) {
+      count++;
+      Assert.assertEquals(INGEST_VALUE, rs.getInt(1));
+    }
+    Assert.assertEquals(1, count);
+  }
+
+  private String createSimpleTable(String createTableColumnName) throws SQLException {
+    String tableName = "a" + UUID.randomUUID().toString().replace("-", "_");
+    String createTableSql =
+        String.format("create table %s (%s int);", tableName, createTableColumnName);
+    conn.createStatement().execute(createTableSql);
+    return tableName;
+  }
+}


### PR DESCRIPTION
This PR is a resurrection of @sfc-gh-azagrebin 's PR https://github.com/snowflakedb/snowflake-ingest-java/pull/214 with adaptations for Parquet and added some integration tests. 

The new code is using column display name everywhere except in Arrow/Parquet field names.

Originally, the idea was to pass the unquoted name from the server side, but it is not enough because we still need to translate between the name entered by the user and the display name of the column. For example, client-side quoting is required when ingesting into the column named `"CREATE"`. 