### PR TITLE
SNOW-696155 fix binary values for Parquet

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -329,7 +329,11 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
               recordConsumer.addLong((long) val);
               break;
             case BINARY:
-              recordConsumer.addBinary(Binary.fromString((String) val));
+              Binary binVal =
+                  val instanceof String
+                      ? Binary.fromString((String) val)
+                      : Binary.fromConstantByteArray((byte[]) val);
+              recordConsumer.addBinary(binVal);
               break;
             case FIXED_LEN_BYTE_ARRAY:
               Binary binary = Binary.fromConstantByteArray((byte[]) val);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -190,7 +190,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       }
     }
     if (logicalType == ColumnLogicalType.BINARY && value != null) {
-      value = ((String) value).getBytes(StandardCharsets.UTF_8);
+      value = value instanceof String ? ((String) value).getBytes(StandardCharsets.UTF_8) : value;
     }
     return value;
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
@@ -235,15 +235,15 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats();
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "Length7".getBytes(), testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
+            "1234abcd".getBytes(), testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
-        .expectedValueClass(String.class)
-        .expectedParsedValue("Length7")
-        .expectedSize(7.0f)
-        .expectedMinMax("Length7")
+        .expectedValueClass(byte[].class)
+        .expectedParsedValue("1234abcd".getBytes())
+        .expectedSize(8.0f)
+        .expectedMinMax("1234abcd")
         .assertMatches();
   }
 
@@ -543,7 +543,6 @@ public class ParquetValueParserTest {
 
     void assertMatches() {
       Assert.assertEquals(valueClass, parquetBufferValue.getValue().getClass());
-      System.out.println("parquetBufferValue = " + parquetBufferValue.getValue().toString());
       if (valueClass.equals(byte[].class)) {
         Assert.assertArrayEquals((byte[]) value, (byte[]) parquetBufferValue.getValue());
       } else {


### PR DESCRIPTION
This PR implements a fix for an issue with binary column values in the Parquet flusher. We were creating a utf-8 String for values with type_name=binary  and for byte arrays (hexadecimal strings) that is wrong. 