### PR TITLE
SNOW-647377 Support quoted column names

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -107,14 +107,16 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
       if (!field.isNullable()) {
         addNonNullableFieldName(field.getName());
       }
-      this.fields.put(column.getName(), field);
+      this.fields.put(column.getInternalName(), field);
       vectors.add(vector);
-      this.statsMap.put(column.getName(), new RowBufferStats(column.getCollation()));
+      this.statsMap.put(
+          column.getInternalName(), new RowBufferStats(column.getName(), column.getCollation()));
 
       if (this.owningChannel.getOnErrorOption() == OpenChannelRequest.OnErrorOption.ABORT) {
         FieldVector tempVector = field.createVector(this.allocator);
         tempVectors.add(tempVector);
-        this.tempStatsMap.put(column.getName(), new RowBufferStats(column.getCollation()));
+        this.tempStatsMap.put(
+            column.getInternalName(), new RowBufferStats(column.getName(), column.getCollation()));
       }
     }
 
@@ -338,7 +340,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
 
     // Create the corresponding column field base on the column data type
     fieldType = new FieldType(column.getNullable(), arrowType, null, metadata);
-    return new Field(column.getName(), fieldType, children);
+    return new Field(column.getInternalName(), fieldType, children);
   }
 
   @Override
@@ -442,7 +444,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
     float rowBufferSize = 0F;
     for (Map.Entry<String, Object> entry : row.entrySet()) {
       rowBufferSize += 0.125; // 1/8 for null value bitmap
-      String columnName = formatColumnName(entry.getKey());
+      String columnName = LiteralQuoteUtils.unquoteColumnName(entry.getKey());
       Object value = entry.getValue();
       Field field = this.fields.get(columnName);
       Utils.assertNotNull("Arrow column field", field);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ColumnMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ColumnMetadata.java
@@ -111,6 +111,10 @@ class ColumnMetadata {
     return this.nullable;
   }
 
+  String getInternalName() {
+    return LiteralQuoteUtils.unquoteColumnName(name);
+  }
+
   @Override
   public String toString() {
     Map<String, Object> map = new HashMap<>();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/LiteralQuoteUtils.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/LiteralQuoteUtils.java
@@ -1,0 +1,62 @@
+package net.snowflake.ingest.streaming.internal;
+
+/**
+ * Util class to normalise literals to match server side metadata.
+ *
+ * <p>Note: The methods in this class have to be kept in sync with the respective methods on server
+ * side.
+ */
+class LiteralQuoteUtils {
+
+  /**
+   * Unquote SQL literal.
+   *
+   * <p>Normalises the column name to how it is stored internally. This function needs to keep in
+   * sync with server side normalisation. The reason, we do it here, is to store the normalised
+   * column name in BDEC file metadata.
+   *
+   * @param columnName column name literal to unquote
+   * @return unquoted literal
+   */
+  static String unquoteColumnName(String columnName) {
+    int length = columnName.length();
+
+    if (length == 0) {
+      return columnName;
+    }
+
+    // If this is an identifier that starts and ends with double quotes,
+    // remove them - accounting for escaped double quotes.
+    // Differs from the second condition in that this one allows repeated
+    // double quotes
+    if (columnName.charAt(0) == '"'
+        && (length >= 2
+            && columnName.charAt(length - 1) == '"'
+            &&
+            // Condition that the string contains no single double-quotes
+            // but allows repeated double-quotes
+            !columnName.substring(1, length - 1).replace("\"\"", "").contains("\""))) {
+      // Remove quotes and turn escaped double-quotes to single double-quotes
+      return columnName.substring(1, length - 1).replace("\"\"", "\"");
+    }
+
+    // If this is an identifier that starts and ends with double quotes,
+    // remove them. Internal single double-quotes are not allowed.
+    else if (columnName.charAt(0) == '"'
+        && (length >= 2
+            && columnName.charAt(length - 1) == '"'
+            && !columnName.substring(1, length - 1).contains("\""))) {
+      // Remove the quotes
+      return columnName.substring(1, length - 1);
+    }
+
+    // unquoted string that can have escaped spaces
+    else {
+      // replace escaped spaces in unquoted name
+      if (columnName.contains("\\ ")) {
+        columnName = columnName.replace("\\ ", " ");
+      }
+      return columnName.toUpperCase();
+    }
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -67,14 +67,16 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
           ParquetTypeGenerator.generateColumnParquetTypeInfo(column, id);
       parquetTypes.add(typeInfo.getParquetType());
       this.metadata.putAll(typeInfo.getMetadata());
-      fieldIndex.put(column.getName(), new Pair<>(column, parquetTypes.size() - 1));
+      fieldIndex.put(column.getInternalName(), new Pair<>(column, parquetTypes.size() - 1));
       if (!column.getNullable()) {
-        addNonNullableFieldName(column.getName());
+        addNonNullableFieldName(column.getInternalName());
       }
-      this.statsMap.put(column.getName(), new RowBufferStats(column.getCollation()));
+      this.statsMap.put(
+          column.getInternalName(), new RowBufferStats(column.getName(), column.getCollation()));
 
       if (this.owningChannel.getOnErrorOption() == OpenChannelRequest.OnErrorOption.ABORT) {
-        this.tempStatsMap.put(column.getName(), new RowBufferStats(column.getCollation()));
+        this.tempStatsMap.put(
+            column.getInternalName(), new RowBufferStats(column.getName(), column.getCollation()));
       }
 
       id++;
@@ -124,7 +126,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
     for (Map.Entry<String, Object> entry : row.entrySet()) {
       String key = entry.getKey();
       Object value = entry.getValue();
-      String columnName = formatColumnName(key);
+      String columnName = LiteralQuoteUtils.unquoteColumnName(key);
       int colIndex = fieldIndex.get(columnName).getSecond();
       RowBufferStats stats = statsMap.get(columnName);
       ColumnMetadata column = fieldIndex.get(columnName).getFirst();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
@@ -67,7 +67,7 @@ public class ParquetTypeGenerator {
     ParquetTypeInfo res = new ParquetTypeInfo();
     Type parquetType;
     Map<String, String> metadata = new HashMap<>();
-    String name = column.getName();
+    String name = column.getInternalName();
 
     AbstractRowBuffer.ColumnPhysicalType physicalType;
     AbstractRowBuffer.ColumnLogicalType logicalType;
@@ -172,7 +172,7 @@ public class ParquetTypeGenerator {
       int id,
       AbstractRowBuffer.ColumnPhysicalType physicalType,
       Type.Repetition repetition) {
-    String name = column.getName();
+    String name = column.getInternalName();
     // the LogicalTypeAnnotation.DecimalLogicalTypeAnnotation is used by server side scanner
     // to discover data type scale and precision
     LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimalLogicalTypeAnnotation =

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -306,11 +306,13 @@ class RowBufferStats {
   private long currentMaxLength;
   private CollationDefinition collationDefinition;
   private final String collationDefinitionString;
+  private final String columnDisplayName;
 
   private static final int MAX_LOB_LEN = 32;
 
   /** Creates empty stats */
-  RowBufferStats(String collationDefinitionString) {
+  RowBufferStats(String columnDisplayName, String collationDefinitionString) {
+    this.columnDisplayName = columnDisplayName;
     this.collationDefinitionString = collationDefinitionString;
     if (collationDefinitionString != null) {
       this.collationDefinition = new CollationDefinition(collationDefinitionString);
@@ -318,8 +320,8 @@ class RowBufferStats {
     reset();
   }
 
-  RowBufferStats() {
-    this(null);
+  RowBufferStats(String columnDisplayName) {
+    this(columnDisplayName, null);
   }
 
   void reset() {
@@ -352,7 +354,8 @@ class RowBufferStats {
               "left=%s, right=%s",
               left.getCollationDefinitionString(), right.getCollationDefinitionString()));
     }
-    RowBufferStats combined = new RowBufferStats(left.getCollationDefinitionString());
+    RowBufferStats combined =
+        new RowBufferStats(left.columnDisplayName, left.getCollationDefinitionString());
 
     if (left.currentMinIntValue != null) {
       combined.addIntValue(left.currentMinIntValue);
@@ -522,6 +525,10 @@ class RowBufferStats {
 
   String getCollationDefinitionString() {
     return collationDefinitionString;
+  }
+
+  String getColumnDisplayName() {
+    return columnDisplayName;
   }
 
   /**

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
@@ -66,7 +66,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.TINYINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB1");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -87,7 +87,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.SMALLINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB2");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -108,7 +108,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.INT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB4");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -128,7 +128,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIGINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -151,7 +151,7 @@ public class ArrowBufferTest {
     ArrowType expectedType =
         new ArrowType.Decimal(testCol.getPrecision(), testCol.getScale(), DECIMAL_BIT_WIDTH);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), expectedType);
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -171,7 +171,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.VARCHAR.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "LOB");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -191,7 +191,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIGINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -211,7 +211,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.STRUCT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -235,7 +235,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.STRUCT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -259,7 +259,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.STRUCT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -285,7 +285,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.DATEDAY.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -305,7 +305,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.INT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB4");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -325,7 +325,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIGINT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB8");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -345,7 +345,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.BIT.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "BINARY");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");
@@ -365,7 +365,7 @@ public class ArrowBufferTest {
 
     Field result = this.rowBufferOnErrorContinue.buildField(testCol);
 
-    Assert.assertEquals("testCol", result.getName());
+    Assert.assertEquals("TESTCOL", result.getName());
     Assert.assertEquals(result.getFieldType().getType(), Types.MinorType.FLOAT8.getType());
     Assert.assertEquals(result.getFieldType().getMetadata().get("physicalType"), "SB16");
     Assert.assertEquals(result.getFieldType().getMetadata().get("scale"), "0");

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelDataTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelDataTest.java
@@ -13,7 +13,7 @@ public class ChannelDataTest {
   @Test
   public void testGetCombinedColumnStatsMapNulls() {
     Map<String, RowBufferStats> left = new HashMap<>();
-    RowBufferStats leftStats1 = new RowBufferStats();
+    RowBufferStats leftStats1 = new RowBufferStats("COL1");
     left.put("one", leftStats1);
     leftStats1.addIntValue(new BigInteger("10"));
 
@@ -42,12 +42,12 @@ public class ChannelDataTest {
   @Test
   public void testGetCombinedColumnStatsMapMissingColumn() {
     Map<String, RowBufferStats> left = new HashMap<>();
-    RowBufferStats leftStats1 = new RowBufferStats();
+    RowBufferStats leftStats1 = new RowBufferStats("COL1");
     left.put("one", leftStats1);
     leftStats1.addIntValue(new BigInteger("10"));
 
     Map<String, RowBufferStats> right = new HashMap<>();
-    RowBufferStats rightStats1 = new RowBufferStats();
+    RowBufferStats rightStats1 = new RowBufferStats("COL1");
     right.put("foo", rightStats1);
     rightStats1.addIntValue(new BigInteger("11"));
 
@@ -77,10 +77,10 @@ public class ChannelDataTest {
     Map<String, RowBufferStats> left = new HashMap<>();
     Map<String, RowBufferStats> right = new HashMap<>();
 
-    RowBufferStats leftStats1 = new RowBufferStats();
-    RowBufferStats rightStats1 = new RowBufferStats();
-    RowBufferStats leftStats2 = new RowBufferStats();
-    RowBufferStats rightStats2 = new RowBufferStats();
+    RowBufferStats leftStats1 = new RowBufferStats("COL1");
+    RowBufferStats rightStats1 = new RowBufferStats("COL1");
+    RowBufferStats leftStats2 = new RowBufferStats("COL1");
+    RowBufferStats rightStats2 = new RowBufferStats("COL1");
 
     left.put("one", leftStats1);
     left.put("two", leftStats2);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -480,8 +480,8 @@ public class FlushServiceTest {
     Map<String, RowBufferStats> eps1 = new HashMap<>();
     Map<String, RowBufferStats> eps2 = new HashMap<>();
 
-    RowBufferStats stats1 = new RowBufferStats();
-    RowBufferStats stats2 = new RowBufferStats();
+    RowBufferStats stats1 = new RowBufferStats("COL1");
+    RowBufferStats stats2 = new RowBufferStats("COL1");
 
     eps1.put("one", stats1);
     eps2.put("one", stats2);
@@ -689,7 +689,7 @@ public class FlushServiceTest {
 
     Map<String, RowBufferStats> eps1 = new HashMap<>();
 
-    RowBufferStats stats1 = new RowBufferStats();
+    RowBufferStats stats1 = new RowBufferStats("COL1");
 
     eps1.put("one", stats1);
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetTypeGeneratorTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetTypeGeneratorTest.java
@@ -22,7 +22,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(4)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
@@ -49,7 +49,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(4)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
@@ -76,7 +76,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(4)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
@@ -103,7 +103,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(8)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
@@ -130,7 +130,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(16)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
@@ -157,7 +157,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(0)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.BINARY)
@@ -185,7 +185,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(8)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
@@ -211,7 +211,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(16)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
@@ -237,7 +237,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(8)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
@@ -263,7 +263,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(16)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
@@ -289,7 +289,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(0)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
@@ -315,7 +315,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(4)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
@@ -341,7 +341,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(8)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
@@ -367,7 +367,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(0)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.BOOLEAN)
@@ -393,7 +393,7 @@ public class ParquetTypeGeneratorTest {
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
     ParquetTypeInfoAssertionBuilder.newBuilder()
         .typeInfo(typeInfo)
-        .expectedFieldName("testCol")
+        .expectedFieldName("TESTCOL")
         .expectedFieldId(0)
         .expectedTypeLength(0)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.DOUBLE)

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
@@ -22,7 +22,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             12, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
@@ -48,7 +48,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             1234, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
@@ -74,7 +74,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             123456789, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
@@ -100,7 +100,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             123456789987654321L, testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats);
@@ -126,7 +126,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             new BigDecimal("91234567899876543219876543211234567891"),
@@ -157,7 +157,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             new BigDecimal("12345.54321"),
@@ -184,7 +184,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             12345.54321d, testCol, PrimitiveType.PrimitiveTypeName.DOUBLE, rowBufferStats);
@@ -208,7 +208,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             true, testCol, PrimitiveType.PrimitiveTypeName.BOOLEAN, rowBufferStats);
@@ -232,7 +232,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             "Length7".getBytes(), testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
@@ -268,7 +268,7 @@ public class ParquetValueParserTest {
     String var =
         "{\"key1\":-879869596,\"key2\":\"value2\",\"key3\":null,"
             + "\"key4\":{\"key41\":0.032437,\"key42\":\"value42\",\"key43\":null}}";
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
@@ -297,7 +297,7 @@ public class ParquetValueParserTest {
     input.put("b", "2");
     input.put("c", "3");
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             input, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
@@ -325,7 +325,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     SFException exception =
         Assert.assertThrows(
             SFException.class,
@@ -350,7 +350,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             "2013-04-28 20:57:01.000",
@@ -378,7 +378,7 @@ public class ParquetValueParserTest {
             .scale(9) // nanos
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             "2022-09-18 22:05:07.123456789",
@@ -407,7 +407,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             "2021-01-01", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
@@ -432,7 +432,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             "01:00:00", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
@@ -457,7 +457,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
             "01:00:00.123", testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats);
@@ -482,7 +482,7 @@ public class ParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats();
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     SFException exception =
         Assert.assertThrows(
             SFException.class,

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
@@ -8,17 +8,17 @@ public class RowBufferStatsTest {
 
   @Test
   public void testCollationStates() throws Exception {
-    RowBufferStats ai = new RowBufferStats("en-ai");
-    RowBufferStats as = new RowBufferStats("en-as");
-    RowBufferStats pi = new RowBufferStats("en-pi");
-    RowBufferStats ps = new RowBufferStats("en-ps");
-    RowBufferStats fu = new RowBufferStats("en-fu");
-    RowBufferStats fl = new RowBufferStats("en-fl");
-    RowBufferStats lower = new RowBufferStats("lower");
-    RowBufferStats upper = new RowBufferStats("upper");
-    RowBufferStats ltrim = new RowBufferStats("ltrim");
-    RowBufferStats rtrim = new RowBufferStats("rtrim");
-    RowBufferStats trim = new RowBufferStats("trim");
+    RowBufferStats ai = new RowBufferStats("COL1", "en-ai");
+    RowBufferStats as = new RowBufferStats("COL1", "en-as");
+    RowBufferStats pi = new RowBufferStats("COL1", "en-pi");
+    RowBufferStats ps = new RowBufferStats("COL1", "en-ps");
+    RowBufferStats fu = new RowBufferStats("COL1", "en-fu");
+    RowBufferStats fl = new RowBufferStats("COL1", "en-fl");
+    RowBufferStats lower = new RowBufferStats("COL1", "lower");
+    RowBufferStats upper = new RowBufferStats("COL1", "upper");
+    RowBufferStats ltrim = new RowBufferStats("COL1", "ltrim");
+    RowBufferStats rtrim = new RowBufferStats("COL1", "rtrim");
+    RowBufferStats trim = new RowBufferStats("COL1", "trim");
 
     // Accents
     ai.addStrValue("a");
@@ -69,7 +69,7 @@ public class RowBufferStatsTest {
 
   @Test
   public void testEmptyState() throws Exception {
-    RowBufferStats stats = new RowBufferStats();
+    RowBufferStats stats = new RowBufferStats("COL1");
 
     Assert.assertNull(stats.getCollationDefinitionString());
     Assert.assertNull(stats.getCurrentMinRealValue());
@@ -85,7 +85,7 @@ public class RowBufferStatsTest {
 
   @Test
   public void testMinMaxStrNonCol() throws Exception {
-    RowBufferStats stats = new RowBufferStats();
+    RowBufferStats stats = new RowBufferStats("COL1");
 
     stats.addStrValue("bob");
     Assert.assertEquals("bob", stats.getCurrentMinColStrValue());
@@ -112,7 +112,7 @@ public class RowBufferStatsTest {
 
   @Test
   public void testStrTruncation() throws Exception {
-    RowBufferStats stats = new RowBufferStats();
+    RowBufferStats stats = new RowBufferStats("COL1");
     stats.addStrValue("abcde|abcde|abcde|abcde|abcde|abcde|");
     Assert.assertEquals("abcde|abcde|abcde|abcde|abcde|ab", stats.getCurrentMinColStrValue());
     Assert.assertEquals("abcde|abcde|abcde|abcde|abcde|ac", stats.getCurrentMaxColStrValue());
@@ -121,7 +121,7 @@ public class RowBufferStatsTest {
     Assert.assertEquals("abcde|abcde|abcde|abcde|abcde|ab", stats.getCurrentMinColStrValue());
     Assert.assertEquals("zabcde|abcde|abcde|abcde|abcde|b", stats.getCurrentMaxColStrValue());
 
-    RowBufferStats ai = new RowBufferStats("en-ai");
+    RowBufferStats ai = new RowBufferStats("COL1", "en-ai");
     ai.addStrValue("abcde|abcde|abcde|abcde|abcde|abcde|");
     Assert.assertEquals("abcde|abcde|abcde|abcde|abcde|ab", ai.getCurrentMinColStrValue());
     Assert.assertEquals("abcde|abcde|abcde|abcde|abcde|ac", ai.getCurrentMaxColStrValue());
@@ -133,7 +133,7 @@ public class RowBufferStatsTest {
 
   @Test
   public void testMinMaxStrCol() throws Exception {
-    RowBufferStats stats = new RowBufferStats("en-ci");
+    RowBufferStats stats = new RowBufferStats("COL1", "en-ci");
 
     Assert.assertEquals("en-ci", stats.getCollationDefinitionString());
 
@@ -161,7 +161,7 @@ public class RowBufferStatsTest {
 
   @Test
   public void testMinMaxInt() throws Exception {
-    RowBufferStats stats = new RowBufferStats();
+    RowBufferStats stats = new RowBufferStats("COL1");
 
     stats.addIntValue(BigInteger.valueOf(5));
     Assert.assertEquals(BigInteger.valueOf((5)), stats.getCurrentMinIntValue());
@@ -188,7 +188,7 @@ public class RowBufferStatsTest {
 
   @Test
   public void testMinMaxReal() throws Exception {
-    RowBufferStats stats = new RowBufferStats();
+    RowBufferStats stats = new RowBufferStats("COL1");
 
     stats.addRealValue(1.0);
     Assert.assertEquals(Double.valueOf(1), stats.getCurrentMinRealValue());
@@ -215,7 +215,7 @@ public class RowBufferStatsTest {
 
   @Test
   public void testIncCurrentNullCount() throws Exception {
-    RowBufferStats stats = new RowBufferStats();
+    RowBufferStats stats = new RowBufferStats("COL1");
 
     Assert.assertEquals(0, stats.getCurrentNullCount());
     stats.incCurrentNullCount();
@@ -226,7 +226,7 @@ public class RowBufferStatsTest {
 
   @Test
   public void testMaxLength() throws Exception {
-    RowBufferStats stats = new RowBufferStats();
+    RowBufferStats stats = new RowBufferStats("COL1");
 
     Assert.assertEquals(0, stats.getCurrentMaxLength());
     stats.setCurrentMaxLength(100L);
@@ -238,8 +238,8 @@ public class RowBufferStatsTest {
   @Test
   public void testGetCombinedStats() throws Exception {
     // Test for Integers
-    RowBufferStats one = new RowBufferStats();
-    RowBufferStats two = new RowBufferStats();
+    RowBufferStats one = new RowBufferStats("COL1");
+    RowBufferStats two = new RowBufferStats("COL1");
 
     one.addIntValue(BigInteger.valueOf(2));
     one.addIntValue(BigInteger.valueOf(4));
@@ -265,8 +265,8 @@ public class RowBufferStatsTest {
     Assert.assertNull(result.getCurrentMaxRealValue());
 
     // Test for Reals
-    one = new RowBufferStats();
-    two = new RowBufferStats();
+    one = new RowBufferStats("COL1");
+    two = new RowBufferStats("COL1");
 
     one.addRealValue(2d);
     one.addRealValue(4d);
@@ -291,8 +291,8 @@ public class RowBufferStatsTest {
     Assert.assertNull(result.getCurrentMaxIntValue());
 
     // Test for Strings without collation
-    one = new RowBufferStats();
-    two = new RowBufferStats();
+    one = new RowBufferStats("COL1");
+    two = new RowBufferStats("COL1");
 
     one.addStrValue("alpha");
     one.addStrValue("d");
@@ -321,8 +321,8 @@ public class RowBufferStatsTest {
     Assert.assertNull(result.getCurrentMaxIntValue());
 
     // Test for Strings with collation
-    one = new RowBufferStats("en-ci");
-    two = new RowBufferStats("en-ci");
+    one = new RowBufferStats("COL1", "en-ci");
+    two = new RowBufferStats("COL1", "en-ci");
 
     one.addStrValue("a");
     one.addStrValue("d");
@@ -351,8 +351,8 @@ public class RowBufferStatsTest {
   @Test
   public void testGetCombinedStatsNull() throws Exception {
     // Test for Integers
-    RowBufferStats one = new RowBufferStats();
-    RowBufferStats two = new RowBufferStats();
+    RowBufferStats one = new RowBufferStats("COL1");
+    RowBufferStats two = new RowBufferStats("COL1");
 
     one.addIntValue(BigInteger.valueOf(2));
     one.addIntValue(BigInteger.valueOf(4));
@@ -373,7 +373,7 @@ public class RowBufferStatsTest {
     Assert.assertNull(result.getCurrentMaxRealValue());
 
     // Test for Reals
-    one = new RowBufferStats();
+    one = new RowBufferStats("COL1");
 
     one.addRealValue(2d);
     one.addRealValue(4d);
@@ -392,8 +392,8 @@ public class RowBufferStatsTest {
     Assert.assertNull(result.getCurrentMaxIntValue());
 
     // Test for Strings
-    one = new RowBufferStats();
-    two = new RowBufferStats();
+    one = new RowBufferStats("COL1");
+    two = new RowBufferStats("COL1");
 
     one.addStrValue("alpha");
     one.addStrValue("d");

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -153,6 +153,7 @@ public class RowBufferTest {
 
     // Fixed LOB
     testCol = new ColumnMetadata();
+    testCol.setName("COL1");
     testCol.setPhysicalType("LOB");
     testCol.setLogicalType("FIXED");
     try {
@@ -164,6 +165,7 @@ public class RowBufferTest {
 
     // TIMESTAMP_NTZ SB2
     testCol = new ColumnMetadata();
+    testCol.setName("COL1");
     testCol.setPhysicalType("SB2");
     testCol.setLogicalType("TIMESTAMP_NTZ");
     try {
@@ -175,6 +177,7 @@ public class RowBufferTest {
 
     // TIMESTAMP_TZ SB1
     testCol = new ColumnMetadata();
+    testCol.setName("COL1");
     testCol.setPhysicalType("SB1");
     testCol.setLogicalType("TIMESTAMP_TZ");
     try {
@@ -186,6 +189,7 @@ public class RowBufferTest {
 
     // TIME SB16
     testCol = new ColumnMetadata();
+    testCol.setName("COL1");
     testCol.setPhysicalType("SB16");
     testCol.setLogicalType("TIME");
     try {
@@ -454,12 +458,12 @@ public class RowBufferTest {
   public void testBuildEpInfoFromStats() {
     Map<String, RowBufferStats> colStats = new HashMap<>();
 
-    RowBufferStats stats1 = new RowBufferStats();
+    RowBufferStats stats1 = new RowBufferStats("intColumn");
     stats1.addIntValue(BigInteger.valueOf(2));
     stats1.addIntValue(BigInteger.valueOf(10));
     stats1.addIntValue(BigInteger.valueOf(1));
 
-    RowBufferStats stats2 = new RowBufferStats();
+    RowBufferStats stats2 = new RowBufferStats("strColumn");
     stats2.addStrValue("alice");
     stats2.addStrValue("bob");
     stats2.incCurrentNullCount();
@@ -490,11 +494,13 @@ public class RowBufferTest {
     final String realColName = "realCol";
     Map<String, RowBufferStats> colStats = new HashMap<>();
 
-    RowBufferStats stats = new RowBufferStats();
-    stats.incCurrentNullCount();
+    RowBufferStats stats1 = new RowBufferStats(intColName);
+    RowBufferStats stats2 = new RowBufferStats(realColName);
+    stats1.incCurrentNullCount();
+    stats2.incCurrentNullCount();
 
-    colStats.put(intColName, stats);
-    colStats.put(realColName, stats);
+    colStats.put(intColName, stats1);
+    colStats.put(realColName, stats2);
 
     EpInfo result = AbstractRowBuffer.buildEpInfoFromStats(2, colStats);
     Map<String, FileColumnProperties> columnResults = result.getColumnEps();
@@ -538,7 +544,7 @@ public class RowBufferTest {
     InsertValidationResponse response = rowBuffer.insertRows(Collections.singletonList(row1), null);
     Assert.assertFalse(response.hasErrors());
 
-    Assert.assertEquals((byte) 10, rowBuffer.getVectorValueAt("\"colTinyInt\"", 0));
+    Assert.assertEquals((byte) 10, rowBuffer.getVectorValueAt("colTinyInt", 0));
     Assert.assertEquals((byte) 1, rowBuffer.getVectorValueAt("COLTINYINT", 0));
     Assert.assertEquals((short) 2, rowBuffer.getVectorValueAt("COLSMALLINT", 0));
     Assert.assertEquals(3, rowBuffer.getVectorValueAt("COLINT", 0));
@@ -615,11 +621,11 @@ public class RowBufferTest {
     Map<String, RowBufferStats> columnEpStats = result.getColumnEps();
 
     Assert.assertEquals(
-        BigInteger.valueOf(11), columnEpStats.get("\"colTinyInt\"").getCurrentMaxIntValue());
+        BigInteger.valueOf(11), columnEpStats.get("colTinyInt").getCurrentMaxIntValue());
     Assert.assertEquals(
-        BigInteger.valueOf(10), columnEpStats.get("\"colTinyInt\"").getCurrentMinIntValue());
-    Assert.assertEquals(0, columnEpStats.get("\"colTinyInt\"").getCurrentNullCount());
-    Assert.assertEquals(-1, columnEpStats.get("\"colTinyInt\"").getDistinctValues());
+        BigInteger.valueOf(10), columnEpStats.get("colTinyInt").getCurrentMinIntValue());
+    Assert.assertEquals(0, columnEpStats.get("colTinyInt").getCurrentNullCount());
+    Assert.assertEquals(-1, columnEpStats.get("colTinyInt").getDistinctValues());
 
     Assert.assertEquals(
         BigInteger.valueOf(1), columnEpStats.get("COLTINYINT").getCurrentMaxIntValue());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -460,7 +460,7 @@ public class SnowflakeStreamingIngestClientTest {
             .build();
 
     Map<String, RowBufferStats> columnEps = new HashMap<>();
-    columnEps.put("column", new RowBufferStats());
+    columnEps.put("column", new RowBufferStats("COL1"));
     EpInfo epInfo = AbstractRowBuffer.buildEpInfoFromStats(1, columnEps);
 
     ChunkMetadata chunkMetadata =
@@ -501,7 +501,7 @@ public class SnowflakeStreamingIngestClientTest {
 
   private Pair<List<BlobMetadata>, Set<ChunkRegisterStatus>> getRetryBlobMetadata() {
     Map<String, RowBufferStats> columnEps = new HashMap<>();
-    columnEps.put("column", new RowBufferStats());
+    columnEps.put("column", new RowBufferStats("COL1"));
     EpInfo epInfo = AbstractRowBuffer.buildEpInfoFromStats(1, columnEps);
 
     ChannelMetadata channelMetadata1 =

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -973,6 +973,88 @@ public class StreamingIngestIT {
     }
   }
 
+  @Test
+  public void testColumnNameQuotes() throws Exception {
+    final String tableName = "T_COLUMN_WITH_QUOTES";
+    final String unquotedColumn = "c1"; // user name <C1>
+    final String quotedColumn = "\"c 2\""; // user name <c 2>
+    final String doubleQuotedColumn = "\"c\"\"a\\ \"\"\\ 3\""; // user name <c"a\ "\ 3>
+    final String escapedSpacesColumn1 =
+        "c\\ 4"; // space is escaped with '\' in Snowflake SQL, user name <C 4>
+    final String escapedSpacesColumn2 =
+        "c\\ 5"; // space is escaped with '\' in Snowflake SQL, user name <C 5>
+    jdbcConnection
+        .createStatement()
+        .execute(
+            String.format(
+                "create or replace table %s.%s.%s (%s NUMBER(38,0), %s NUMBER(38,0), %s"
+                    + " NUMBER(38,0), %s NUMBER(38,0), %s NUMBER(38,0));",
+                testDb,
+                TEST_SCHEMA,
+                tableName,
+                unquotedColumn,
+                quotedColumn,
+                doubleQuotedColumn,
+                escapedSpacesColumn1,
+                escapedSpacesColumn2));
+
+    OpenChannelRequest request1 =
+        OpenChannelRequest.builder("CHANNEL")
+            .setDBName(testDb)
+            .setSchemaName(TEST_SCHEMA)
+            .setTableName(tableName)
+            .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
+            .build();
+
+    // Open a streaming ingest channel from the given client
+    SnowflakeStreamingIngestChannel channel1 = client.openChannel(request1);
+    for (int val = 0; val < 10; val++) {
+      Map<String, Object> row = new HashMap<>();
+      row.put(unquotedColumn, val);
+      row.put(quotedColumn, val);
+      row.put(doubleQuotedColumn, val);
+      row.put(escapedSpacesColumn1, val);
+      // space escape '\' is not really required, because Java always has its own outer double
+      // quotes.
+      // hence, it happens to also work w/o the space escape after the internal literal
+      // normalisation.
+      String escapedSpacesColumn2NoSpaceEscape = escapedSpacesColumn2.replace("\\", "");
+      row.put(escapedSpacesColumn2NoSpaceEscape, val);
+      verifyInsertValidationResponse(channel1.insertRow(row, Integer.toString(val)));
+    }
+
+    // Close the channel after insertion
+    channel1.close().get();
+
+    for (int i = 1; i < 15; i++) {
+      if (channel1.getLatestCommittedOffsetToken() != null
+          && channel1.getLatestCommittedOffsetToken().equals("9")) {
+        ResultSet result =
+            jdbcConnection
+                .createStatement()
+                .executeQuery(
+                    String.format(
+                        "select %s, %s, %s, %s, %s from %s.%s.%s order by %s",
+                        unquotedColumn,
+                        quotedColumn,
+                        doubleQuotedColumn,
+                        escapedSpacesColumn1,
+                        escapedSpacesColumn2,
+                        testDb,
+                        TEST_SCHEMA,
+                        tableName,
+                        unquotedColumn));
+        for (int val = 0; val < 10; val++) {
+          result.next();
+          for (int index = 1; index <= 5; index++) Assert.assertEquals(val, result.getInt(index));
+        }
+        return;
+      }
+      Thread.sleep(500);
+    }
+    Assert.fail("Row sequencer not updated before timeout");
+  }
+
   /** Verify the insert validation response and throw the exception if needed */
   private void verifyInsertValidationResponse(InsertValidationResponse response) {
     if (response.hasErrors()) {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/it/ColumnNamesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/it/ColumnNamesIT.java
@@ -1,0 +1,175 @@
+package net.snowflake.ingest.streaming.internal.it;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import net.snowflake.ingest.TestUtils;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.streaming.internal.datatypes.AbstractDataTypeTest;
+import net.snowflake.ingest.utils.Constants;
+import net.snowflake.ingest.utils.SFException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ColumnNamesIT extends AbstractDataTypeTest {
+  private static final int INGEST_VALUE = 1;
+
+  public ColumnNamesIT(String name, Constants.BdecVersion bdecVersion) {
+    super(name, bdecVersion);
+  }
+
+  @Test
+  public void testColumnNamesSupport() throws Exception {
+    // Test simple case
+    testWorks("FOO", "FOO");
+    testWorks("FOO", "FoO");
+    testWorks("FOO", "\"FOO\"");
+    testDoesNotWork("FOO", "\"Foo\"");
+
+    // Test quoted identifier
+    testWorks("\"FOO\"", "\"FOO\"");
+    testWorks("\"FOO\"", "FOO");
+    testWorks("\"FOO\"", "Foo");
+    testDoesNotWork("\"FOO\"", "\"Foo\"");
+
+    testWorks("\"Foo\"", "\"Foo\"");
+    testDoesNotWork("\"Foo\"", "Foo");
+
+    // Test keyword
+    testWorks("\"CReATE\"", "\"CReATE\"");
+    testWorks("\"CREATE\"", "CReATE");
+    testDoesNotWork("\"CReATE\"", "\"CREATE\"");
+    testDoesNotWork("\"CReATE\"", "CReATE");
+
+    // Test escaped space
+    testWorks("fO\\ O", "fO\\ O");
+    testWorks("fO\\ O", "fO\\ o");
+    testWorks("fO\\ O", "fO O");
+    testWorks("fO\\ O", "fO o");
+    testWorks("fO\\ O", "\"FO O\"");
+    testDoesNotWork("fO\\ O", "\"FO\\ O\"");
+
+    // Test double quotes
+    testWorks("\"\"\"\"", "\"");
+    testWorks("\"\"\"\"", "\"\"\"\"");
+    testDoesNotWork("\"\"\"\"", "\"\"\"\"\"\"");
+
+    // Test quoted column with spaces
+    testWorks("\"FO O\"", "FO O");
+    testWorks("\"FO O\"", "\"FO O\"");
+    testDoesNotWork("\"FO O\"", "\"FO\\ O\"");
+  }
+
+  @Test
+  public void testNonstandardTableAndColumnNames() throws Exception {
+    testWorks("fo\\ o");
+    testWorks("foo");
+    testWorks("\"foo\"");
+    testWorks("\"fo o\"");
+    testWorks("\"alter\"");
+    testWorks("\"table\"");
+    testWorks("\"  \"");
+    testWorks("\"\"");
+    testWorks("\"a\"\"b\"");
+    testWorks("\"\"\"\"");
+    testWorks("\"  \"\"  \"\"  \"");
+    testWorks("\"  \"\" Ť \"\"  \"");
+  }
+
+  /** Tests that quoted columns are correctly resolved for null-backfill */
+  @Test
+  public void testNullableResolution() throws Exception {
+    String tableName = "t1";
+    conn.createStatement()
+        .execute(
+            String.format(
+                "create or replace table %s (AbC int, \"AbC\" int, \"abC\" int, ab\\ c int, \"Ab"
+                    + " c\" int);",
+                tableName));
+    SnowflakeStreamingIngestChannel channel = openChannel(tableName);
+    String offsetToken = "token1";
+    channel.insertRow(new HashMap<>(), offsetToken);
+    TestUtils.waitForOffset(channel, offsetToken);
+
+    ResultSet rs =
+        conn.createStatement().executeQuery(String.format("select * from %s", tableName));
+    rs.next();
+    Assert.assertNull(rs.getObject(1));
+    Assert.assertNull(rs.getObject(2));
+    Assert.assertNull(rs.getObject(3));
+    Assert.assertNull(rs.getObject(4));
+    Assert.assertNull(rs.getObject(5));
+  }
+
+  /** Tests that quoted columns are correctly resolved for not-null checks */
+  @Test
+  public void testNonNullableResolution() throws Exception {
+    String tableName = "t1";
+    conn.createStatement()
+        .execute(
+            String.format(
+                "create or replace table %s (AbC int not null, \"AbC\" int not null);", tableName));
+    SnowflakeStreamingIngestChannel channel = openChannel(tableName);
+    testInsertRowFails(channel, Collections.singletonMap("AbC", 1));
+    testInsertRowFails(channel, Collections.singletonMap("\"AbC\"", 1));
+  }
+
+  private void testWorks(String column) throws SQLException, InterruptedException {
+    testWorks(column, column);
+  }
+
+  /** Verifies that column names that are not support to work, does not work */
+  private void testDoesNotWork(String createTableColumnName, String ingestColumnName)
+      throws SQLException {
+
+    Map<String, Object> row = new HashMap<>();
+    row.put(ingestColumnName, INGEST_VALUE);
+
+    SnowflakeStreamingIngestChannel channel = openChannel(createSimpleTable(createTableColumnName));
+    testInsertRowFails(channel, row);
+  }
+
+  private void testInsertRowFails(
+      SnowflakeStreamingIngestChannel channel, Map<String, Object> row) {
+    try {
+      channel.insertRow(row, UUID.randomUUID().toString());
+      Assert.fail("Ingest row should not succeed");
+    } catch (SFException e) {
+      // all good, expected exception has been thrown
+    }
+  }
+
+  private void testWorks(String createTableColumnName, String ingestColumnName)
+      throws SQLException, InterruptedException {
+
+    String tableName = createSimpleTable(createTableColumnName);
+    String offsetToken = UUID.randomUUID().toString();
+    SnowflakeStreamingIngestChannel channel = openChannel(tableName);
+    Map<String, Object> row = new HashMap<>();
+    row.put(ingestColumnName, INGEST_VALUE);
+    channel.insertRow(row, offsetToken);
+
+    TestUtils.waitForOffset(channel, offsetToken);
+
+    // Verify that supported columns work
+    ResultSet rs =
+        conn.createStatement().executeQuery(String.format("select * from %s;", tableName));
+    int count = 0;
+    while (rs.next()) {
+      count++;
+      Assert.assertEquals(INGEST_VALUE, rs.getInt(1));
+    }
+    Assert.assertEquals(1, count);
+  }
+
+  private String createSimpleTable(String createTableColumnName) throws SQLException {
+    String tableName = "a" + UUID.randomUUID().toString().replace("-", "_");
+    String createTableSql =
+        String.format("create table %s (%s int);", tableName, createTableColumnName);
+    conn.createStatement().execute(createTableSql);
+    return tableName;
+  }
+}


### PR DESCRIPTION
This PR implements support for quoted column names. In the code, internal unquoted name is used everywhere with the exception of statistics because REST API expects column display name in EpInfo.

Testing
Integration tests have been added with coverage for various corner cases.