### PR TITLE
SNOW-703928 add two system properties for IT tests

### DIFF
--- a/src/test/java/net/snowflake/ingest/TestUtils.java
+++ b/src/test/java/net/snowflake/ingest/TestUtils.java
@@ -91,7 +91,11 @@ public class TestUtils {
    * @throws IOException if can't read profile
    */
   private static void init() throws Exception {
-    Path path = Paths.get(PROFILE_PATH);
+    String testProfilePath =
+        System.getProperty("testProfilePath") != null
+            ? System.getProperty("testProfilePath")
+            : PROFILE_PATH;
+    Path path = Paths.get(testProfilePath);
 
     if (Files.exists(path)) {
       profile = (ObjectNode) mapper.readTree(new String(Files.readAllBytes(path)));

--- a/src/test/java/net/snowflake/ingest/TestUtils.java
+++ b/src/test/java/net/snowflake/ingest/TestUtils.java
@@ -28,6 +28,8 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Properties;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
@@ -91,10 +93,7 @@ public class TestUtils {
    * @throws IOException if can't read profile
    */
   private static void init() throws Exception {
-    String testProfilePath =
-        System.getProperty("testProfilePath") != null
-            ? System.getProperty("testProfilePath")
-            : PROFILE_PATH;
+    String testProfilePath = getTestProfilePath();
     Path path = Paths.get(testProfilePath);
 
     if (Files.exists(path)) {
@@ -131,6 +130,35 @@ public class TestUtils {
       privateKey = keyPair.getPrivate();
       privateKeyPem = java.util.Base64.getEncoder().encodeToString(privateKey.getEncoded());
     }
+  }
+
+  /** @return profile path that will be used for tests. */
+  private static String getTestProfilePath() {
+    String testProfilePath =
+        System.getProperty("testProfilePath") != null
+            ? System.getProperty("testProfilePath")
+            : PROFILE_PATH;
+    return testProfilePath;
+  }
+
+  /** @return list of Bdec versions for which to execute IT tests. */
+  public static Collection<Object[]> getBdecVersionItCases() {
+    boolean enableParquetTests =
+        System.getProperty("enableParquetTests") != null
+            && Boolean.parseBoolean(System.getProperty("enableParquetTests"));
+    if (enableParquetTests) {
+      return Arrays.asList(
+          new Object[][] {
+            {"Arrow", Constants.BdecVersion.ONE}, {"Parquet", Constants.BdecVersion.THREE}
+          });
+    }
+    return Arrays.asList(
+        new Object[][] {
+          {"Arrow", Constants.BdecVersion.ONE},
+          // TODO: uncomment once SNOW-659721 is deployed and we set the parameter
+          // DISABLE_PARQUET_CACHE to true for the test account
+          // {"Parquet", Constants.BdecVersion.THREE}
+        });
   }
 
   public static String getUser() throws Exception {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -48,6 +48,15 @@ import org.junit.runners.Parameterized;
 public class StreamingIngestIT {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> bdecVersion() {
+    boolean enableParquetTests =
+        System.getProperty("enableParquetTests") != null
+            && Boolean.parseBoolean(System.getProperty("enableParquetTests"));
+    if (enableParquetTests) {
+      return Arrays.asList(
+          new Object[][] {
+            {"Arrow", Constants.BdecVersion.ONE}, {"Parquet", Constants.BdecVersion.THREE}
+          });
+    }
     return Arrays.asList(
         new Object[][] {
           {"Arrow", Constants.BdecVersion.ONE},

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -48,22 +48,7 @@ import org.junit.runners.Parameterized;
 public class StreamingIngestIT {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> bdecVersion() {
-    boolean enableParquetTests =
-        System.getProperty("enableParquetTests") != null
-            && Boolean.parseBoolean(System.getProperty("enableParquetTests"));
-    if (enableParquetTests) {
-      return Arrays.asList(
-          new Object[][] {
-            {"Arrow", Constants.BdecVersion.ONE}, {"Parquet", Constants.BdecVersion.THREE}
-          });
-    }
-    return Arrays.asList(
-        new Object[][] {
-          {"Arrow", Constants.BdecVersion.ONE},
-          // TODO: uncomment once SNOW-659721 is deployed and we set the parameter
-          // DISABLE_PARQUET_CACHE to true for the test account
-          // {"Parquet", Constants.BdecVersion.THREE}
-        });
+    return TestUtils.getBdecVersionItCases();
   }
 
   private static final String TEST_TABLE = "STREAMING_INGEST_TEST_TABLE";

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -33,6 +33,15 @@ import org.junit.runners.Parameterized;
 public abstract class AbstractDataTypeTest {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> bdecVersion() {
+    boolean enableParquetTests =
+        System.getProperty("enableParquetTests") != null
+            && Boolean.parseBoolean(System.getProperty("enableParquetTests"));
+    if (enableParquetTests) {
+      return Arrays.asList(
+          new Object[][] {
+            {"Arrow", Constants.BdecVersion.ONE}, {"Parquet", Constants.BdecVersion.THREE}
+          });
+    }
     return Arrays.asList(
         new Object[][] {
           {"Arrow", Constants.BdecVersion.ONE},

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -9,7 +9,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,22 +32,7 @@ import org.junit.runners.Parameterized;
 public abstract class AbstractDataTypeTest {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> bdecVersion() {
-    boolean enableParquetTests =
-        System.getProperty("enableParquetTests") != null
-            && Boolean.parseBoolean(System.getProperty("enableParquetTests"));
-    if (enableParquetTests) {
-      return Arrays.asList(
-          new Object[][] {
-            {"Arrow", Constants.BdecVersion.ONE}, {"Parquet", Constants.BdecVersion.THREE}
-          });
-    }
-    return Arrays.asList(
-        new Object[][] {
-          {"Arrow", Constants.BdecVersion.ONE},
-          // TODO: uncomment once SNOW-659721 is deployed and we set the parameter
-          // DISABLE_PARQUET_CACHE to true for the test account
-          // {"Parquet", Constants.BdecVersion.THREE}
-        });
+    return TestUtils.getBdecVersionItCases();
   }
 
   private static final String SOURCE_COLUMN_NAME = "source";


### PR DESCRIPTION
Since a couple of IT tests are not run with Parquet format as part of merge gates, we want to have the ability to run them internally (in precommits) before merging changes. This can be done be setting the `-DenableParquetTests=true` and `-DtestProfile_path=profile.json` properties.