### PR TITLE
SNOW-704566 Add filename in Parquet extra MD

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -343,10 +343,11 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
    * Flush the data in the row buffer by taking the ownership of the old vectors and pass all the
    * required info back to the flush service to build the blob
    *
+   * @param filePath the name of the file the data will be written in
    * @return A ChannelData object that contains the info needed by the flush service to build a blob
    */
   @Override
-  public ChannelData<T> flush() {
+  public ChannelData<T> flush(final String filePath) {
     logger.logDebug("Start get data for channel={}", channelFullyQualifiedName);
     if (this.rowCount > 0) {
       Optional<T> oldData = Optional.empty();
@@ -363,7 +364,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       try {
         if (this.rowCount > 0) {
           // Transfer the ownership of the vectors
-          oldData = getSnapshot();
+          oldData = getSnapshot(filePath);
           oldRowCount = this.rowCount;
           oldBufferSize = this.bufferSize;
           oldRowSequencer = this.channelState.incrementAndGetRowSequencer();
@@ -451,8 +452,12 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
             new RowBufferStats(value.getColumnDisplayName(), value.getCollationDefinitionString()));
   }
 
-  /** Get buffered data snapshot for later flushing. */
-  abstract Optional<T> getSnapshot();
+  /**
+   * Get buffered data snapshot for later flushing.
+   *
+   * @param filePath the name of the file the data will be written in
+   */
+  abstract Optional<T> getSnapshot(final String filePath);
 
   @VisibleForTesting
   abstract Object getVectorValueAt(String column, int index);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -366,7 +366,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
   }
 
   @Override
-  Optional<VectorSchemaRoot> getSnapshot() {
+  Optional<VectorSchemaRoot> getSnapshot(final String filePath) {
     List<FieldVector> oldVectors = new ArrayList<>();
     for (FieldVector vector : this.vectorsRoot.getFieldVectors()) {
       vector.setValueCount(this.rowCount);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBuffer.java
@@ -36,9 +36,10 @@ interface RowBuffer<T> {
    * Flush the data in the row buffer by taking the ownership of the old vectors and pass all the
    * required info back to the flush service to build the blob
    *
+   * @param filePath the name of the file the data will be written in
    * @return A ChannelData object that contains the info needed by the flush service to build a blob
    */
-  ChannelData<T> flush();
+  ChannelData<T> flush(final String filePath);
 
   /**
    * Close the row buffer and release resources. Note that the caller needs to handle

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -186,10 +186,11 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   /**
    * Get all the data needed to build the blob during flush
    *
+   * @param filePath the name of the file the data will be written in
    * @return a ChannelData object
    */
-  ChannelData<T> getData() {
-    ChannelData<T> data = this.rowBuffer.flush();
+  ChannelData<T> getData(final String filePath) {
+    ChannelData<T> data = this.rowBuffer.flush(filePath);
     if (data != null) {
       data.setChannelContext(channelFlushContext);
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtils.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtils.java
@@ -117,4 +117,9 @@ public class StreamingIngestUtils {
     } while (retries <= MAX_STREAMING_INGEST_API_CHANNEL_RETRY);
     return response;
   }
+
+  public static String getShortname(final String fullname) {
+    final String[] parts = fullname.split("/");
+    return parts[parts.length - 1];
+  }
 }

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -25,6 +25,8 @@ public class Constants {
   public static final String PRIVATE_KEY = "private_key";
   public static final String PRIVATE_KEY_PASSPHRASE = "private_key_passphrase";
   public static final String JDBC_PRIVATE_KEY = "privateKey";
+  public static final String PRIMARY_FILE_ID_KEY =
+      "primaryFileId"; // Don't change, should match Parquet Scanner
   public static final long RESPONSE_SUCCESS = 0L; // Don't change, should match server side
   public static final long RESPONSE_ERR_GENERAL_EXCEPTION_RETRY_REQUEST =
       10L; // Don't change, should match server side

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
@@ -48,7 +48,8 @@ public class ArrowBufferTest {
         rowBufferOnErrorContinue.insertRows(Collections.singletonList(row), offsetToken);
     Assert.assertFalse(response.hasErrors());
 
-    ChannelData<VectorSchemaRoot> data = rowBufferOnErrorContinue.flush();
+    ChannelData<VectorSchemaRoot> data =
+        rowBufferOnErrorContinue.flush("my_snowpipe_streaming.bdec");
     Assert.assertEquals(7, data.getVectors().getFieldVectors().size());
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -101,7 +101,7 @@ public class FlushServiceTest {
 
     ChannelData<T> flushChannel(String name) {
       SnowflakeStreamingIngestChannelInternal<T> channel = channels.get(name);
-      ChannelData<T> channelData = channel.getRowBuffer().flush();
+      ChannelData<T> channelData = channel.getRowBuffer().flush(name + "_snowpipe_streaming.bdec");
       channelData.setChannelContext(channel.getChannelContext());
       this.channelData.add(channelData);
       return channelData;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -494,7 +494,7 @@ public class SnowflakeStreamingIngestChannelTest {
     row.put("col", 1);
 
     // Get data before insert to verify that there is no row (data should be null)
-    ChannelData<VectorSchemaRoot> data = channel.getData();
+    ChannelData<VectorSchemaRoot> data = channel.getData("my_snowpipe_streaming.bdec");
     Assert.assertNull(data);
 
     InsertValidationResponse response = channel.insertRow(row, "1");
@@ -503,7 +503,7 @@ public class SnowflakeStreamingIngestChannelTest {
     Assert.assertFalse(response.hasErrors());
 
     // Get data again to verify the row is inserted
-    data = channel.getData();
+    data = channel.getData("my_snowpipe_streaming.bdec");
     Assert.assertEquals(2, data.getRowCount());
     Assert.assertEquals((Long) 1L, data.getRowSequencer());
     Assert.assertEquals(1, data.getVectors().getFieldVectors().size());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
@@ -54,6 +54,11 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({TestUtils.class, HttpUtil.class, SnowflakeFileTransferAgent.class})
 public class StreamingIngestStageTest {
+
+  private final String prefix = "EXAMPLE_PREFIX";
+
+  private final long deploymentId = 123;
+
   private ObjectMapper mapper = new ObjectMapper();
 
   final String exampleRemoteMeta =
@@ -78,8 +83,13 @@ public class StreamingIngestStageTest {
 
   String exampleRemoteMetaResponse =
       "{\"src_locations\": [\"foo/\"],"
+          + " \"deployment_id\": "
+          + deploymentId
+          + ","
           + " \"status_code\": 0, \"message\": \"Success\", \"prefix\":"
-          + " \"EXAMPLE_PREFIX\", \"stage_location\": {\"locationType\": \"S3\", \"location\":"
+          + " \""
+          + prefix
+          + "\", \"stage_location\": {\"locationType\": \"S3\", \"location\":"
           + " \"foo/streaming_ingest/\", \"path\": \"streaming_ingest/\", \"region\":"
           + " \"us-east-1\", \"storageAccount\": null, \"isClientSideEncrypted\": true,"
           + " \"creds\": {\"AWS_KEY_ID\": \"EXAMPLE_AWS_KEY_ID\", \"AWS_SECRET_KEY\":"
@@ -279,6 +289,7 @@ public class StreamingIngestStageTest {
         "foo/streaming_ingest/", metadataWithAge.fileTransferMetadata.getStageInfo().getLocation());
     Assert.assertEquals(
         "placeholder", metadataWithAge.fileTransferMetadata.getPresignedUrlFileName());
+    Assert.assertEquals(prefix + "_" + deploymentId, stage.getClientPrefix());
   }
 
   @Test


### PR DESCRIPTION
This is the client SDK part of the fix for streams on replicated mixed tables, as described [here](https://docs.google.com/document/d/1MZWhyQznTSinT9ZhKYnOO3UIof2n_qAUWVu1S3qZdaY/edit#heading=h.w6d46ulzf6d2). It will only work for Parquet, as we are not planning to go PuPr with Arrow.

The XP and the GS parts are implemented in these two PRs: https://github.com/snowflakedb/snowflake/pull/80212 (for GS) and https://github.com/snowflakedb/snowflake/pull/80209 (for XP).