### PR TITLE
@snow SNOW-705508 Exclude slf4j-reload4j from Hadoop dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,10 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -405,6 +409,10 @@
                 <exclusion>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Hadoop dependencies add custom logging implementation that should be provided by users, not by the library.
The PR excludes logging for the Hadoop dependencies.