### PR TITLE
SNOW-706682 Log retry-related messages as INFO

### DIFF
--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -231,7 +231,7 @@ public class HttpUtil {
                 || statusCode >= SERVER_ERRORS);
         if (needNextRetry) {
           long interval = getRetryInterval();
-          LOGGER.warn(
+          LOGGER.info(
               "In retryRequest for service unavailability with statusCode:{} and uri:{}",
               statusCode,
               getRequestUriFromContext(context));


### PR DESCRIPTION
429 responses are going to occasionally happen, the SDK will retry and there is no need to scare the users by logging these events on WARN level.