### PR TITLE
SNOW-710401 Avoid datetime parsing wherever possible

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -557,7 +557,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
                 {
                   BigIntVector bigIntVector = (BigIntVector) vector;
                   TimestampWrapper timestampWrapper =
-                      DataValidationUtil.validateAndParseTimestampNtzSb16(
+                      DataValidationUtil.validateAndParseTimestamp(
                           stats.getColumnDisplayName(),
                           value,
                           getColumnScale(field.getMetadata()),
@@ -578,7 +578,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
                   structVector.setIndexDefined(curRowIndex);
 
                   TimestampWrapper timestampWrapper =
-                      DataValidationUtil.validateAndParseTimestampNtzSb16(
+                      DataValidationUtil.validateAndParseTimestamp(
                           stats.getColumnDisplayName(),
                           value,
                           getColumnScale(field.getMetadata()),
@@ -606,8 +606,11 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
                   structVector.setIndexDefined(curRowIndex);
 
                   TimestampWrapper timestampWrapper =
-                      DataValidationUtil.validateAndParseTimestampTz(
-                          stats.getColumnDisplayName(), value, getColumnScale(field.getMetadata()));
+                      DataValidationUtil.validateAndParseTimestamp(
+                          stats.getColumnDisplayName(),
+                          value,
+                          getColumnScale(field.getMetadata()),
+                          false);
                   epochVector.setSafe(curRowIndex, timestampWrapper.getTimeInScale().longValue());
                   timezoneVector.setSafe(
                       curRowIndex,
@@ -646,8 +649,11 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
                   structVector.setIndexDefined(curRowIndex);
 
                   TimestampWrapper timestampWrapper =
-                      DataValidationUtil.validateAndParseTimestampTz(
-                          stats.getColumnDisplayName(), value, getColumnScale(field.getMetadata()));
+                      DataValidationUtil.validateAndParseTimestamp(
+                          stats.getColumnDisplayName(),
+                          value,
+                          getColumnScale(field.getMetadata()),
+                          false);
                   epochVector.setSafe(curRowIndex, timestampWrapper.getEpoch());
                   fractionVector.setSafe(curRowIndex, timestampWrapper.getFraction());
                   timezoneVector.setSafe(

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -350,15 +350,15 @@ class DataValidationUtil {
               .add(BigInteger.valueOf(fractionInScale));
       return new TimestampWrapper(
           epoch, fractionInScale * Power10.intTable[9 - scale], timeInScale, timestamp);
-    } else {
-      throw valueFormatNotAllowedException(
-          columnName,
-          input.toString(),
-          "TIMESTAMP",
-          "Not a valid timestamp, see"
-              + " https://docs.snowflake.com/en/user-guide/date-time-input-output.html#timestamp-formats"
-              + " for the list of supported formats");
     }
+
+    throw valueFormatNotAllowedException(
+        columnName,
+        input.toString(),
+        "TIMESTAMP",
+        "Not a valid timestamp, see"
+            + " https://docs.snowflake.com/en/user-guide/date-time-input-output.html#timestamp-formats"
+            + " for the list of supported formats");
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
@@ -200,14 +200,13 @@ class ParquetValueParser {
       case TIMESTAMP_NTZ:
         boolean ignoreTimezone = logicalType == AbstractRowBuffer.ColumnLogicalType.TIMESTAMP_NTZ;
         longValue =
-            DataValidationUtil.validateAndParseTimestampNtzSb16(
-                    columnName, value, scale, ignoreTimezone)
+            DataValidationUtil.validateAndParseTimestamp(columnName, value, scale, ignoreTimezone)
                 .getTimeInScale()
                 .longValue();
         break;
       case TIMESTAMP_TZ:
         longValue =
-            DataValidationUtil.validateAndParseTimestampTz(columnName, value, scale)
+            DataValidationUtil.validateAndParseTimestamp(columnName, value, scale, false)
                 .getSfTimestamp()
                 .orElseThrow(
                     () ->
@@ -250,7 +249,7 @@ class ParquetValueParser {
       AbstractRowBuffer.ColumnPhysicalType physicalType) {
     switch (logicalType) {
       case TIMESTAMP_TZ:
-        return DataValidationUtil.validateAndParseTimestampTz(columnName, value, scale)
+        return DataValidationUtil.validateAndParseTimestamp(columnName, value, scale, false)
             .getSfTimestamp()
             .orElseThrow(
                 () ->
@@ -262,7 +261,7 @@ class ParquetValueParser {
       case TIMESTAMP_LTZ:
       case TIMESTAMP_NTZ:
         boolean ignoreTimezone = logicalType == AbstractRowBuffer.ColumnLogicalType.TIMESTAMP_NTZ;
-        return DataValidationUtil.validateAndParseTimestampNtzSb16(
+        return DataValidationUtil.validateAndParseTimestamp(
                 columnName, value, scale, ignoreTimezone)
             .getTimeInScale();
       case FIXED:

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
@@ -864,10 +864,35 @@ public class DateTimeIT extends AbstractDataTypeTest {
         new StringProvider());
     testIngestion(
         "DATE",
+        OffsetDateTime.parse("2007-12-03T00:00:00+01:00"),
+        "2007-12-03",
+        new StringProvider());
+    testIngestion(
+        "DATE",
+        OffsetDateTime.parse("2007-12-03T00:00:00-08:00"),
+        "2007-12-03",
+        new StringProvider());
+    testIngestion(
+        "DATE",
         ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]"),
         "2007-12-03",
         new StringProvider());
-
+    testIngestion(
+        "DATE",
+        ZonedDateTime.parse("2007-12-03T00:00:00+01:00[Europe/Paris]"),
+        "2007-12-03",
+        new StringProvider());
+    testIngestion(
+        "DATE",
+        ZonedDateTime.parse("2007-12-03T00:00:00-08:00[America/Los_Angeles]"),
+        "2007-12-03",
+        new StringProvider());
+    testIngestion(
+        "DATE",
+        ZonedDateTime.parse("2007-07-03T00:00:00-07:00[America/Los_Angeles]"),
+        "2007-07-03",
+        new StringProvider());
+    //
     // TIMESTAMP_NTZ (LocalDate, LocalDateTime, OffsetDateTime, ZonedDateTime are supported)
     testIngestion(
         "TIMESTAMP_NTZ",
@@ -893,6 +918,11 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "TIMESTAMP_NTZ",
         ZonedDateTime.parse("2007-12-03T10:15:30.123456789+01:00[Europe/Paris]"),
         "2007-12-03 10:15:30.123456789 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        ZonedDateTime.parse("2007-07-03T10:15:30.123456789+02:00[Europe/Paris]"),
+        "2007-07-03 10:15:30.123456789 Z",
         new StringProvider());
 
     useLosAngelesTimeZone();
@@ -922,6 +952,11 @@ public class DateTimeIT extends AbstractDataTypeTest {
         ZonedDateTime.parse("2007-12-03T10:15:30.123456789+01:00[Europe/Paris]"),
         "2007-12-03 01:15:30.123456789 -0800",
         new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        ZonedDateTime.parse("2007-07-03T10:15:30.123456789+02:00[Europe/Paris]"),
+        "2007-07-03 01:15:30.123456789 -0700",
+        new StringProvider());
 
     // TIMESTAMP_TZ (LocalDate, LocalDateTime, OffsetDateTime, ZonedDateTime are supported)
     testIngestion(
@@ -948,6 +983,11 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "TIMESTAMP_TZ",
         ZonedDateTime.parse("2007-12-03T10:15:30.123456789+01:00[Europe/Paris]"),
         "2007-12-03 10:15:30.123456789 +0100",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ",
+        ZonedDateTime.parse("2007-07-03T10:15:30.123456789+02:00[Europe/Paris]"),
+        "2007-07-03 10:15:30.123456789 +0200",
         new StringProvider());
   }
 


### PR DESCRIPTION
This patch implements more efficient calculation of `SFTimestamp` from supported `java.time.*` objects, without calling `toString` on them and parsing the result.

Users should be advised to pass date/time values either as unix timestamp strings or as `java.time.*` objects. Passing dates as formatted strings requires parsing, which is less efficient.

A simple microbenchmark on my local machine shows ≈19x improvement. Sequentially parsing and validating 10M ZonedDateTime objects took ≈36s with the old approach compared to 1.9s with the new approach.

Additionally, this commit unifies processing of timestamps with and without timezones.