### PR TITLE
[Snowpipe ingest][SDK] Attaching additional unshaded jar into release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,23 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <id>unshaded</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>unshaded</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <!-- disable default maven deploy plugin since we are using gpg:sign-and-deploy-file -->
@@ -455,6 +472,7 @@
                         <artifactId>maven-shade-plugin</artifactId>
                         <version>3.1.1</version>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <relocations>
                                 <relocation>
                                     <pattern>com.nimbusds</pattern>
@@ -646,5 +664,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>


### PR DESCRIPTION
In order to be able to resolving various version conflicts and integrating the ingest SDK into GS, we are making two changes:
1. In the released artifacts, a new unshaded jar will be added.
2. The pom file generated now include all the transitive dependencies.

maven install logs:
```
[INFO] --- maven-install-plugin:2.4:install (default-install) @ snowflake-ingest-sdk ---
[INFO] Installing /home/hqin/Snowflake/trunk/GlobalServices/modules/snowflake-ingest-java/target/snowflake-ingest-sdk.jar to /home/hqin/.m2/repository/net/snowflake/snowflake-ingest-sdk/1.0.2-beta.7/snowflake-ingest-sdk-1.0.2-beta.7.jar
[INFO] Installing /home/hqin/Snowflake/trunk/GlobalServices/modules/snowflake-ingest-java/pom.xml to /home/hqin/.m2/repository/net/snowflake/snowflake-ingest-sdk/1.0.2-beta.7/snowflake-ingest-sdk-1.0.2-beta.7.pom
[INFO] Installing /home/hqin/Snowflake/trunk/GlobalServices/modules/snowflake-ingest-java/target/snowflake-ingest-sdk-javadoc.jar to /home/hqin/.m2/repository/net/snowflake/snowflake-ingest-sdk/1.0.2-beta.7/snowflake-ingest-sdk-1.0.2-beta.7-javadoc.jar
[INFO] Installing /home/hqin/Snowflake/trunk/GlobalServices/modules/snowflake-ingest-java/target/snowflake-ingest-sdk-sources.jar to /home/hqin/.m2/repository/net/snowflake/snowflake-ingest-sdk/1.0.2-beta.7/snowflake-ingest-sdk-1.0.2-beta.7-sources.jar
[INFO] Installing /home/hqin/Snowflake/trunk/GlobalServices/modules/snowflake-ingest-java/target/snowflake-ingest-sdk-unshaded.jar to /home/hqin/.m2/repository/net/snowflake/snowflake-ingest-sdk/1.0.2-beta.7/snowflake-ingest-sdk-1.0.2-beta.7-unshaded.jar
```

artifacts installed in local m2 cache
```
[hqin@SDP_DevVM-hqin snowflake-ingest-java]$ ls -alh /home/hqin/.m2/repository/net/snowflake/snowflake-ingest-sdk/1.0.2-beta.7/
total 96M
drwxrwxr-x 2 hqin hqin  284 Jan 17 17:10 .
drwxrwxr-x 3 hqin hqin   58 Jan 17 17:10 ..
-rw-rw-r-- 1 hqin hqin  365 Jan 17 17:10 _remote.repositories
-rw-rw-r-- 1 hqin hqin  94M Jan 17 17:10 snowflake-ingest-sdk-1.0.2-beta.7.jar
-rw-rw-r-- 1 hqin hqin 787K Jan 17 17:10 snowflake-ingest-sdk-1.0.2-beta.7-javadoc.jar
-rw-rw-r-- 1 hqin hqin  28K Jan 17 17:07 snowflake-ingest-sdk-1.0.2-beta.7.pom
-rw-rw-r-- 1 hqin hqin 158K Jan 17 17:10 snowflake-ingest-sdk-1.0.2-beta.7-sources.jar
-rw-rw-r-- 1 hqin hqin 257K Jan 17 17:10 snowflake-ingest-sdk-1.0.2-beta.7-unshaded.jar
```
[Content of the generated POM](https://docs.google.com/document/d/1bD2cGEuxb8NuOIgQOluTsoVNsA3KWn6P3MTNn2vIyB8/edit?usp=sharing)

Customers now can consume the newly added unshaded version by specifying the `<classifier>` tag:
```
<dependency>
    <groupId>net.snowflake</groupId>
    <artifactId>snowflake-ingest-sdk</artifactId>
    <version>1.0.2-beta.7</version>
    <classifier>unshaded</classifier>
<dependency>
```

On the GS side, we will add following dependency into the POM:
```
    <dependency>
      <groupId>net.snowflake</groupId>
      <artifactId>snowflake-ingest-sdk</artifactId>
      <version>1.0.2-beta.7</version>
      <classifier>unshaded</classifier>
      <exclusions>
        <exclusion>
          <groupId>ch.qos.reload4j</groupId>
          <artifactId>reload4j</artifactId>
        </exclusion>
        <exclusion>
          <groupId>com.ibm.icu</groupId>
          <artifactId>icu4j</artifactId>
        </exclusion>
        <exclusion>
          <groupId>com.nimbusds</groupId>
          <artifactId>nimbus-jose-jwt</artifactId>
        </exclusion>
        <exclusion>
          <groupId>org.apache.arrow</groupId>
          <artifactId>arrow-memory-netty</artifactId>
        </exclusion>
        <exclusion>
          <groupId>org.apache.arrow</groupId>
          <artifactId>arrow-vector</artifactId>
        </exclusion>
        <exclusion>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-reload4j</artifactId>
        </exclusion>
      </exclusions>
    </dependency>
```
and `make build_gs` does pass and bringing relevant classes into the GS project.