### PR TITLE
[SNOW-726993] Ingest SDK Does Not Honor http.nonProxyHosts JVM Argument

### DIFF
--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -406,7 +406,7 @@ public class SimpleIngestManager implements AutoCloseable {
     this.keyPair = keyPair;
 
     // make our client for sending requests
-    httpClient = HttpUtil.getHttpClient();
+    httpClient = HttpUtil.getHttpClient(account);
     // make the request builder we'll use to build messages to the service
   }
 


### PR DESCRIPTION
This change checks if the Snowflake account matches any of the hosts provided by the -Dhttp.nonProxyHosts JVM argument. If so, we connect to the host directly without going through the proxy server.