### PR TITLE
SNOW-711299 New date/time processing

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/OpenChannelRequest.java
+++ b/src/main/java/net/snowflake/ingest/streaming/OpenChannelRequest.java
@@ -4,6 +4,8 @@
 
 package net.snowflake.ingest.streaming;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import net.snowflake.ingest.utils.Utils;
 
 /** A class that is used to open/create a {@link SnowflakeStreamingIngestChannel} */
@@ -28,6 +30,9 @@ public class OpenChannelRequest {
   // On_error option on this channel
   private final OnErrorOption onErrorOption;
 
+  // Default timezone for TIMESTAMP_LTZ and TIMESTAMP_TZ columns
+  private final ZoneId defaultTimezone;
+
   public static OpenChannelRequestBuilder builder(String channelName) {
     return new OpenChannelRequestBuilder(channelName);
   }
@@ -39,9 +44,11 @@ public class OpenChannelRequest {
     private String schemaName;
     private String tableName;
     private OnErrorOption onErrorOption;
+    private ZoneId defaultTimezone;
 
     public OpenChannelRequestBuilder(String channelName) {
       this.channelName = channelName;
+      this.defaultTimezone = ZoneOffset.UTC;
     }
 
     public OpenChannelRequestBuilder setDBName(String dbName) {
@@ -64,6 +71,11 @@ public class OpenChannelRequest {
       return this;
     }
 
+    public OpenChannelRequestBuilder setDefaultTimezone(ZoneId defaultTimezone) {
+      this.defaultTimezone = defaultTimezone;
+      return this;
+    }
+
     public OpenChannelRequest build() {
       return new OpenChannelRequest(this);
     }
@@ -81,6 +93,7 @@ public class OpenChannelRequest {
     this.schemaName = builder.schemaName;
     this.tableName = builder.tableName;
     this.onErrorOption = builder.onErrorOption;
+    this.defaultTimezone = builder.defaultTimezone;
   }
 
   public String getDBName() {
@@ -97,6 +110,10 @@ public class OpenChannelRequest {
 
   public String getChannelName() {
     return this.channelName;
+  }
+
+  public ZoneId getDefaultTimezone() {
+    return this.defaultTimezone;
   }
 
   public String getFullyQualifiedTableName() {

--- a/src/main/java/net/snowflake/ingest/streaming/OpenChannelRequest.java
+++ b/src/main/java/net/snowflake/ingest/streaming/OpenChannelRequest.java
@@ -5,7 +5,6 @@
 package net.snowflake.ingest.streaming;
 
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import net.snowflake.ingest.utils.Utils;
 
 /** A class that is used to open/create a {@link SnowflakeStreamingIngestChannel} */
@@ -14,6 +13,12 @@ public class OpenChannelRequest {
     CONTINUE, // CONTINUE loading the rows, and return all the errors in the response
     ABORT, // ABORT the entire batch, and throw an exception when we hit the first error
   }
+
+  /**
+   * Default value of the timezone, which will be used for TIMESTAMP_LTZ and TIMESTAMP_TZ column
+   * types when the user input does not have any timezone information.
+   */
+  private static final ZoneId DEFAULT_DEFAULT_TIMEZONE = ZoneId.of("America/Los_Angeles");
 
   // Name of the channel
   private final String channelName;
@@ -48,7 +53,7 @@ public class OpenChannelRequest {
 
     public OpenChannelRequestBuilder(String channelName) {
       this.channelName = channelName;
-      this.defaultTimezone = ZoneOffset.UTC;
+      this.defaultTimezone = DEFAULT_DEFAULT_TIMEZONE;
     }
 
     public OpenChannelRequestBuilder setDBName(String dbName) {
@@ -87,6 +92,7 @@ public class OpenChannelRequest {
     Utils.assertStringNotNullOrEmpty("schema name", builder.schemaName);
     Utils.assertStringNotNullOrEmpty("table name", builder.tableName);
     Utils.assertNotNull("on_error option", builder.onErrorOption);
+    Utils.assertNotNull("default_timezone", builder.defaultTimezone);
 
     this.channelName = builder.channelName;
     this.dbName = builder.dbName;

--- a/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestChannel.java
+++ b/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestChannel.java
@@ -184,7 +184,7 @@ public interface SnowflakeStreamingIngestChannel {
    *
    *             </ul>
    *
-   *             For TIMESTAMP_LTZ and TIMESTAMP_TZ, all input without timezone will be by default interpreted in UTC. This can be changed by calling {@link net.snowflake.ingest.streaming.OpenChannelRequest.OpenChannelRequestBuilder#setDefaultTimezone(ZoneId)}.
+   *             For TIMESTAMP_LTZ and TIMESTAMP_TZ, all input without timezone will be by default interpreted in the timezone "America/Los_Angeles". This can be changed by calling {@link net.snowflake.ingest.streaming.OpenChannelRequest.OpenChannelRequestBuilder#setDefaultTimezone(ZoneId)}.
    *         </td>
    *         <tr>
    *             <td>VARIANT, ARRAY</td>

--- a/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestChannel.java
+++ b/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestChannel.java
@@ -4,6 +4,7 @@
 
 package net.snowflake.ingest.streaming;
 
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
@@ -75,7 +76,149 @@ public interface SnowflakeStreamingIngestChannel {
 
   /**
    * Insert one row into the channel, the row is represented using Map where the key is column name
-   * and the value is a row of data
+   * and the value is a row of data. The following table summarizes supported value types and their
+   * formats:
+   *
+   * <table>
+   *     <tr>
+   *     <th>Snowflake Column Type</th>
+   *     <th>Allowed Java Data Type</th>
+   *     </tr>
+   *     <tr>
+   *         <td>CHAR, VARCHAR</td>
+   *         <td>
+   *             <ul>
+   *                 <li>String</li>
+   *                 <li>primitive data types (int, boolean, char, …)</li>
+   *             </ul>
+   *         </td>
+   *     </tr>
+   *     <tr>
+   *         <td>BINARY</td>
+   *         <td>
+   *             <ul>
+   *                 <li>byte[]</li>
+   *                 <li>String (hex-encoded)</li>
+   *             </ul>
+   *         </td>
+   *     </tr>
+   *     <tr>
+   *         <td>NUMBER, FLOAT</td>
+   *         <td>
+   *             <ul>
+   *                 <li>numeric types (BigInteger, BigDecimal, byte, int, double, …)</li>
+   *                 <li>String</li>
+   *             </ul>
+   *         </td>
+   *     </tr>
+   *     <tr>
+   *         <td>BOOLEAN</td>
+   *         <td>
+   *             <ul>
+   *                 <li>boolean</li>
+   *                 <li>numeric types (BigInteger, BigDecimal, byte, int, double, …)</li>
+   *                 <li>String</li>
+   *             </ul>
+   *             See <a href="https://docs.snowflake.com/en/sql-reference/data-types-logical.html#label-boolean-conversion">boolean conversion details.</a>
+   *         </td>
+   *     </tr>
+   *     <tr>
+   *         <td>TIME</td>
+   *         <td>
+   *             <ul>
+   *                 <li>{@link java.time.LocalTime}</li>
+   *                 <li>{@link java.time.OffsetTime}</li>
+   *                 <li>
+   *                     String (in one of the following formats):
+   *                     <ul>
+   *                         <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_TIME}</li>
+   *                         <li>{@link java.time.format.DateTimeFormatter#ISO_OFFSET_TIME}</li>
+   *                         <li>Integer-stored time (see <a href="https://docs.snowflake.com/en/user-guide/date-time-input-output.html#auto-detection-of-integer-stored-date-time-and-timestamp-values">Snowflake Docs</a> for more details)</li>
+   *                     </ul>
+   *                 </li>
+   *
+   *             </ul>
+   *         </td>
+   *     </tr>
+   *     <tr>
+   *         <td>DATE</td>
+   *         <td>
+   *             <ul>
+   *                 <li>{@link java.time.LocalDate}</li>
+   *                 <li>{@link java.time.LocalDateTime}</li>
+   *                 <li>{@link java.time.OffsetDateTime}</li>
+   *                 <li>{@link java.time.ZonedDateTime}</li>
+   *                 <li>{@link java.time.Instant}</li>
+   *                 <li>
+   *                     String (in one of the following formats):
+   *                     <ul>
+   *                         <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE}</li>
+   *                         <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE_TIME}</li>
+   *                         <li>{@link java.time.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME}</li>
+   *                         <li>{@link java.time.format.DateTimeFormatter#ISO_ZONED_DATE_TIME}</li>
+   *                         <li>Integer-stored date (see <a href="https://docs.snowflake.com/en/user-guide/date-time-input-output.html#auto-detection-of-integer-stored-date-time-and-timestamp-values">Snowflake Docs</a> for more details)</li>
+   *                     </ul>
+   *                 </li>
+   *             </ul>
+   *         </td>
+   *     </tr>
+   *     <tr>
+   *         <td>TIMESTAMP_NTZ, TIMESTAMP_LTZ, TIMESTAMP_TZ</td>
+   *         <td>
+   *             <ul>
+   *                 <li>{@link java.time.LocalDate}</li>
+   *                 <li>{@link java.time.LocalDateTime}</li>
+   *                 <li>{@link java.time.OffsetDateTime}</li>
+   *                 <li>{@link java.time.ZonedDateTime}</li>
+   *                 <li>{@link java.time.Instant}</li>
+   *                 <li>
+   *                     String (in one of the following formats):
+   *                     <ul>
+   *                         <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE}</li>
+   *                         <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE_TIME}</li>
+   *                         <li>{@link java.time.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME}</li>
+   *                         <li>{@link java.time.format.DateTimeFormatter#ISO_ZONED_DATE_TIME}</li>
+   *                         <li>Integer-stored timestamp (see <a href="https://docs.snowflake.com/en/user-guide/date-time-input-output.html#auto-detection-of-integer-stored-date-time-and-timestamp-values">Snowflake Docs</a> for more details)</li>
+   *                     </ul>
+   *                 </li>
+   *
+   *             </ul>
+   *
+   *             For TIMESTAMP_LTZ and TIMESTAMP_TZ, all input without timezone will be by default interpreted in UTC. This can be changed by calling {@link net.snowflake.ingest.streaming.OpenChannelRequest.OpenChannelRequestBuilder#setDefaultTimezone(ZoneId)}.
+   *         </td>
+   *         <tr>
+   *             <td>VARIANT, ARRAY</td>
+   *             <td>
+   *                 <ul>
+   *                     <li>String (must be a valid JSON value)</li>
+   *                     <li>primitive data types and their arrays</li>
+   *                     <li>BigInteger, BigDecimal</li>
+   *                     <li>{@link java.time.LocalDate}</li>
+   *                     <li>{@link java.time.LocalDateTime}</li>
+   *                     <li>{@link java.time.OffsetDateTime}</li>
+   *                     <li>{@link java.time.ZonedDateTime}</li>
+   *                     <li>Map&lt;String, T&gt; where T is a valid VARIANT type</li>
+   *                     <li>T[] where T is a valid VARIANT type</li>
+   *                     <li>List&lt;T&gt; where T is a valid VARIANT type</li>
+   *                 </ul>
+   *             </td>
+   *         </tr>
+   *         <tr>
+   *             <td>OBJECT</td>
+   *             <td>
+   *                 <ul>
+   *                     <li>String (must be a valid JSON object)</li>
+   *                     <li>Map&lt;String, T&gt; where T is a valid variant type</li>
+   *                 </ul>
+   *             </td>
+   *         </tr>
+   *         <tr>
+   *            <td>GEOGRAPHY, GEOMETRY</td>
+   *            <td>Not supported</td>
+   *         </tr>
+   *     </tr>
+   *
+   * </table>
    *
    * @param row object data to write
    * @param offsetToken offset of given row, used for replay in case of failures. It could be null
@@ -86,7 +229,9 @@ public interface SnowflakeStreamingIngestChannel {
 
   /**
    * Insert a batch of rows into the channel, each row is represented using Map where the key is
-   * column name and the value is a row of data
+   * column name and the value is a row of data. See {@link
+   * SnowflakeStreamingIngestChannel#insertRow(Map, String)} for more information about accepted
+   * values.
    *
    * @param rows object data to write
    * @param offsetToken offset of last row in the row-set, used for replay in case of failures, It

--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -4,6 +4,7 @@
 
 package net.snowflake.ingest.streaming.internal;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -169,13 +170,17 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
   // ON_ERROR option for this channel
   final OpenChannelRequest.OnErrorOption onErrorOption;
 
+  final ZoneId defaultTimezone;
+
   AbstractRowBuffer(
       OpenChannelRequest.OnErrorOption onErrorOption,
+      ZoneId defaultTimezone,
       BufferAllocator allocator,
       String fullyQualifiedChannelName,
       Consumer<Float> rowSizeMetric,
       ChannelRuntimeState channelRuntimeState) {
     this.onErrorOption = onErrorOption;
+    this.defaultTimezone = defaultTimezone;
     this.rowSizeMetric = rowSizeMetric;
     this.channelState = channelRuntimeState;
     this.channelFullyQualifiedName = fullyQualifiedChannelName;
@@ -542,6 +547,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
   /** Row buffer factory. */
   static <T> AbstractRowBuffer<T> createRowBuffer(
       OpenChannelRequest.OnErrorOption onErrorOption,
+      ZoneId defaultTimezone,
       BufferAllocator allocator,
       Constants.BdecVersion bdecVersion,
       String fullyQualifiedChannelName,
@@ -555,6 +561,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
         return (AbstractRowBuffer<T>)
             new ArrowRowBuffer(
                 onErrorOption,
+                defaultTimezone,
                 allocator,
                 fullyQualifiedChannelName,
                 rowSizeMetric,
@@ -564,6 +571,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
         return (AbstractRowBuffer<T>)
             new ParquetRowBuffer(
                 onErrorOption,
+                defaultTimezone,
                 allocator,
                 fullyQualifiedChannelName,
                 rowSizeMetric,

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -4,8 +4,6 @@
 
 package net.snowflake.ingest.streaming.internal;
 
-import static net.snowflake.client.jdbc.internal.snowflake.common.core.SnowflakeDateTimeFormat.DATE;
-import static net.snowflake.client.jdbc.internal.snowflake.common.core.SnowflakeDateTimeFormat.TIMESTAMP;
 import static net.snowflake.ingest.streaming.internal.BinaryStringUtils.unicodeCharactersCount;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,19 +24,18 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SimpleTimeZone;
-import java.util.TimeZone;
-import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import javax.xml.bind.DatatypeConverter;
 import net.snowflake.client.jdbc.internal.google.common.collect.Sets;
-import net.snowflake.client.jdbc.internal.snowflake.common.core.SFDate;
-import net.snowflake.client.jdbc.internal.snowflake.common.core.SFTimestamp;
 import net.snowflake.client.jdbc.internal.snowflake.common.core.SnowflakeDateTimeFormat;
 import net.snowflake.client.jdbc.internal.snowflake.common.util.Power10;
 import net.snowflake.ingest.streaming.internal.serialization.ByteArraySerializer;
@@ -48,16 +45,17 @@ import net.snowflake.ingest.utils.SFException;
 
 /** Utility class for parsing and validating inputs based on Snowflake types */
 class DataValidationUtil {
+
+  private static final long SECONDS_LIMIT_FOR_EPOCH = 31536000000L;
+  private static final long MILLISECONDS_LIMIT_FOR_EPOCH = SECONDS_LIMIT_FOR_EPOCH * 1000L;
+  private static final long MICROSECONDS_LIMIT_FOR_EPOCH = SECONDS_LIMIT_FOR_EPOCH * 1000000L;
+
   public static final int BYTES_8_MB = 8 * 1024 * 1024;
   public static final int BYTES_16_MB = 2 * BYTES_8_MB;
 
   // TODO SNOW-664249: There is a few-byte mismatch between the value sent by the user and its
   // server-side representation. Validation leaves a small buffer for this difference.
   static final int MAX_SEMI_STRUCTURED_LENGTH = BYTES_16_MB - 64;
-
-  private static final TimeZone DEFAULT_TIMEZONE =
-      TimeZone.getTimeZone("America/Los_Angeles"); // default value of TIMEZONE system parameter
-  private static final TimeZone GMT = TimeZone.getTimeZone("GMT");
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -311,6 +309,93 @@ class DataValidationUtil {
   }
 
   /**
+   * Converts user input to offset date time, which is the canonical representation of dates and
+   * timestamps.
+   */
+  private static OffsetDateTime inputToOffsetDateTime(
+      String columnName, String typeName, Object input, ZoneId defaultTimezone) {
+    if (input instanceof OffsetDateTime) {
+      return (OffsetDateTime) input;
+    }
+
+    if (input instanceof ZonedDateTime) {
+      return ((ZonedDateTime) input).toOffsetDateTime();
+    }
+
+    if (input instanceof LocalDateTime) {
+      return ((LocalDateTime) input).atZone(defaultTimezone).toOffsetDateTime();
+    }
+
+    if (input instanceof LocalDate) {
+      return ((LocalDate) input).atStartOfDay().atZone(defaultTimezone).toOffsetDateTime();
+    }
+
+    if (input instanceof Instant) {
+      // Just like integer-stored timestamps, instants are always interpreted in UTC
+      return ((Instant) input).atZone(ZoneOffset.UTC).toOffsetDateTime();
+    }
+
+    if (input instanceof String) {
+      String stringInput = (String) input;
+      {
+        // First, try to parse ZonedDateTime
+        ZonedDateTime zoned = catchParsingError(() -> ZonedDateTime.parse(stringInput));
+        if (zoned != null) return zoned.toOffsetDateTime();
+      }
+
+      {
+        // Next, try to parse OffsetDateTime
+        OffsetDateTime offset = catchParsingError(() -> OffsetDateTime.parse(stringInput));
+        if (offset != null) return offset;
+      }
+
+      {
+        // Alternatively, try to parse LocalDateTime
+        LocalDateTime localDateTime = catchParsingError(() -> LocalDateTime.parse(stringInput));
+        if (localDateTime != null) return localDateTime.atZone(defaultTimezone).toOffsetDateTime();
+      }
+
+      {
+        // Alternatively, try to parse LocalDate
+        LocalDate localDate = catchParsingError(() -> LocalDate.parse(stringInput));
+        if (localDate != null)
+          return localDate.atStartOfDay().atZone(defaultTimezone).toOffsetDateTime();
+      }
+
+      {
+        // Alternatively, try to parse integer-stored timestamp
+        // Just like in Snowflake, integer-stored timestamps are always in UTC
+        Instant instant = catchParsingError(() -> parseInstantGuessScale(stringInput));
+        if (instant != null) return instant.atOffset(ZoneOffset.UTC);
+      }
+
+      // Couldn't parse anything, throw an exception
+      throw valueFormatNotAllowedException(
+          columnName,
+          input.toString(),
+          typeName,
+          "Not a valid value, see"
+              + " https://docs.snowflake.com/en/LIMITEDACCESS/snowpipe-streaming.html"
+              + " for the list of supported formats");
+    }
+
+    // Type is not supported, throw an exception
+    throw typeNotAllowedException(
+        columnName,
+        input.getClass(),
+        typeName,
+        new String[] {"String", "LocalDate", "LocalDateTime", "ZonedDateTime", "OffsetDateTime"});
+  }
+
+  private static <T> T catchParsingError(Supplier<T> op) {
+    try {
+      return op.get();
+    } catch (DateTimeParseException | NumberFormatException e) {
+      return null;
+    }
+  }
+
+  /**
    * Validates and parses input for TIMESTAMP_NTZ, TIMESTAMP_LTZ and TIMEATAMP_TZ Snowflake types.
    * Allowed Java types:
    *
@@ -322,69 +407,25 @@ class DataValidationUtil {
    *   <li>ZonedDateTime
    * </ul>
    *
+   * @param columnName Column name, used in validation error messages
    * @param input String date in valid format, seconds past the epoch or java.time.* object. Accepts
    *     fractional seconds with precision up to the column's scale
    * @param scale decimal scale of timestamp 16 byte integer
-   * @param ignoreTimezone Must be true for TIMESTAMP_NTZ
-   * @return TimestampWrapper with epoch seconds, fractional seconds, and epoch time in the column
-   *     scale
+   * @param defaultTimezone Input, which does not carry timezone information is going to be
+   *     interpreted in the default timezone.
+   * @param trimTimezone Whether timezone information should be removed from the resulting date,
+   *     should be true for TIMESTAMP_NTZ columns.
+   * @return TimestampWrapper
    */
   static TimestampWrapper validateAndParseTimestamp(
-      String columnName, Object input, int scale, boolean ignoreTimezone) {
-    TimeZone effectiveTimeZone = ignoreTimezone ? GMT : DEFAULT_TIMEZONE;
-    SFTimestamp timestamp;
-    if (input instanceof String) {
-      SnowflakeDateTimeFormat snowflakeDateTimeFormatter = createDateTimeFormatter();
-      timestamp =
-          snowflakeDateTimeFormatter.parse(
-              (String) input, effectiveTimeZone, 0, DATE | TIMESTAMP, ignoreTimezone, null);
-    } else if (input instanceof LocalDate) {
-      timestamp = timeStampFromLocalDate((LocalDate) input, effectiveTimeZone);
-    } else if (input instanceof LocalDateTime) {
-      timestamp = timeStampFromLocalDateTime((LocalDateTime) input, effectiveTimeZone);
-    } else if (input instanceof ZonedDateTime) {
-      timestamp = timestampFromZonedDateTime((ZonedDateTime) input, ignoreTimezone);
-    } else if (input instanceof OffsetDateTime) {
-      timestamp = timestampFromOffsetDateTime((OffsetDateTime) input, ignoreTimezone);
-    } else {
-      throw typeNotAllowedException(
-          columnName,
-          input.getClass(),
-          "TIMESTAMP",
-          new String[] {"String", "LocalDate", "LocalDateTime", "ZonedDateTime", "OffsetDateTime"});
+      String columnName, Object input, int scale, ZoneId defaultTimezone, boolean trimTimezone) {
+    OffsetDateTime offsetDateTime =
+        inputToOffsetDateTime(columnName, "TIMESTAMP", input, defaultTimezone);
+
+    if (trimTimezone) {
+      offsetDateTime = offsetDateTime.withOffsetSameLocal(ZoneOffset.UTC);
     }
-
-    if (timestamp != null) {
-      long epoch = timestamp.getSeconds().longValue();
-      int fractionInScale = getFractionFromTimestamp(timestamp) / Power10.intTable[9 - scale];
-      BigInteger timeInScale =
-          BigInteger.valueOf(epoch)
-              .multiply(Power10.sb16Table[scale])
-              .add(BigInteger.valueOf(fractionInScale));
-      return new TimestampWrapper(
-          epoch, fractionInScale * Power10.intTable[9 - scale], timeInScale, timestamp);
-    }
-
-    throw valueFormatNotAllowedException(
-        columnName,
-        input.toString(),
-        "TIMESTAMP",
-        "Not a valid timestamp, see"
-            + " https://docs.snowflake.com/en/user-guide/date-time-input-output.html#timestamp-formats"
-            + " for the list of supported formats");
-  }
-
-  /**
-   * Given a SFTimestamp, get the number of nanoseconds since the last whole second. This
-   * corresponds to the fraction component for Timestamp types
-   *
-   * @param input SFTimestamp
-   * @return Timestamp fraction value, the number of nanoseconds since the last whole second
-   */
-  private static int getFractionFromTimestamp(SFTimestamp input) {
-    BigDecimal epochSecondsInNanoSeconds =
-        new BigDecimal(input.getSeconds().multiply(BigInteger.valueOf(Power10.intTable[9])));
-    return input.getNanosSinceEpoch().subtract(epochSecondsInNanoSeconds).intValue();
+    return new TimestampWrapper(offsetDateTime, scale);
   }
 
   /**
@@ -494,43 +535,17 @@ class DataValidationUtil {
    *
    * <ul>
    *   <li>String
-   *   <li>LocalDate
-   *   <li>LocalDateTime
-   *   <li>OffsetDateTime
-   *   <li>ZonedDateTime
+   *   <li>{@link LocalDate}
+   *   <li>{@link LocalDateTime}
+   *   <li>{@link OffsetDateTime}
+   *   <li>{@link ZonedDateTime}
+   *   <li>{@link Instant}
    * </ul>
    */
   static int validateAndParseDate(String columnName, Object input) {
-    SFTimestamp timestamp;
-    if (input instanceof String) {
-      timestamp =
-          createDateTimeFormatter().parse((String) input, GMT, 0, DATE | TIMESTAMP, true, null);
-    } else if (input instanceof LocalDate) {
-      timestamp = timeStampFromLocalDate((LocalDate) input, GMT);
-    } else if (input instanceof LocalDateTime) {
-      timestamp = timeStampFromLocalDateTime((LocalDateTime) input, GMT);
-    } else if (input instanceof ZonedDateTime) {
-      timestamp = timestampFromZonedDateTime((ZonedDateTime) input, true);
-    } else if (input instanceof OffsetDateTime) {
-      timestamp = timestampFromOffsetDateTime((OffsetDateTime) input, true);
-    } else {
-      throw typeNotAllowedException(
-          columnName,
-          input.getClass(),
-          "DATE",
-          new String[] {"String", "LocalDate", "LocalDateTime", "ZonedDateTime", "OffsetDateTime"});
-    }
-
-    if (timestamp == null)
-      throw valueFormatNotAllowedException(
-          columnName,
-          input,
-          "DATE",
-          "Not a valid date, see"
-              + " https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats"
-              + " for the list of supported formats");
-
-    return (int) TimeUnit.MILLISECONDS.toDays(SFDate.fromTimestamp(timestamp).getTime());
+    OffsetDateTime offsetDateTime =
+        inputToOffsetDateTime(columnName, "DATE", input, ZoneOffset.UTC);
+    return Math.toIntExact(offsetDateTime.toLocalDate().toEpochDay());
   }
 
   /**
@@ -579,44 +594,83 @@ class DataValidationUtil {
    *
    * <ul>
    *   <li>String
-   *   <li>LocalTime
-   *   <li>OffsetTime
+   *   <li>{@link LocalTime}
+   *   <li>{@link OffsetTime}
    * </ul>
    */
   static BigInteger validateAndParseTime(String columnName, Object input, int scale) {
-    SFTimestamp timestamp;
-    if (input instanceof String) {
-      String stringInput = (String) input;
-      timestamp =
-          createDateTimeFormatter()
-              .parse(stringInput, GMT, 0, SnowflakeDateTimeFormat.TIME, true, null);
-    } else if (input instanceof LocalTime) {
-      timestamp =
-          timeStampFromLocalDateTime(((LocalTime) input).atDate(LocalDate.ofEpochDay(0)), GMT);
+    if (input instanceof LocalTime) {
+      LocalTime localTime = (LocalTime) input;
+      return BigInteger.valueOf(localTime.toNanoOfDay()).divide(Power10.sb16Table[9 - scale]);
     } else if (input instanceof OffsetTime) {
-      timestamp =
-          timeStampFromLocalDateTime(
-              ((OffsetTime) input).toLocalTime().atDate(LocalDate.ofEpochDay(0)), GMT);
-    } else {
-      throw typeNotAllowedException(
-          columnName, input.getClass(), "TIME", new String[] {"String", "LocalTime", "OffsetTime"});
-    }
+      return validateAndParseTime(columnName, ((OffsetTime) input).toLocalTime(), scale);
+    } else if (input instanceof String) {
+      String stringInput = (String) input;
+      {
+        // First, try to parse LocalTime
+        LocalTime localTime = catchParsingError(() -> LocalTime.parse(stringInput));
+        if (localTime != null) {
+          return validateAndParseTime(columnName, localTime, scale);
+        }
+      }
 
-    if (timestamp == null) {
+      {
+        // Alternatively, try to parse OffsetTime
+        OffsetTime offsetTime = catchParsingError((() -> OffsetTime.parse(stringInput)));
+        if (offsetTime != null) {
+          return validateAndParseTime(columnName, offsetTime.toLocalTime(), scale);
+        }
+      }
+
+      {
+        // Alternatively, try to parse integer-stored time
+        Instant parsedInstant = catchParsingError(() -> parseInstantGuessScale(stringInput));
+        if (parsedInstant != null) {
+          return validateAndParseTime(
+              columnName,
+              LocalDateTime.ofInstant(parsedInstant, ZoneOffset.UTC).toLocalTime(),
+              scale);
+        }
+      }
+
       throw valueFormatNotAllowedException(
           columnName,
           input,
           "TIME",
           "Not a valid time, see"
-              + " https://docs.snowflake.com/en/user-guide/date-time-input-output.html#time-formats"
+              + " https://docs.snowflake.com/en/LIMITEDACCESS/snowpipe-streaming.html"
               + " for the list of supported formats");
-    }
 
-    return timestamp
-        .getNanosSinceEpoch()
-        .toBigInteger()
-        .divide(Power10.sb16Table[9 - scale])
-        .mod(BigInteger.valueOf(24L * 60 * 60).multiply(Power10.sb16Table[scale]));
+    } else {
+      throw typeNotAllowedException(
+          columnName, input.getClass(), "TIME", new String[] {"String", "LocalTime", "OffsetTime"});
+    }
+  }
+
+  /**
+   * Attempts to parse integer-stored date from string input. Tries to guess the scale according to
+   * the rules documented at
+   * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#auto-detection-of-integer-stored-date-time-and-timestamp-values.
+   *
+   * @param input String to parse, must represent a valid long
+   * @return Instant representing the input
+   * @throws NumberFormatException If the input in not a valid long
+   */
+  private static Instant parseInstantGuessScale(String input) {
+    long epochNanos;
+    long val = Long.parseLong(input);
+
+    if (val > -SECONDS_LIMIT_FOR_EPOCH && val < SECONDS_LIMIT_FOR_EPOCH) {
+      epochNanos = val * Power10.intTable[9];
+    } else if (val > -MILLISECONDS_LIMIT_FOR_EPOCH && val < MILLISECONDS_LIMIT_FOR_EPOCH) {
+      epochNanos = val * Power10.intTable[6];
+    } else if (val > -MICROSECONDS_LIMIT_FOR_EPOCH && val < MICROSECONDS_LIMIT_FOR_EPOCH) {
+      epochNanos = val * Power10.intTable[3];
+    } else {
+      epochNanos = val;
+    }
+    return Instant.ofEpochSecond(
+        epochNanos / Power10.intTable[9], epochNanos % Power10.intTable[9]);
   }
 
   /**
@@ -765,63 +819,15 @@ class DataValidationUtil {
   }
 
   /**
-   * Constructs SFTimestamp from {@link LocalDate}. Default timezone is used for _TZ and _LTZ and
-   * UTC for _NTZ.
-   */
-  private static SFTimestamp timeStampFromLocalDate(LocalDate date, TimeZone tz) {
-    return timeStampFromLocalDateTime(date.atStartOfDay(), tz);
-  }
-
-  /**
-   * Constructs SFTimestamp from {@link LocalDateTime}. Default timezone is used for _TZ and _LTZ
-   * and UTC for _NTZ.
-   */
-  private static SFTimestamp timeStampFromLocalDateTime(LocalDateTime localDateTime, TimeZone tz) {
-    return timestampFromInstant(localDateTime.atZone(tz.toZoneId()).toInstant(), tz);
-  }
-
-  /** Constructs SFTimestamp from {@link ZonedDateTime}. Timezone is dropped for _NTZ. */
-  private static SFTimestamp timestampFromZonedDateTime(
-      ZonedDateTime zonedDateTime, boolean ignoreTimezone) {
-    if (ignoreTimezone) {
-      LocalDateTime local = zonedDateTime.toLocalDateTime();
-      return timeStampFromLocalDateTime(local, GMT);
-    }
-
-    TimeZone timeZone = TimeZone.getTimeZone(zonedDateTime.getZone().toString());
-    return timestampFromInstant(zonedDateTime.toInstant(), timeZone);
-  }
-
-  /** Constructs SFTimestamp from {@link OffsetDateTime}. Timezone is dropped for _NTZ. */
-  private static SFTimestamp timestampFromOffsetDateTime(
-      OffsetDateTime offsetDateTime, boolean dropTimezone) {
-    if (dropTimezone) {
-      LocalDateTime local = offsetDateTime.toLocalDateTime();
-      return timeStampFromLocalDateTime(local, GMT);
-    }
-    TimeZone tz =
-        new SimpleTimeZone(
-            offsetDateTime.getOffset().getTotalSeconds() * 1000,
-            "GENERATED_SNOWPIPE_STREAMING:" + offsetDateTime.getOffset());
-    return timestampFromInstant(offsetDateTime.toInstant(), tz);
-  }
-
-  /** Constructs SFTimestamp from {@link Instant} and time zone. */
-  private static SFTimestamp timestampFromInstant(Instant instant, TimeZone timeZone) {
-    return SFTimestamp.fromNanoseconds(
-        instant.getEpochSecond() * Power10.intTable[9] + instant.getNano(), timeZone);
-  }
-
-  /**
    * Validates that a string is valid UTF-8 string. It catches situations like unmatched high/low
    * UTF-16 surrogate, for example.
    */
   private static void verifyValidUtf8(String input, String columnName, String dataType) {
     CharsetEncoder charsetEncoder =
-        StandardCharsets.UTF_8
-            .newEncoder()
-            .onMalformedInput(CodingErrorAction.REPORT)
-            .onUnmappableCharacter(CodingErrorAction.REPORT);
+            StandardCharsets.UTF_8
+                    .newEncoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT);
     try {
       charsetEncoder.encode(CharBuffer.wrap(input));
     } catch (CharacterCodingException e) {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -60,13 +61,20 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   /** Construct a ParquetRowBuffer object. */
   ParquetRowBuffer(
       OpenChannelRequest.OnErrorOption onErrorOption,
+      ZoneId defaultTimezone,
       BufferAllocator allocator,
       String fullyQualifiedChannelName,
       Consumer<Float> rowSizeMetric,
       ChannelRuntimeState channelRuntimeState,
       boolean bufferForTests,
       boolean enableParquetInternalBuffering) {
-    super(onErrorOption, allocator, fullyQualifiedChannelName, rowSizeMetric, channelRuntimeState);
+    super(
+        onErrorOption,
+        defaultTimezone,
+        allocator,
+        fullyQualifiedChannelName,
+        rowSizeMetric,
+        channelRuntimeState);
     fieldIndex = new HashMap<>();
     metadata = new HashMap<>();
     data = new ArrayList<>();
@@ -185,7 +193,8 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       PrimitiveType.PrimitiveTypeName typeName =
           columnDescriptor.getPrimitiveType().getPrimitiveTypeName();
       ParquetValueParser.ParquetBufferValue valueWithSize =
-          ParquetValueParser.parseColumnValueToParquet(value, column, typeName, stats);
+          ParquetValueParser.parseColumnValueToParquet(
+              value, column, typeName, stats, defaultTimezone);
       indexedRow[colIndex] = valueWithSize.getValue();
       size += valueWithSize.getSize();
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelFactory.java
@@ -4,6 +4,8 @@
 
 package net.snowflake.ingest.streaming.internal;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Utils;
 import org.apache.arrow.memory.BufferAllocator;
@@ -28,6 +30,8 @@ class SnowflakeStreamingIngestChannelFactory {
     private String encryptionKey;
     private Long encryptionKeyId;
     private OpenChannelRequest.OnErrorOption onErrorOption;
+
+    private ZoneId defaultTimezone = ZoneOffset.UTC;
 
     private SnowflakeStreamingIngestChannelBuilder(String name) {
       this.name = name;
@@ -79,6 +83,11 @@ class SnowflakeStreamingIngestChannelFactory {
       return this;
     }
 
+    SnowflakeStreamingIngestChannelBuilder<T> setDefaultTimezone(ZoneId zoneId) {
+      this.defaultTimezone = zoneId;
+      return this;
+    }
+
     SnowflakeStreamingIngestChannelBuilder<T> setOwningClient(
         SnowflakeStreamingIngestClientInternal<T> client) {
       this.owningClient = client;
@@ -96,6 +105,7 @@ class SnowflakeStreamingIngestChannelFactory {
       Utils.assertStringNotNullOrEmpty("encryption key", this.encryptionKey);
       Utils.assertNotNull("encryption key_id", this.encryptionKeyId);
       Utils.assertNotNull("on_error option", this.onErrorOption);
+      Utils.assertNotNull("default timezone", this.defaultTimezone);
       BufferAllocator allocator = createBufferAllocator();
       return new SnowflakeStreamingIngestChannelInternal<>(
           this.name,
@@ -109,6 +119,7 @@ class SnowflakeStreamingIngestChannelFactory {
           this.encryptionKey,
           this.encryptionKeyId,
           this.onErrorOption,
+          this.defaultTimezone,
           this.owningClient.getParameterProvider().getBlobFormatVersion(),
           allocator);
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelFactory.java
@@ -5,7 +5,6 @@
 package net.snowflake.ingest.streaming.internal;
 
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Utils;
 import org.apache.arrow.memory.BufferAllocator;
@@ -31,7 +30,7 @@ class SnowflakeStreamingIngestChannelFactory {
     private Long encryptionKeyId;
     private OpenChannelRequest.OnErrorOption onErrorOption;
 
-    private ZoneId defaultTimezone = ZoneOffset.UTC;
+    private ZoneId defaultTimezone;
 
     private SnowflakeStreamingIngestChannelBuilder(String name) {
       this.name = name;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -11,6 +11,8 @@ import static net.snowflake.ingest.utils.Constants.RESPONSE_SUCCESS;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +78,8 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
       SnowflakeStreamingIngestClientInternal<T> client,
       String encryptionKey,
       Long encryptionKeyId,
-      OpenChannelRequest.OnErrorOption onErrorOption) {
+      OpenChannelRequest.OnErrorOption onErrorOption,
+      ZoneOffset defaultTimezone) {
     this(
         name,
         dbName,
@@ -89,6 +92,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
         encryptionKey,
         encryptionKeyId,
         onErrorOption,
+        defaultTimezone,
         client.getParameterProvider().getBlobFormatVersion(),
         new RootAllocator());
   }
@@ -106,6 +110,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
       String encryptionKey,
       Long encryptionKeyId,
       OpenChannelRequest.OnErrorOption onErrorOption,
+      ZoneId defaultTimezone,
       Constants.BdecVersion bdecVersion,
       BufferAllocator allocator) {
     this.isClosed = false;
@@ -117,6 +122,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
     this.rowBuffer =
         AbstractRowBuffer.createRowBuffer(
             onErrorOption,
+            defaultTimezone,
             allocator,
             bdecVersion,
             getFullyQualifiedName(),

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -328,6 +328,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
               .setEncryptionKey(response.getEncryptionKey())
               .setEncryptionKeyId(response.getEncryptionKeyId())
               .setOnErrorOption(request.getOnErrorOption())
+              .setDefaultTimezone(request.getDefaultTimezone())
               .build();
 
       // Setup the row buffer schema

--- a/src/main/java/net/snowflake/ingest/streaming/internal/TimestampWrapper.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/TimestampWrapper.java
@@ -1,40 +1,48 @@
-/*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
- */
-
 package net.snowflake.ingest.streaming.internal;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Objects;
-import java.util.Optional;
-import net.snowflake.client.jdbc.internal.snowflake.common.core.SFTimestamp;
+import java.math.RoundingMode;
+import java.time.OffsetDateTime;
+import net.snowflake.client.jdbc.internal.snowflake.common.util.Power10;
 
-class TimestampWrapper {
+public class TimestampWrapper {
+  private final long epoch;
+  private final int fraction;
+  private final int timezoneOffsetSeconds;
 
-  /** Seconds since the epoch */
-  private long epoch;
+  private final int scale;
 
-  /** Fraction of a second since the epoch in nanoseconds */
-  private int fraction;
+  private static final int BITS_FOR_TIMEZONE = 14;
 
-  /** Epoch time in column's scale, e.g. for scale=3 this milliseconds past the epoch */
-  private BigInteger timeInScale;
+  private static final int MASK_OF_TIMEZONE = (1 << BITS_FOR_TIMEZONE) - 1;
 
-  /** SFTimestamp including timezone information */
-  private Optional<SFTimestamp> sfTimestamp = Optional.empty();
-
-  public TimestampWrapper(long epoch, int fraction, BigInteger timeInScale) {
-    this.epoch = epoch;
-    this.fraction = fraction;
-    this.timeInScale = timeInScale;
+  public TimestampWrapper(OffsetDateTime offsetDateTime, int scale) {
+    if (scale < 0 || scale > 9) {
+      throw new IllegalArgumentException(
+          String.format("Scale must be between 0 and 9, actual: %d", scale));
+    }
+    this.epoch = offsetDateTime.toEpochSecond();
+    this.fraction =
+        offsetDateTime.getNano() / Power10.intTable[9 - scale] * Power10.intTable[9 - scale];
+    this.timezoneOffsetSeconds = offsetDateTime.getOffset().getTotalSeconds();
+    this.scale = scale;
   }
 
-  public TimestampWrapper(
-      long epoch, int fraction, BigInteger timeInScale, SFTimestamp sfTimestamp) {
-    this.epoch = epoch;
-    this.fraction = fraction;
-    this.timeInScale = timeInScale;
-    this.sfTimestamp = Optional.ofNullable(sfTimestamp);
+  public BigInteger toBinary(boolean includeTimezone) {
+    BigDecimal timeInNs =
+        BigDecimal.valueOf(epoch).scaleByPowerOfTen(9).add(new BigDecimal(fraction));
+    BigDecimal scaledTime = timeInNs.scaleByPowerOfTen(scale - 9);
+    scaledTime = scaledTime.setScale(0, RoundingMode.DOWN);
+    BigInteger fcpInt = scaledTime.unscaledValue();
+    if (includeTimezone) {
+      int offsetMin = timezoneOffsetSeconds / 60;
+      assert offsetMin >= -1440 && offsetMin <= 1440;
+      offsetMin += 1440;
+      fcpInt = fcpInt.shiftLeft(14);
+      fcpInt = fcpInt.add(BigInteger.valueOf(offsetMin & MASK_OF_TIMEZONE));
+    }
+    return fcpInt;
   }
 
   public long getEpoch() {
@@ -45,35 +53,11 @@ class TimestampWrapper {
     return fraction;
   }
 
-  public BigInteger getTimeInScale() {
-    return timeInScale;
+  public int getTimezoneOffsetSeconds() {
+    return timezoneOffsetSeconds;
   }
 
-  public Optional<Integer> getTimezoneOffset() {
-    return sfTimestamp.map(t -> t.getTimeZoneOffsetMillis());
-  }
-
-  public Optional<Integer> getTimeZoneIndex() {
-    return this.getTimezoneOffset().map(t -> (t / 1000 / 60) + 1440);
-  }
-
-  public Optional<SFTimestamp> getSfTimestamp() {
-    return sfTimestamp;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    TimestampWrapper that = (TimestampWrapper) o;
-    return epoch == that.epoch
-        && fraction == that.fraction
-        && Objects.equals(timeInScale, that.timeInScale)
-        && sfTimestamp.equals(that.sfTimestamp);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(epoch, fraction, timeInScale, sfTimestamp);
+  public int getTimeZoneIndex() {
+    return timezoneOffsetSeconds / 60 + 1440;
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ArrowBufferTest.java
@@ -2,6 +2,7 @@ package net.snowflake.ingest.streaming.internal;
 
 import static net.snowflake.ingest.streaming.internal.ArrowRowBuffer.DECIMAL_BIT_WIDTH;
 
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,7 +30,7 @@ public class ArrowBufferTest {
   ArrowRowBuffer createTestBuffer(OpenChannelRequest.OnErrorOption onErrorOption) {
     ChannelRuntimeState initialState = new ChannelRuntimeState("0", 0L, true);
     return new ArrowRowBuffer(
-        onErrorOption, new RootAllocator(), "test.buffer", rs -> {}, initialState);
+        onErrorOption, ZoneOffset.UTC, new RootAllocator(), "test.buffer", rs -> {}, initialState);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
@@ -1,5 +1,7 @@
 package net.snowflake.ingest.streaming.internal;
 
+import static java.time.ZoneOffset.UTC;
+
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -35,7 +37,8 @@ public class ChannelCacheTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
     channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel2",
@@ -48,7 +51,8 @@ public class ChannelCacheTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
     channel3 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel3",
@@ -61,7 +65,8 @@ public class ChannelCacheTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
     cache.addChannel(channel1);
     cache.addChannel(channel2);
     cache.addChannel(channel3);
@@ -86,7 +91,8 @@ public class ChannelCacheTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
     cache.addChannel(channel);
     Assert.assertEquals(1, cache.getSize());
     Assert.assertTrue(channel == cache.iterator().next().getValue().get(channelName));
@@ -103,7 +109,8 @@ public class ChannelCacheTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
     cache.addChannel(channelDup);
     // The old channel should be invalid now
     Assert.assertTrue(!channel.isValid());
@@ -183,7 +190,8 @@ public class ChannelCacheTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
     cache.removeChannelIfSequencersMatch(channel3Dup);
     // Verify that remove the same channel with a different channel sequencer is a no op
     Assert.assertEquals(1, cache.getSize());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -1,5 +1,6 @@
 package net.snowflake.ingest.streaming.internal;
 
+import static java.time.ZoneOffset.UTC;
 import static net.snowflake.ingest.TestUtils.buildString;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.BYTES_16_MB;
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.BYTES_8_MB;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -19,6 +19,8 @@ import java.nio.file.Paths;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -122,7 +124,8 @@ public class FlushServiceTest {
         Long rowSequencer,
         String encryptionKey,
         Long encryptionKeyId,
-        OpenChannelRequest.OnErrorOption onErrorOption);
+        OpenChannelRequest.OnErrorOption onErrorOption,
+        ZoneId defaultTimezone);
 
     ChannelBuilder channelBuilder(String name) {
       return new ChannelBuilder(name);
@@ -197,7 +200,8 @@ public class FlushServiceTest {
                 rowSequencer,
                 encryptionKey,
                 encryptionKeyId,
-                onErrorOption);
+                onErrorOption,
+                ZoneOffset.UTC);
         channels.put(name, channel);
         channelCache.addChannel(channel);
         return channel;
@@ -246,7 +250,8 @@ public class FlushServiceTest {
         Long rowSequencer,
         String encryptionKey,
         Long encryptionKeyId,
-        OpenChannelRequest.OnErrorOption onErrorOption) {
+        OpenChannelRequest.OnErrorOption onErrorOption,
+        ZoneId defaultTimezone) {
       return new SnowflakeStreamingIngestChannelInternal<>(
           name,
           dbName,
@@ -259,6 +264,7 @@ public class FlushServiceTest {
           encryptionKey,
           encryptionKeyId,
           onErrorOption,
+          defaultTimezone,
           Constants.BdecVersion.ONE,
           allocator);
     }
@@ -295,7 +301,8 @@ public class FlushServiceTest {
         Long rowSequencer,
         String encryptionKey,
         Long encryptionKeyId,
-        OpenChannelRequest.OnErrorOption onErrorOption) {
+        OpenChannelRequest.OnErrorOption onErrorOption,
+        ZoneId defaultTimezone) {
       return new SnowflakeStreamingIngestChannelInternal<>(
           name,
           dbName,
@@ -308,6 +315,7 @@ public class FlushServiceTest {
           encryptionKey,
           encryptionKeyId,
           onErrorOption,
+          defaultTimezone,
           Constants.BdecVersion.THREE,
           null);
     }
@@ -638,7 +646,8 @@ public class FlushServiceTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            ZoneOffset.UTC);
 
     SnowflakeStreamingIngestChannelInternal<StubChunkData> channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
@@ -652,7 +661,8 @@ public class FlushServiceTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            ZoneOffset.UTC);
 
     channelCache.addChannel(channel1);
     channelCache.addChannel(channel2);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
@@ -1,5 +1,7 @@
 package net.snowflake.ingest.streaming.internal;
 
+import static java.time.ZoneOffset.UTC;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -26,7 +28,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            12, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+            12, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -52,7 +54,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            1234, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+            1234, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -78,7 +80,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            123456789, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+            123456789, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -104,7 +106,11 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            123456789987654321L, testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats);
+            123456789987654321L,
+            testCol,
+            PrimitiveType.PrimitiveTypeName.INT64,
+            rowBufferStats,
+            UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -133,7 +139,8 @@ public class ParquetValueParserTest {
             new BigDecimal("91234567899876543219876543211234567891"),
             testCol,
             PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
-            rowBufferStats);
+            rowBufferStats,
+            UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -164,7 +171,8 @@ public class ParquetValueParserTest {
             new BigDecimal("12345.54321"),
             testCol,
             PrimitiveType.PrimitiveTypeName.DOUBLE,
-            rowBufferStats);
+            rowBufferStats,
+            UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -188,7 +196,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            12345.54321d, testCol, PrimitiveType.PrimitiveTypeName.DOUBLE, rowBufferStats);
+            12345.54321d, testCol, PrimitiveType.PrimitiveTypeName.DOUBLE, rowBufferStats, UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -212,7 +220,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            true, testCol, PrimitiveType.PrimitiveTypeName.BOOLEAN, rowBufferStats);
+            true, testCol, PrimitiveType.PrimitiveTypeName.BOOLEAN, rowBufferStats, UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -236,7 +244,11 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "1234abcd".getBytes(), testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
+            "1234abcd".getBytes(),
+            testCol,
+            PrimitiveType.PrimitiveTypeName.BINARY,
+            rowBufferStats,
+            UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -272,7 +284,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
+            var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -310,7 +322,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
+            var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -340,7 +352,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            input, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats);
+            input, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC);
 
     String resultArray = "[{\"a\":\"1\",\"b\":\"2\",\"c\":\"3\"}]";
 
@@ -374,7 +386,8 @@ public class ParquetValueParserTest {
                     "2013-04-28 20:57:00",
                     testCol,
                     PrimitiveType.PrimitiveTypeName.INT32,
-                    rowBufferStats));
+                    rowBufferStats,
+                    UTC));
     Assert.assertEquals(
         "Unknown data type for logical: TIMESTAMP_NTZ, physical: SB4.", exception.getMessage());
   }
@@ -393,10 +406,11 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "2013-04-28 20:57:01.000",
+            "2013-04-28T20:57:01.000",
             testCol,
             PrimitiveType.PrimitiveTypeName.INT64,
-            rowBufferStats);
+            rowBufferStats,
+            UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -421,10 +435,11 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "2022-09-18 22:05:07.123456789",
+            "2022-09-18T22:05:07.123456789",
             testCol,
             PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
-            rowBufferStats);
+            rowBufferStats,
+            UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -450,7 +465,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "2021-01-01", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+            "2021-01-01", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -475,7 +490,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "01:00:00", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats);
+            "01:00:00", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -500,7 +515,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "01:00:00.123", testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats);
+            "01:00:00.123", testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats, UTC);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -531,7 +546,8 @@ public class ParquetValueParserTest {
                     "11:00:00.12345678",
                     testCol,
                     PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
-                    rowBufferStats));
+                    rowBufferStats,
+                    UTC));
     Assert.assertEquals(
         "Unknown data type for logical: TIME, physical: SB16.", exception.getMessage());
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -1,5 +1,7 @@
 package net.snowflake.ingest.streaming.internal;
 
+import static java.time.ZoneOffset.UTC;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -119,6 +121,7 @@ public class RowBufferTest {
     ChannelRuntimeState initialState = new ChannelRuntimeState("0", 0L, true);
     return AbstractRowBuffer.createRowBuffer(
         onErrorOption,
+        UTC,
         new RootAllocator(),
         bdecVersion,
         "test.buffer",

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -1,5 +1,6 @@
 package net.snowflake.ingest.streaming.internal;
 
+import static java.time.ZoneOffset.UTC;
 import static net.snowflake.ingest.utils.Constants.ACCOUNT_URL;
 import static net.snowflake.ingest.utils.Constants.JDBC_PRIVATE_KEY;
 import static net.snowflake.ingest.utils.Constants.OPEN_CHANNEL_ENDPOINT;
@@ -138,7 +139,8 @@ public class SnowflakeStreamingIngestChannelTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
 
     Assert.assertTrue(channel.isValid());
     channel.invalidate("from testChannelValid");
@@ -187,7 +189,8 @@ public class SnowflakeStreamingIngestChannelTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
 
     Assert.assertFalse(channel.isClosed());
     channel.markClosed();
@@ -484,7 +487,8 @@ public class SnowflakeStreamingIngestChannelTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
 
     ColumnMetadata col = new ColumnMetadata();
     col.setName("COL");
@@ -543,7 +547,8 @@ public class SnowflakeStreamingIngestChannelTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
 
     Runtime mockedRunTime = Mockito.mock(Runtime.class);
     Mockito.when(mockedRunTime.maxMemory()).thenReturn(maxMemory);
@@ -590,7 +595,8 @@ public class SnowflakeStreamingIngestChannelTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("Success");
@@ -625,7 +631,8 @@ public class SnowflakeStreamingIngestChannelTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("Success");
@@ -658,7 +665,8 @@ public class SnowflakeStreamingIngestChannelTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
 
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -11,6 +11,7 @@ import static net.snowflake.ingest.utils.Constants.USER;
 
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,7 +57,9 @@ public class SnowflakeStreamingIngestChannelTest {
         new SnowflakeStreamingIngestClientInternal<>("client");
 
     Object[] fields =
-        new Object[] {name, dbName, schemaName, tableName, channelSequencer, rowSequencer, client};
+        new Object[] {
+          name, dbName, schemaName, tableName, channelSequencer, rowSequencer, client, UTC
+        };
 
     for (int i = 0; i < fields.length; i++) {
       Object tmp = fields[i];
@@ -69,6 +72,7 @@ public class SnowflakeStreamingIngestChannelTest {
             .setRowSequencer((Long) fields[4])
             .setChannelSequencer((Long) fields[5])
             .setOwningClient((SnowflakeStreamingIngestClientInternal<StubChunkData>) fields[6])
+            .setDefaultTimezone((ZoneId) fields[7])
             .build();
         Assert.fail("Channel factory should fail with null fields");
       } catch (SFException e) {
@@ -106,6 +110,7 @@ public class SnowflakeStreamingIngestChannelTest {
             .setEncryptionKey(encryptionKey)
             .setEncryptionKeyId(1234L)
             .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
+            .setDefaultTimezone(UTC)
             .build();
 
     Assert.assertEquals(name, channel.getName());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -1,5 +1,6 @@
 package net.snowflake.ingest.streaming.internal;
 
+import static java.time.ZoneOffset.UTC;
 import static net.snowflake.ingest.utils.Constants.ACCOUNT_URL;
 import static net.snowflake.ingest.utils.Constants.CHANNEL_STATUS_ENDPOINT;
 import static net.snowflake.ingest.utils.Constants.JDBC_PRIVATE_KEY;
@@ -20,6 +21,7 @@ import java.io.StringWriter;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.Security;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -89,6 +91,7 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
+            ZoneOffset.UTC,
             Constants.BdecVersion.ONE,
             new RootAllocator());
     channel2 =
@@ -104,6 +107,7 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
+            ZoneOffset.UTC,
             Constants.BdecVersion.ONE,
             new RootAllocator());
     channel3 =
@@ -119,6 +123,7 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
+            ZoneOffset.UTC,
             Constants.BdecVersion.ONE,
             new RootAllocator());
     channel4 =
@@ -134,6 +139,7 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
+            ZoneOffset.UTC,
             Constants.BdecVersion.ONE,
             new RootAllocator());
   }
@@ -351,6 +357,7 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
+            ZoneOffset.UTC,
             Constants.BdecVersion.ONE,
             new RootAllocator());
 
@@ -410,6 +417,7 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
+            ZoneOffset.UTC,
             Constants.BdecVersion.ONE,
             new RootAllocator());
 
@@ -449,6 +457,7 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
+            ZoneOffset.UTC,
             Constants.BdecVersion.ONE,
             new RootAllocator());
 
@@ -1050,7 +1059,8 @@ public class SnowflakeStreamingIngestClientTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
     SnowflakeStreamingIngestChannelInternal<StubChunkData> channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
             channel2Name,
@@ -1063,7 +1073,8 @@ public class SnowflakeStreamingIngestClientTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
     client.getChannelCache().addChannel(channel1);
     client.getChannelCache().addChannel(channel2);
 
@@ -1189,7 +1200,8 @@ public class SnowflakeStreamingIngestClientTest {
             client,
             "key",
             1234L,
-            OpenChannelRequest.OnErrorOption.CONTINUE);
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
     client.getChannelCache().addChannel(channel);
 
     ChannelsStatusResponse response = new ChannelsStatusResponse();

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -361,26 +361,26 @@ public class StreamingIngestIT {
     SnowflakeStreamingIngestChannel channel1 = client.openChannel(request1);
 
     Map<String, Object> row = new HashMap<>();
-    row.put("ttzsmall", "2021-01-01 01:00:00.123 -0300");
-    row.put("ttzbig", "2021-01-01 09:00:00.12345678 -0300");
+    row.put("ttzsmall", "2021-01-01T01:00:00.123-03:00");
+    row.put("ttzbig", "2021-01-01T09:00:00.12345678-03:00");
     row.put("tsmall", "01:00:00.123");
     row.put("tbig", "09:00:00.12345678");
     row.put("tntzsmall", "1609462800123");
     row.put("tntzbig", "1609462800123450000");
     verifyInsertValidationResponse(channel1.insertRow(row, null));
-    row.put("ttzsmall", "2021-01-01 10:00:00.123 +0700");
-    row.put("ttzbig", "2021-01-01 19:00:00.12345678 -0300");
+    row.put("ttzsmall", "2021-01-01T10:00:00.123+07:00");
+    row.put("ttzbig", "2021-01-01T19:00:00.12345678-03:00");
     row.put("tsmall", "02:00:00.123");
     row.put("tbig", "10:00:00.12345678");
     row.put("tntzsmall", "1709462800123");
     row.put("tntzbig", "170946280212345000");
     verifyInsertValidationResponse(channel1.insertRow(row, null));
-    row.put("ttzsmall", "2021-01-01 05:00:00 +0100");
-    row.put("ttzbig", "2021-01-01 23:00:00.12345678 -0300");
+    row.put("ttzsmall", "2021-01-01T05:00:00+01:00");
+    row.put("ttzbig", "2021-01-01T23:00:00.12345678-03:00");
     row.put("tsmall", "03:00:00.123");
     row.put("tbig", "11:00:00.12345678");
     row.put("tntzsmall", "1809462800123");
-    row.put("tntzbig", "2031-01-01 09:00:00.123456780");
+    row.put("tntzbig", "2031-01-01T09:00:00.123456780");
     verifyInsertValidationResponse(channel1.insertRow(row, "1"));
 
     // Close the channel after insertion
@@ -472,7 +472,7 @@ public class StreamingIngestIT {
     row.put("tinyfloat", 1.1);
     row.put("var", "{\"e\":2.7}");
     row.put("t", String.valueOf(timestamp));
-    row.put("d", "1969-12-31 00:00:00");
+    row.put("d", "1969-12-31T00:00:00");
     verifyInsertValidationResponse(channel1.insertRow(row, "1"));
 
     // Close the channel after insertion
@@ -1230,9 +1230,9 @@ public class StreamingIngestIT {
         "{ \"a\": 1, \"b\": \"qwerty\", \"c\": null, \"d\": { \"e\": 2, \"f\": \"asdf\", \"g\":"
             + " null } }");
     posRow.put("arr", Arrays.asList("{ \"a\": 1}", "{ \"b\": 2 }", "{ \"c\": 3 }"));
-    posRow.put("epochdays", "2022-09-18 20:05:07"); // DATE, 18.09.2022
-    posRow.put("epochsec", "2022-09-18 20:05:07"); // TIMESTAMP_NTZ(0)
-    posRow.put("epochnano", "2022-09-18 20:05:07.999999999"); // TIMESTAMP_NTZ(9)
+    posRow.put("epochdays", "2022-09-18T20:05:07"); // DATE, 18.09.2022
+    posRow.put("epochsec", "2022-09-18T20:05:07"); // TIMESTAMP_NTZ(0)
+    posRow.put("epochnano", "2022-09-18T20:05:07.999999999"); // TIMESTAMP_NTZ(9)
     posRow.put("timesec", "01:00:01.999999999"); // TIME(0)
     posRow.put("timenano", "01:00:01.999999999"); // TIME(9)
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -9,6 +9,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,6 +44,8 @@ public abstract class AbstractDataTypeTest {
   private static final String SOURCE_JDBC = "JDBC";
   private static final String SCHEMA_NAME = "PUBLIC";
 
+  private static final ZoneId DEFAULT_DEFAULT_TIMEZONE = ZoneOffset.UTC;
+
   protected static BigInteger MAX_ALLOWED_BIG_INTEGER =
       new BigInteger("99999999999999999999999999999999999999");
   protected static BigInteger MIN_ALLOWED_BIG_INTEGER =
@@ -52,6 +56,8 @@ public abstract class AbstractDataTypeTest {
 
   protected Connection conn;
   private String databaseName;
+
+  private ZoneId defaultTimezone = DEFAULT_DEFAULT_TIMEZONE;
 
   private String schemaName = "PUBLIC";
   private SnowflakeStreamingIngestClient client;
@@ -86,6 +92,7 @@ public abstract class AbstractDataTypeTest {
 
   @After
   public void after() throws Exception {
+    resetTimezone();
     conn.createStatement().executeQuery(String.format("drop database %s", databaseName));
     if (client != null) {
       client.close();
@@ -93,6 +100,14 @@ public abstract class AbstractDataTypeTest {
     if (conn != null) {
       conn.close();
     }
+  }
+
+  void setChannelDefaultTimezone(ZoneId defaultTimezone) {
+    this.defaultTimezone = defaultTimezone;
+  }
+
+  void resetTimezone() {
+    this.defaultTimezone = DEFAULT_DEFAULT_TIMEZONE;
   }
 
   protected String createTable(String dataType) throws SQLException {
@@ -121,6 +136,7 @@ public abstract class AbstractDataTypeTest {
             .setSchemaName(SCHEMA_NAME)
             .setTableName(tableName)
             .setOnErrorOption(onErrorOption)
+            .setDefaultTimezone(defaultTimezone)
             .build();
     return client.openChannel(openChannelRequest);
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
@@ -6,117 +6,34 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import net.snowflake.ingest.utils.Constants;
-import org.junit.Ignore;
+import org.junit.After;
 import org.junit.Test;
 
-/**
- * Supported date, time and timestamp formats:
- * https://docs.snowflake.com/en/user-guide/date-time-input-output.html#date-formats
- */
 public class DateTimeIT extends AbstractDataTypeTest {
+
+  private static final ZoneId TZ_LOS_ANGELES = ZoneId.of("America/Los_Angeles");
+  private static final ZoneId TZ_BERLIN = ZoneId.of("Europe/Berlin");
+  private static final ZoneId TZ_TOKYO = ZoneId.of("Asia/Tokyo");
 
   public DateTimeIT(String name, Constants.BdecVersion bdecVersion) {
     super(name, bdecVersion);
   }
 
+  @After
+  public void tearDown() throws Exception {
+    conn.createStatement().execute("alter session unset timezone;");
+  }
+
   @Test
   public void testTimestampWithTimeZone() throws Exception {
-    useLosAngelesTimeZone();
+    setJdbcSessionTimezone(TZ_LOS_ANGELES);
+    setChannelDefaultTimezone(TZ_LOS_ANGELES);
 
     // Test timestamp formats
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2/18/2008 02:36:48",
-        "2008-02-18 02:36:48.000000000 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20",
-        "2013-04-28 20:00:00.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20:57",
-        "2013-04-28 20:57:00.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20:57:01",
-        "2013-04-28 20:57:01.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20:57:01 +07:00",
-        "2013-04-28 20:57:01.000000000 +0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20:57:01 +0700",
-        "2013-04-28 20:57:01.000000000 +0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20:57:01-07",
-        "2013-04-28 20:57:01.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20:57:01-07:00",
-        "2013-04-28 20:57:01.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20:57:01.123456",
-        "2013-04-28 20:57:01.123456000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20:57:01.123456789 +07:00",
-        "2013-04-28 20:57:01.123456789 +0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20:57:01.123456789 +0700",
-        "2013-04-28 20:57:01.123456789 +0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20:57:01.123456789+07",
-        "2013-04-28 20:57:01.123456789 +0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20:57:01.123456789+07:00",
-        "2013-04-28 20:57:01.123456789 +0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28 20:57+07:00",
-        "2013-04-28 20:57:00.000000000 +0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "2013-04-28T20",
-        "2013-04-28 20:00:00.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_TZ",
         "2013-04-28T20:57",
@@ -147,65 +64,11 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "2013-04-28 20:57:01.123456789 +0700",
         new StringProvider(),
         new StringProvider());
-    testJdbcTypeCompatibility(
+    // Here we test ingestion only because JDBC cannot ingest ISO_ZONED_DATE_TIME
+    testIngestion(
         "TIMESTAMP_TZ",
-        "2013-04-28T20:57+07:00",
-        "2013-04-28 20:57:00.000000000 +0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "Mon Jul 08 18:09:51 +0000 2013",
-        "2013-07-08 18:09:51.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "Thu, 21 Dec 2000 04:01:07 PM",
-        "2000-12-21 16:01:07.000000000 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "Thu, 21 Dec 2000 04:01:07 PM +0200",
-        "2000-12-21 16:01:07.000000000 +0200",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "Thu, 21 Dec 2000 04:01:07.123456789 PM",
-        "2000-12-21 16:01:07.123456789 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "Thu, 21 Dec 2000 04:01:07.123456789 PM +0200",
-        "2000-12-21 16:01:07.123456789 +0200",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "Thu, 21 Dec 2000 16:01:07",
-        "2000-12-21 16:01:07.000000000 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "Thu, 21 Dec 2000 16:01:07 +0200",
-        "2000-12-21 16:01:07.000000000 +0200",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "Thu, 21 Dec 2000 16:01:07.123456789",
-        "2000-12-21 16:01:07.123456789 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "Thu, 21 Dec 2000 16:01:07.123456789 +0200",
-        "2000-12-21 16:01:07.123456789 +0200",
-        new StringProvider(),
+        "2013-04-28T20:57:01.123456789+09:00[Asia/Tokyo]",
+        "2013-04-28 20:57:01.123456789 +0900",
         new StringProvider());
 
     // Test date formats
@@ -213,18 +76,6 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "TIMESTAMP_TZ",
         "2013-04-28",
         "2013-04-28 00:00:00.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "17-DEC-1980",
-        "1980-12-17 00:00:00.000000000 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ",
-        "12/17/1980",
-        "1980-12-17 00:00:00.000000000 -0800",
         new StringProvider(),
         new StringProvider());
 
@@ -235,9 +86,9 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "2024-02-29 23:59:59.999999999 Z",
         new StringProvider(),
         new StringProvider());
-    expectArrowNotSupported("TIMESTAMP_TZ", "2023-02-29T23:59:59.999999999Z");
+    expectArrowNotSupported("TIMESTAMP_TZ", "2023-02-29T23:59:59.999999999");
 
-    // Test numeric strings
+    // Numeric strings
     testJdbcTypeCompatibility(
         "TIMESTAMP_TZ",
         "0",
@@ -246,137 +97,173 @@ public class DateTimeIT extends AbstractDataTypeTest {
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_TZ",
-        "86399",
-        "1970-01-01 23:59:59.000000000 Z",
+        "1674478926",
+        "2023-01-23 13:02:06.000000000 Z",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_TZ",
-        "86401",
-        "1970-01-02 00:00:01.000000000 Z",
+        "1674478926123",
+        "2023-01-23 13:02:06.123000000 Z",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_TZ",
-        "-86401",
-        "1969-12-30 23:59:59.000000000 Z",
+        "1674478926123456",
+        "2023-01-23 13:02:06.123456000 Z",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_TZ",
-        "-86399",
-        "1969-12-31 00:00:01.000000000 Z",
+        "1674478926123456789",
+        "2023-01-23 13:02:06.123456789 Z",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_TZ",
-        "1662731080",
-        "2022-09-09 13:44:40.000000000 Z",
+        "-1674478926",
+        "1916-12-09 10:57:54.000000000 Z",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_TZ",
-        "1662731080123456789",
-        "2022-09-09 13:44:40.123456789 Z",
+        "-1674478926123",
+        "1916-12-09 10:57:53.877000000 Z",
         new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "-1674478926123456",
+        "1916-12-09 10:57:53.876544000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "-1674478926123456789",
+        "1916-12-09 10:57:53.876543211 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    // java.time.LocalDate
+    testIngestion(
+        "TIMESTAMP_TZ",
+        LocalDate.parse("2007-12-03"),
+        "2007-12-03 00:00:00.000000000 -0800",
+        new StringProvider());
+    // java.time.LocalDateTime
+    testIngestion(
+        "TIMESTAMP_TZ",
+        LocalDateTime.parse("2007-12-03T10:15:30"),
+        "2007-12-03 10:15:30.000000000 -0800",
+        new StringProvider());
+    // java.time.OffsetDateTime
+    testIngestion(
+        "TIMESTAMP_TZ",
+        OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
+        "2007-12-03 10:15:30.000000000 +0100",
+        new StringProvider());
+    // java.time.ZonedDateTime
+    testIngestion(
+        "TIMESTAMP_TZ",
+        ZonedDateTime.parse("2007-12-03T10:15:30.000456789+01:00[Europe/Paris]"),
+        "2007-12-03 10:15:30.000456789 +0100",
+        new StringProvider());
+    // java.time.Instant
+    testIngestion(
+        "TIMESTAMP_TZ",
+        OffsetDateTime.parse("2007-12-03T10:15:30.123456789+00:00").toInstant(),
+        "2007-12-03 10:15:30.123456789 Z",
+        new StringProvider());
+
+    // Verify that default timezone has impact on input without timezone information
+    setChannelDefaultTimezone(TZ_BERLIN);
+    testIngestion(
+        "TIMESTAMP_TZ",
+        "2013-04-28T20:57:01.123456789",
+        "2013-04-28 20:57:01.123456789 +0200",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ",
+        LocalDate.parse("2007-12-03"),
+        "2007-12-03 00:00:00.000000000 +0100",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ",
+        LocalDateTime.parse("2007-12-03T10:15:30"),
+        "2007-12-03 10:15:30.000000000 +0100",
+        new StringProvider());
+
+    // No impact on integer-stored and instant as they are always UTC
+    testIngestion(
+        "TIMESTAMP_TZ",
+        "1674478926123456789",
+        "2023-01-23 13:02:06.123456789 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ",
+        OffsetDateTime.parse("2007-12-03T10:15:30.123456789+00:00").toInstant(),
+        "2007-12-03 10:15:30.123456789 Z",
+        new StringProvider());
+
+    // Limited scale
+    testIngestion(
+        "TIMESTAMP_TZ(0)",
+        "2022-01-31T13:00:00+09:00",
+        "2022-01-31 13:00:00. +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ(0)",
+        "2022-01-31T13:00:00.123456+09:00",
+        "2022-01-31 13:00:00. +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ(1)",
+        "2022-01-31T13:00:00+09:00",
+        "2022-01-31 13:00:00.0 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ(1)",
+        "2022-01-31T13:00:00.123456+09:00",
+        "2022-01-31 13:00:00.1 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ(2)",
+        "2022-01-31T13:00:00.1+09:00",
+        "2022-01-31 13:00:00.10 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ(2)",
+        "2022-01-31T13:00:00.123456+09:00",
+        "2022-01-31 13:00:00.12 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ(8)",
+        "2022-01-31T13:00:00.1+09:00",
+        "2022-01-31 13:00:00.10000000 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ(8)",
+        "2022-01-31T13:00:00.123456789+09:00",
+        "2022-01-31 13:00:00.12345678 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ(8)",
+        "2022-01-31T13:00:00.000000009+09:00",
+        "2022-01-31 13:00:00.00000000 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ(8)",
+        "2022-01-31T13:00:00.000000019+09:00",
+        "2022-01-31 13:00:00.00000001 +0900",
         new StringProvider());
   }
 
   @Test
   public void testTimestampWithLocalTimeZone() throws Exception {
-    useLosAngelesTimeZone();
+    setJdbcSessionTimezone(TZ_LOS_ANGELES);
+    setChannelDefaultTimezone(TZ_LOS_ANGELES);
 
     // Test timestamp formats
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2/18/2008 02:36:48",
-        "2008-02-18 02:36:48.000000000 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20",
-        "2013-04-28 20:00:00.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20:57",
-        "2013-04-28 20:57:00.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20:57:01",
-        "2013-04-28 20:57:01.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20:57:01 +07:00",
-        "2013-04-28 06:57:01.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20:57:01 +0700",
-        "2013-04-28 06:57:01.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20:57:01-07",
-        "2013-04-28 20:57:01.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20:57:01-07:00",
-        "2013-04-28 20:57:01.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20:57:01.123456",
-        "2013-04-28 20:57:01.123456000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20:57:01.123456789 +07:00",
-        "2013-04-28 06:57:01.123456789 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20:57:01.123456789 +0700",
-        "2013-04-28 06:57:01.123456789 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20:57:01.123456789+07",
-        "2013-04-28 06:57:01.123456789 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20:57:01.123456789+07:00",
-        "2013-04-28 06:57:01.123456789 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28 20:57+07:00",
-        "2013-04-28 06:57:00.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "2013-04-28T20",
-        "2013-04-28 20:00:00.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_LTZ",
         "2013-04-28T20:57",
@@ -407,65 +294,11 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "2013-04-28 06:57:01.123456789 -0700",
         new StringProvider(),
         new StringProvider());
-    testJdbcTypeCompatibility(
+    // Here we test ingestion only because JDBC cannot ingest ISO_ZONED_DATE_TIME
+    testIngestion(
         "TIMESTAMP_LTZ",
-        "2013-04-28T20:57+07:00",
-        "2013-04-28 06:57:00.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "Mon Jul 08 18:09:51 +0000 2013",
-        "2013-07-08 11:09:51.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "Thu, 21 Dec 2000 04:01:07 PM",
-        "2000-12-21 16:01:07.000000000 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "Thu, 21 Dec 2000 04:01:07 PM +0200",
-        "2000-12-21 06:01:07.000000000 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "Thu, 21 Dec 2000 04:01:07.123456789 PM",
-        "2000-12-21 16:01:07.123456789 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "Thu, 21 Dec 2000 04:01:07.123456789 PM +0200",
-        "2000-12-21 06:01:07.123456789 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "Thu, 21 Dec 2000 16:01:07",
-        "2000-12-21 16:01:07.000000000 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "Thu, 21 Dec 2000 16:01:07 +0200",
-        "2000-12-21 06:01:07.000000000 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "Thu, 21 Dec 2000 16:01:07.123456789",
-        "2000-12-21 16:01:07.123456789 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "Thu, 21 Dec 2000 16:01:07.123456789 +0200",
-        "2000-12-21 06:01:07.123456789 -0800",
-        new StringProvider(),
+        "2013-04-28T20:57:01.123456789+09:00[Asia/Tokyo]",
+        "2013-04-28 04:57:01.123456789 -0700",
         new StringProvider());
 
     // Test date formats
@@ -473,18 +306,6 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "TIMESTAMP_LTZ",
         "2013-04-28",
         "2013-04-28 00:00:00.000000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "17-DEC-1980",
-        "1980-12-17 00:00:00.000000000 -0800",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ",
-        "12/17/1980",
-        "1980-12-17 00:00:00.000000000 -0800",
         new StringProvider(),
         new StringProvider());
 
@@ -509,9 +330,9 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "2024-02-29 15:59:59.999999999 -0800",
         new StringProvider(),
         new StringProvider());
-    expectArrowNotSupported("TIMESTAMP_LTZ", "2023-02-29T23:59:59.999999999Z");
+    expectArrowNotSupported("TIMESTAMP_LTZ", "2023-02-29T23:59:59.999999999");
 
-    // Test numeric strings
+    // Numeric strings
     testJdbcTypeCompatibility(
         "TIMESTAMP_LTZ",
         "0",
@@ -520,135 +341,171 @@ public class DateTimeIT extends AbstractDataTypeTest {
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_LTZ",
-        "86399",
-        "1970-01-01 15:59:59.000000000 -0800",
+        "1674478926",
+        "2023-01-23 05:02:06.000000000 -0800",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_LTZ",
-        "86401",
-        "1970-01-01 16:00:01.000000000 -0800",
+        "1674478926123",
+        "2023-01-23 05:02:06.123000000 -0800",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_LTZ",
-        "-86401",
-        "1969-12-30 15:59:59.000000000 -0800",
+        "1674478926123456",
+        "2023-01-23 05:02:06.123456000 -0800",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_LTZ",
-        "-86399",
-        "1969-12-30 16:00:01.000000000 -0800",
+        "1674478926123456789",
+        "2023-01-23 05:02:06.123456789 -0800",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_LTZ",
-        "1662731080",
-        "2022-09-09 06:44:40.000000000 -0700",
+        "-1674478926",
+        "1916-12-09 02:57:54.000000000 -0800",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_LTZ",
-        "1662731080123456789",
-        "2022-09-09 06:44:40.123456789 -0700",
+        "-1674478926123",
+        "1916-12-09 02:57:53.877000000 -0800",
         new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "-1674478926123456",
+        "1916-12-09 02:57:53.876544000 -0800",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "-1674478926123456789",
+        "1916-12-09 02:57:53.876543211 -0800",
+        new StringProvider(),
+        new StringProvider());
+
+    // java.time.LocalDate
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        LocalDate.parse("2007-12-03"),
+        "2007-12-03 00:00:00.000000000 -0800",
+        new StringProvider());
+    // java.time.LocalDateTime
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        LocalDateTime.parse("2007-12-03T10:15:30"),
+        "2007-12-03 10:15:30.000000000 -0800",
+        new StringProvider());
+    // java.time.OffsetDateTime
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
+        "2007-12-03 01:15:30.000000000 -0800",
+        new StringProvider());
+    // java.time.ZonedDateTime
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        ZonedDateTime.parse("2007-12-03T10:15:30.123456789+01:00[Europe/Paris]"),
+        "2007-12-03 01:15:30.123456789 -0800",
+        new StringProvider());
+    // java.time.Instant
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        OffsetDateTime.parse("2007-12-03T10:15:30.123456789+00:00").toInstant(),
+        "2007-12-03 02:15:30.123456789 -0800",
+        new StringProvider());
+
+    // Verify that default timezone has impact on input without timezone information
+    setChannelDefaultTimezone(TZ_BERLIN);
+    setJdbcSessionTimezone(TZ_BERLIN);
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        "1674478926123456789",
+        "2023-01-23 14:02:06.123456789 +0100",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        "2013-04-28T20:57:01.123456789",
+        "2013-04-28 20:57:01.123456789 +0200",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        LocalDate.parse("2007-12-03"),
+        "2007-12-03 00:00:00.000000000 +0100",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        LocalDateTime.parse("2007-12-03T10:15:30"),
+        "2007-12-03 10:15:30.000000000 +0100",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ",
+        OffsetDateTime.parse("2007-12-03T10:15:30.123456789+00:00").toInstant(),
+        "2007-12-03 11:15:30.123456789 +0100",
+        new StringProvider());
+
+    // Limited scale
+    setChannelDefaultTimezone(TZ_TOKYO);
+    setJdbcSessionTimezone(TZ_TOKYO);
+    testIngestion(
+        "TIMESTAMP_LTZ(0)",
+        "2022-01-31T13:00:00+09:00",
+        "2022-01-31 13:00:00. +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ(0)",
+        "2022-01-31T13:00:00.123456+09:00",
+        "2022-01-31 13:00:00. +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ(1)",
+        "2022-01-31T13:00:00+09:00",
+        "2022-01-31 13:00:00.0 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ(1)",
+        "2022-01-31T13:00:00.123456+09:00",
+        "2022-01-31 13:00:00.1 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ(2)",
+        "2022-01-31T13:00:00.1+09:00",
+        "2022-01-31 13:00:00.10 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ(2)",
+        "2022-01-31T13:00:00.123456+09:00",
+        "2022-01-31 13:00:00.12 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ(8)",
+        "2022-01-31T13:00:00.1+09:00",
+        "2022-01-31 13:00:00.10000000 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ(8)",
+        "2022-01-31T13:00:00.123456789+09:00",
+        "2022-01-31 13:00:00.12345678 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ(8)",
+        "2022-01-31T13:00:00.000000009+09:00",
+        "2022-01-31 13:00:00.00000000 +0900",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ(8)",
+        "2022-01-31T13:00:00.000000019+09:00",
+        "2022-01-31 13:00:00.00000001 +0900",
         new StringProvider());
   }
 
   @Test
   public void testTimestampWithoutTimeZone() throws Exception {
     // Test timestamp formats
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2/18/2008 02:36:48",
-        "2008-02-18 02:36:48.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20",
-        "2013-04-28 20:00:00.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20:57",
-        "2013-04-28 20:57:00.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20:57:01",
-        "2013-04-28 20:57:01.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20:57:01 +07:00",
-        "2013-04-28 20:57:01.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20:57:01 +0700",
-        "2013-04-28 20:57:01.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20:57:01-07",
-        "2013-04-28 20:57:01.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20:57:01-07:00",
-        "2013-04-28 20:57:01.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20:57:01.123456",
-        "2013-04-28 20:57:01.123456000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20:57:01.123456789 +07:00",
-        "2013-04-28 20:57:01.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20:57:01.123456789 +0700",
-        "2013-04-28 20:57:01.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20:57:01.123456789+07",
-        "2013-04-28 20:57:01.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20:57:01.123456789+07:00",
-        "2013-04-28 20:57:01.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28 20:57+07:00",
-        "2013-04-28 20:57:00.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "2013-04-28T20",
-        "2013-04-28 20:00:00.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_NTZ",
         "2013-04-28T20:57",
@@ -679,65 +536,11 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "2013-04-28 20:57:01.123456789 Z",
         new StringProvider(),
         new StringProvider());
-    testJdbcTypeCompatibility(
+    // Here we test ingestion only because JDBC cannot ingest ISO_ZONED_DATE_TIME
+    testIngestion(
         "TIMESTAMP_NTZ",
-        "2013-04-28T20:57+07:00",
-        "2013-04-28 20:57:00.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "Mon Jul 08 18:09:51 +0000 2013",
-        "2013-07-08 18:09:51.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "Thu, 21 Dec 2000 04:01:07 PM",
-        "2000-12-21 16:01:07.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "Thu, 21 Dec 2000 04:01:07 PM +0200",
-        "2000-12-21 16:01:07.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "Thu, 21 Dec 2000 04:01:07.123456789 PM",
-        "2000-12-21 16:01:07.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "Thu, 21 Dec 2000 04:01:07.123456789 PM +0200",
-        "2000-12-21 16:01:07.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "Thu, 21 Dec 2000 16:01:07",
-        "2000-12-21 16:01:07.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "Thu, 21 Dec 2000 16:01:07 +0200",
-        "2000-12-21 16:01:07.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "Thu, 21 Dec 2000 16:01:07.123456789",
-        "2000-12-21 16:01:07.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "Thu, 21 Dec 2000 16:01:07.123456789 +0200",
-        "2000-12-21 16:01:07.123456789 Z",
-        new StringProvider(),
+        "2013-04-28T20:57:01.123456789+09:00[Asia/Tokyo]",
+        "2013-04-28 20:57:01.123456789 Z",
         new StringProvider());
 
     // Test date formats
@@ -745,18 +548,6 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "TIMESTAMP_NTZ",
         "2013-04-28",
         "2013-04-28 00:00:00.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "17-DEC-1980",
-        "1980-12-17 00:00:00.000000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ",
-        "12/17/1980",
-        "1980-12-17 00:00:00.000000000 Z",
         new StringProvider(),
         new StringProvider());
 
@@ -781,9 +572,9 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "2024-02-29 23:59:59.999999999 Z",
         new StringProvider(),
         new StringProvider());
-    expectArrowNotSupported("TIMESTAMP_NTZ", "2023-02-29T23:59:59.999999999Z");
+    expectArrowNotSupported("TIMESTAMP_NTZ", "2023-02-29T23:59:59.999999999");
 
-    // Test numeric strings
+    // Numeric strings
     testJdbcTypeCompatibility(
         "TIMESTAMP_NTZ",
         "0",
@@ -792,54 +583,236 @@ public class DateTimeIT extends AbstractDataTypeTest {
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_NTZ",
-        "86399",
-        "1970-01-01 23:59:59.000000000 Z",
+        "1674478926",
+        "2023-01-23 13:02:06.000000000 Z",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_NTZ",
-        "86401",
-        "1970-01-02 00:00:01.000000000 Z",
+        "1674478926123",
+        "2023-01-23 13:02:06.123000000 Z",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_NTZ",
-        "-86401",
-        "1969-12-30 23:59:59.000000000 Z",
+        "1674478926123456",
+        "2023-01-23 13:02:06.123456000 Z",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_NTZ",
-        "-86399",
-        "1969-12-31 00:00:01.000000000 Z",
+        "1674478926123456789",
+        "2023-01-23 13:02:06.123456789 Z",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_NTZ",
-        "1662731080",
-        "2022-09-09 13:44:40.000000000 Z",
+        "-1674478926",
+        "1916-12-09 10:57:54.000000000 Z",
         new StringProvider(),
         new StringProvider());
     testJdbcTypeCompatibility(
         "TIMESTAMP_NTZ",
-        "1662731080123456789",
-        "2022-09-09 13:44:40.123456789 Z",
+        "-1674478926123",
+        "1916-12-09 10:57:53.877000000 Z",
         new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "-1674478926123456",
+        "1916-12-09 10:57:53.876544000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "-1674478926123456789",
+        "1916-12-09 10:57:53.876543211 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    // java.time.LocalDate
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        LocalDate.parse("2007-12-03"),
+        "2007-12-03 00:00:00.000000000 Z",
+        new StringProvider());
+    // java.time.LocalDateTime
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        LocalDateTime.parse("2007-12-03T10:15:30"),
+        "2007-12-03 10:15:30.000000000 Z",
+        new StringProvider());
+    // java.time.OffsetDateTime
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
+        "2007-12-03 10:15:30.000000000 Z",
+        new StringProvider());
+    // java.time.ZonedDateTime
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        ZonedDateTime.parse("2007-12-03T10:15:30.123456789+01:00[Europe/Paris]"),
+        "2007-12-03 10:15:30.123456789 Z",
+        new StringProvider());
+    // java.time.Instant
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        OffsetDateTime.parse("2007-12-03T10:15:30.123456789+00:00").toInstant(),
+        "2007-12-03 10:15:30.123456789 Z",
+        new StringProvider());
+
+    // Verify that default timezone has no impact
+    setChannelDefaultTimezone(TZ_LOS_ANGELES);
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        "1674478926123456789",
+        "2023-01-23 13:02:06.123456789 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        "2013-04-28T20:57:01.123456789",
+        "2013-04-28 20:57:01.123456789 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        LocalDate.parse("2007-12-03"),
+        "2007-12-03 00:00:00.000000000 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        LocalDateTime.parse("2007-12-03T10:15:30"),
+        "2007-12-03 10:15:30.000000000 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        OffsetDateTime.parse("2007-12-03T10:15:30.123456789+00:00").toInstant(),
+        "2007-12-03 10:15:30.123456789 Z",
+        new StringProvider());
+
+    // Limited scale
+    testIngestion(
+        "TIMESTAMP_NTZ(0)",
+        "2022-01-31T13:00:00+09:00",
+        "2022-01-31 13:00:00. Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ(0)",
+        "2022-01-31T13:00:00.123456+09:00",
+        "2022-01-31 13:00:00. Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ(1)",
+        "2022-01-31T13:00:00+09:00",
+        "2022-01-31 13:00:00.0 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ(1)",
+        "2022-01-31T13:00:00.123456+09:00",
+        "2022-01-31 13:00:00.1 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ(2)",
+        "2022-01-31T13:00:00.1+09:00",
+        "2022-01-31 13:00:00.10 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ(2)",
+        "2022-01-31T13:00:00.123456+09:00",
+        "2022-01-31 13:00:00.12 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ(8)",
+        "2022-01-31T13:00:00.1+09:00",
+        "2022-01-31 13:00:00.10000000 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ(8)",
+        "2022-01-31T13:00:00.123456789+09:00",
+        "2022-01-31 13:00:00.12345678 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ(8)",
+        "2022-01-31T13:00:00.000000009+09:00",
+        "2022-01-31 13:00:00.00000000 Z",
+        new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ(8)",
+        "2022-01-31T13:00:00.000000019+09:00",
+        "2022-01-31 13:00:00.00000001 Z",
         new StringProvider());
   }
 
   @Test
-  public void testJavaTimeObjects() throws Exception {
-    // TIME (LocalTime and OffsetTime are supported)
+  public void testTime() throws Exception {
+    // Simple time parsing
+    testJdbcTypeCompatibility(
+        "TIME", "20:57", "20:57:00.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME", "20:57:01", "20:57:01.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME",
+        "20:57:01.123456789",
+        "20:57:01.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME",
+        "20:57:01.123456789+07:00",
+        "20:57:01.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    // Numeric strings
+    testJdbcTypeCompatibility(
+        "TIME", "0", "00:00:00.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME", "1674478926", "13:02:06.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME",
+        "1674478926123",
+        "13:02:06.123000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME",
+        "1674478926123456",
+        "13:02:06.123456000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME",
+        "1674478926123456789",
+        "13:02:06.123456789 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME", "-1674478926", "10:57:54.000000000 Z", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME",
+        "-1674478926123",
+        "10:57:53.877000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME",
+        "-1674478926123456",
+        "10:57:53.876544000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIME",
+        "-1674478926123456789",
+        "10:57:53.876543211 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    // java.time.LocalTime
     testIngestion("TIME", LocalTime.of(23, 59, 59), "23:59:59.000000000 Z", new StringProvider());
+
+    // java.time.OffsetTime
     testIngestion(
         "TIME",
         OffsetTime.of(23, 59, 59, 0, ZoneOffset.ofHoursMinutes(4, 0)),
-        "23:59:59.000000000 Z",
-        new StringProvider());
-    testIngestion(
-        "TIME",
-        OffsetTime.of(23, 59, 59, 0, ZoneOffset.ofHoursMinutes(-4, 0)),
         "23:59:59.000000000 Z",
         new StringProvider());
     testIngestion(
@@ -853,714 +826,22 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "23:59:59.123456789 Z",
         new StringProvider());
 
-    // DATE (LocalDate, LocalDateTime, OffsetDateTime, ZonedDateTime are supported)
-    testIngestion("DATE", LocalDate.parse("2007-12-03"), "2007-12-03", new StringProvider());
-    testIngestion(
-        "DATE", LocalDateTime.parse("2007-12-03T10:15:30"), "2007-12-03", new StringProvider());
-    testIngestion(
-        "DATE",
-        OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
-        "2007-12-03",
-        new StringProvider());
-    testIngestion(
-        "DATE",
-        OffsetDateTime.parse("2007-12-03T00:00:00+01:00"),
-        "2007-12-03",
-        new StringProvider());
-    testIngestion(
-        "DATE",
-        OffsetDateTime.parse("2007-12-03T00:00:00-08:00"),
-        "2007-12-03",
-        new StringProvider());
-    testIngestion(
-        "DATE",
-        ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]"),
-        "2007-12-03",
-        new StringProvider());
-    testIngestion(
-        "DATE",
-        ZonedDateTime.parse("2007-12-03T00:00:00+01:00[Europe/Paris]"),
-        "2007-12-03",
-        new StringProvider());
-    testIngestion(
-        "DATE",
-        ZonedDateTime.parse("2007-12-03T00:00:00-08:00[America/Los_Angeles]"),
-        "2007-12-03",
-        new StringProvider());
-    testIngestion(
-        "DATE",
-        ZonedDateTime.parse("2007-07-03T00:00:00-07:00[America/Los_Angeles]"),
-        "2007-07-03",
-        new StringProvider());
-    //
-    // TIMESTAMP_NTZ (LocalDate, LocalDateTime, OffsetDateTime, ZonedDateTime are supported)
-    testIngestion(
-        "TIMESTAMP_NTZ",
-        LocalDate.parse("2007-12-03"),
-        "2007-12-03 00:00:00.000000000 Z",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_NTZ",
-        LocalDateTime.parse("2007-12-03T10:15:30"),
-        "2007-12-03 10:15:30.000000000 Z",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_NTZ",
-        OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
-        "2007-12-03 10:15:30.000000000 Z",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_NTZ",
-        ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]"),
-        "2007-12-03 10:15:30.000000000 Z",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_NTZ",
-        ZonedDateTime.parse("2007-12-03T10:15:30.123456789+01:00[Europe/Paris]"),
-        "2007-12-03 10:15:30.123456789 Z",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_NTZ",
-        ZonedDateTime.parse("2007-07-03T10:15:30.123456789+02:00[Europe/Paris]"),
-        "2007-07-03 10:15:30.123456789 Z",
-        new StringProvider());
-
-    useLosAngelesTimeZone();
-    // TIMESTAMP_LTZ (LocalDate, LocalDateTime, OffsetDateTime, ZonedDateTime are supported)
-    testIngestion(
-        "TIMESTAMP_LTZ",
-        LocalDate.parse("2007-12-03"),
-        "2007-12-03 00:00:00.000000000 -0800",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_LTZ",
-        LocalDateTime.parse("2007-12-03T10:15:30"),
-        "2007-12-03 10:15:30.000000000 -0800",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_LTZ",
-        OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
-        "2007-12-03 01:15:30.000000000 -0800",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_LTZ",
-        ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]"),
-        "2007-12-03 01:15:30.000000000 -0800",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_LTZ",
-        ZonedDateTime.parse("2007-12-03T10:15:30.123456789+01:00[Europe/Paris]"),
-        "2007-12-03 01:15:30.123456789 -0800",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_LTZ",
-        ZonedDateTime.parse("2007-07-03T10:15:30.123456789+02:00[Europe/Paris]"),
-        "2007-07-03 01:15:30.123456789 -0700",
-        new StringProvider());
-
-    // TIMESTAMP_TZ (LocalDate, LocalDateTime, OffsetDateTime, ZonedDateTime are supported)
-    testIngestion(
-        "TIMESTAMP_TZ",
-        LocalDate.parse("2007-12-03"),
-        "2007-12-03 00:00:00.000000000 -0800",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_TZ",
-        LocalDateTime.parse("2007-12-03T10:15:30"),
-        "2007-12-03 10:15:30.000000000 -0800",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_TZ",
-        OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
-        "2007-12-03 10:15:30.000000000 +0100",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_TZ",
-        ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]"),
-        "2007-12-03 10:15:30.000000000 +0100",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_TZ",
-        ZonedDateTime.parse("2007-12-03T10:15:30.123456789+01:00[Europe/Paris]"),
-        "2007-12-03 10:15:30.123456789 +0100",
-        new StringProvider());
-    testIngestion(
-        "TIMESTAMP_TZ",
-        ZonedDateTime.parse("2007-07-03T10:15:30.123456789+02:00[Europe/Paris]"),
-        "2007-07-03 10:15:30.123456789 +0200",
-        new StringProvider());
-  }
-
-  @Test
-  public void testTime() throws Exception {
-    // All (7) documented time formats are supported
-    // https://docs.snowflake.com/en/user-guide/date-time-input-output.html#time-formats
-
-    testJdbcTypeCompatibility(
-        "TIME",
-        "20:57:01.123456789+07:00",
-        "20:57:01.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME",
-        "20:57:01.123456789",
-        "20:57:01.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME", "20:57:01", "20:57:01.000000000 Z", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME", "20:57", "20:57:00.000000000 Z", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME",
-        "07:57:01.123456789 AM",
-        "07:57:01.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME", "04:01:07 AM", "04:01:07.000000000 Z", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME", "04:01 PM", "16:01:00.000000000 Z", new StringProvider(), new StringProvider());
-
-    // Test numeric strings
-    testJdbcTypeCompatibility(
-        "TIME", "0", "00:00:00.000000000 Z", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME", "86399", "23:59:59.000000000 Z", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME", "86401", "00:00:01.000000000 Z", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME", "-86401", "23:59:59.000000000 Z", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME", "-86399", "00:00:01.000000000 Z", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME", "1662731080", "13:44:40.000000000 Z", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME",
-        "1662731080123456789",
-        "13:44:40.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-  }
-
-  @Test
-  public void testLimitedScale() throws Exception {
-    // Of TIME
-    testJdbcTypeCompatibility(
-        "TIME(0)", "13:00:00.999", "13:00:00. Z", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME(0)", "13:00:00.999999999", "13:00:00. Z", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME(0)",
-        "13:00:00.999999999+07:30",
-        "13:00:00. Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME(0)",
-        "1662731080123456789",
-        "13:44:40. Z",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIME(4)", "13:00:00.999", "13:00:00.9990 Z", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME(4)",
-        "13:00:00.999999999",
-        "13:00:00.9999 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME(4)",
-        "13:00:00.999999999+07:30",
-        "13:00:00.9999 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME(4)",
-        "1662731080123456789",
-        "13:44:40.1234 Z",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIME(9)",
-        "13:00:00.999",
-        "13:00:00.999000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME(9)",
-        "13:00:00.999999999",
-        "13:00:00.999999999 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME(9)",
-        "13:00:00.999999999+07:30",
-        "13:00:00.999999999 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME(9)",
-        "1662731080123456789",
-        "13:44:40.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIME(9)",
-        "1662731080123456",
-        "13:44:40.123456000 Z",
-        new StringProvider(),
-        new StringProvider());
-
-    // Of TIMESTAMP_NTZ
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(0)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00. Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(0)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00. Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(0)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-07 13:00:00. Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(0)",
-        "1662731080123456789",
-        "2022-09-09 13:44:40. Z",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(4)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00.9990 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(4)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00.9999 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(4)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-07 13:00:00.9999 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(4)",
-        "1662731080123456789",
-        "2022-09-09 13:44:40.1234 Z",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(7)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00.9990000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(7)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00.9999999 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(7)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-07 13:00:00.9999999 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(7)",
-        "1662731080123456789",
-        "2022-09-09 13:44:40.1234567 Z",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(8)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00.99900000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(8)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00.99999999 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(8)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-07 13:00:00.99999999 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(8)",
-        "1662731080123456789",
-        "2022-09-09 13:44:40.12345678 Z",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(9)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00.999000000 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(9)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00.999999999 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(9)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-07 13:00:00.999999999 Z",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_NTZ(9)",
-        "1662731080123456789",
-        "2022-09-09 13:44:40.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
-
-    // Of TIMESTAMP_LTZ
-    useLosAngelesTimeZone();
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(0)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00. -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(0)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00. -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(0)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-06 22:30:00. -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(0)",
-        "1662731080123456789",
-        "2022-09-09 06:44:40. -0700",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(4)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00.9990 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(4)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00.9999 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(4)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-06 22:30:00.9999 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(4)",
-        "1662731080123456789",
-        "2022-09-09 06:44:40.1234 -0700",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(7)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00.9990000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(7)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00.9999999 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(7)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-06 22:30:00.9999999 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(7)",
-        "1662731080123456789",
-        "2022-09-09 06:44:40.1234567 -0700",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(8)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00.99900000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(8)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00.99999999 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(8)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-06 22:30:00.99999999 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(8)",
-        "1662731080123456789",
-        "2022-09-09 06:44:40.12345678 -0700",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(9)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00.999000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(9)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00.999999999 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(9)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-06 22:30:00.999999999 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_LTZ(9)",
-        "1662731080123456789",
-        "2022-09-09 06:44:40.123456789 -0700",
-        new StringProvider(),
-        new StringProvider());
-
-    // Of TIMESTAMP_TZ
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(0)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00. -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(0)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00. -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(0)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-07 13:00:00. +0730",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(0)",
-        "1662731080123456789",
-        "2022-09-09 13:44:40. Z",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(4)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00.9990 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(4)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00.9999 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(4)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-07 13:00:00.9999 +0730",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(4)",
-        "1662731080123456789",
-        "2022-09-09 13:44:40.1234 Z",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(7)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00.9990000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(7)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00.9999999 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(7)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-07 13:00:00.9999999 +0730",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(7)",
-        "1662731080123456789",
-        "2022-09-09 13:44:40.1234567 Z",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(8)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00.99900000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(8)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00.99999999 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(8)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-07 13:00:00.99999999 +0730",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(8)",
-        "1662731080123456789",
-        "2022-09-09 13:44:40.12345678 Z",
-        new StringProvider(),
-        new StringProvider());
-
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(9)",
-        "2010-07-07 13:00:00.999",
-        "2010-07-07 13:00:00.999000000 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(9)",
-        "2010-07-07 13:00:00.999999999",
-        "2010-07-07 13:00:00.999999999 -0700",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(9)",
-        "2010-07-07 13:00:00.999999999+07:30",
-        "2010-07-07 13:00:00.999999999 +0730",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "TIMESTAMP_TZ(9)",
-        "1662731080123456789",
-        "2022-09-09 13:44:40.123456789 Z",
-        new StringProvider(),
-        new StringProvider());
+    // Limited scale
+    testIngestion("TIME(0)", "13:00:00", "13:00:00. Z", new StringProvider());
+    testIngestion("TIME(0)", "13:00:00.123456", "13:00:00. Z", new StringProvider());
+    testIngestion("TIME(1)", "13:00:00", "13:00:00.0 Z", new StringProvider());
+    testIngestion("TIME(1)", "13:00:00.123456", "13:00:00.1 Z", new StringProvider());
+    testIngestion("TIME(2)", "13:00:00.1", "13:00:00.10 Z", new StringProvider());
+    testIngestion("TIME(2)", "13:00:00.123456", "13:00:00.12 Z", new StringProvider());
+    testIngestion("TIME(8)", "13:00:00.1", "13:00:00.10000000 Z", new StringProvider());
+    testIngestion("TIME(8)", "13:00:00.123456789", "13:00:00.12345678 Z", new StringProvider());
+    testIngestion("TIME(8)", "13:00:00.000000009", "13:00:00.00000000 Z", new StringProvider());
+    testIngestion("TIME(8)", "13:00:00.000000019", "13:00:00.00000001 Z", new StringProvider());
   }
 
   @Test
   public void testDate() throws Exception {
     // Test timestamp formats
-    testJdbcTypeCompatibility(
-        "DATE", "2/18/2008 02:36:48", "2008-02-18", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE", "2013-04-28 20", "2013-04-28", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE", "2013-04-28 20:57", "2013-04-28", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE", "2013-04-28 20:57:01", "2013-04-28", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "2013-04-28 20:57:01 +07:00",
-        "2013-04-28",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "2013-04-28 20:57:01 +0700",
-        "2013-04-28",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE", "2013-04-28 20:57:01-07", "2013-04-28", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "2013-04-28 20:57:01-07:00",
-        "2013-04-28",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "2013-04-28 20:57:01.123456",
-        "2013-04-28",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "2013-04-28 20:57:01.123456789 +07:00",
-        "2013-04-28",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "2013-04-28 20:57:01.123456789 +0700",
-        "2013-04-28",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "2013-04-28 20:57:01.123456789+07",
-        "2013-04-28",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "2013-04-28 20:57:01.123456789+07:00",
-        "2013-04-28",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE", "2013-04-28 20:57+07:00", "2013-04-28", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE", "2013-04-28T20", "2013-04-28", new StringProvider(), new StringProvider());
     testJdbcTypeCompatibility(
         "DATE", "2013-04-28T20:57", "2013-04-28", new StringProvider(), new StringProvider());
     testJdbcTypeCompatibility(
@@ -1585,68 +866,44 @@ public class DateTimeIT extends AbstractDataTypeTest {
         new StringProvider());
     testJdbcTypeCompatibility(
         "DATE", "2013-04-28T20:57+07:00", "2013-04-28", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "Mon Jul 08 18:09:51 +0000 2013",
-        "2013-07-08",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "Thu, 21 Dec 2000 04:01:07 PM",
-        "2000-12-21",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "Thu, 21 Dec 2000 04:01:07 PM +0200",
-        "2000-12-21",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "Thu, 21 Dec 2000 04:01:07.123456789 PM",
-        "2000-12-21",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "Thu, 21 Dec 2000 04:01:07.123456789 PM +0200",
-        "2000-12-21",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "Thu, 21 Dec 2000 16:01:07",
-        "2000-12-21",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "Thu, 21 Dec 2000 16:01:07 +0200",
-        "2000-12-21",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "Thu, 21 Dec 2000 16:01:07.123456789",
-        "2000-12-21",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "Thu, 21 Dec 2000 16:01:07.123456789 +0200",
-        "2000-12-21",
-        new StringProvider(),
-        new StringProvider());
 
     // Test date formats
     testJdbcTypeCompatibility(
         "DATE", "2013-04-28", "2013-04-28", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE", "17-DEC-1980", "1980-12-17", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE", "12/17/1980", "1980-12-17", new StringProvider(), new StringProvider());
+
+    // Test LocalDate
+    testIngestion("DATE", LocalDate.parse("2007-12-03"), "2007-12-03", new StringProvider());
+    // Test LocalDateTime
+    testIngestion(
+        "DATE", LocalDateTime.parse("2007-12-03T10:15:30.123"), "2007-12-03", new StringProvider());
+    // Test OffsetDateTime
+    testIngestion(
+        "DATE",
+        OffsetDateTime.parse("2007-12-03T02:15:30.123+09:00"),
+        "2007-12-03",
+        new StringProvider());
+    testIngestion(
+        "DATE",
+        OffsetDateTime.parse("2007-12-03T02:15:30.123-08:00"),
+        "2007-12-03",
+        new StringProvider());
+    // Test ZonedDateTime
+    testIngestion(
+        "DATE",
+        ZonedDateTime.parse("2007-12-03T02:15:30.123+09:00[Asia/Tokyo]"),
+        "2007-12-03",
+        new StringProvider());
+    testIngestion(
+        "DATE",
+        ZonedDateTime.parse("2007-12-03T02:15:30.123-08:00[America/Los_Angeles]"),
+        "2007-12-03",
+        new StringProvider());
+    // Test Instant
+    testIngestion(
+        "DATE",
+        ZonedDateTime.parse("2007-12-03T02:15:30.123-08:00[America/Los_Angeles]").toInstant(),
+        "2007-12-03",
+        new StringProvider());
 
     // Test leap years
     testJdbcTypeCompatibility(
@@ -1655,102 +912,111 @@ public class DateTimeIT extends AbstractDataTypeTest {
         "2024-02-29",
         new StringProvider(),
         new StringProvider());
-    expectArrowNotSupported("DATE", "2023-02-29T23:59:59.999999999Z");
-
-    testJdbcTypeCompatibility(
-        "DATE", "9999-12-31", "9999-12-31", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "9999-12-31T23:59:59.999999999Z",
-        "9999-12-31",
-        new StringProvider(),
-        new StringProvider());
-
-    // Test boundary date
-    testJdbcTypeCompatibility(
-        "DATE",
-        "2013-04-28T00:00:00+07:00",
-        "2013-04-28",
-        new StringProvider(),
-        new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE",
-        "2013-04-28T00:00:00-07:00",
-        "2013-04-28",
-        new StringProvider(),
-        new StringProvider());
+    expectArrowNotSupported("DATE", "2023-02-29T23:59:59.999999999");
 
     // Test numeric strings
     testJdbcTypeCompatibility(
         "DATE", "0", "1970-01-01", new StringProvider(), new StringProvider());
     testJdbcTypeCompatibility(
-        "DATE", "86399", "1970-01-01", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE", "86401", "1970-01-02", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE", "-86401", "1969-12-30", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
-        "DATE", "-86399", "1969-12-31", new StringProvider(), new StringProvider());
-    testJdbcTypeCompatibility(
         "DATE", "1662731080", "2022-09-09", new StringProvider(), new StringProvider());
     testJdbcTypeCompatibility(
+        "DATE", "1662731080123", "2022-09-09", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "1662731080123456", "2022-09-09", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
         "DATE", "1662731080123456789", "2022-09-09", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "-1674478926", "1916-12-09", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "-1674478926123", "1916-12-09", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "-1674478926123456", "1916-12-09", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "-1674478926123456789", "1916-12-09", new StringProvider(), new StringProvider());
   }
 
   @Test
-  @Ignore("SNOW-663646")
-  public void testOldValues() throws Exception {
+  public void testOldTimestamps() throws Exception {
+    testIngestion("DATE", "0001-12-31", "0001-12-31", new StringProvider());
+    testIngestion(
+        "TIMESTAMP_NTZ",
+        "0001-12-31T11:11:11",
+        "0001-12-31 11:11:11.000000000 Z",
+        new StringProvider());
+    // TODO uncomment once SNOW-727474 is resolved
+    //        testIngestion("TIMESTAMP_LTZ", "0001-12-31T11:11:11", "0001-12-31 03:11:11.000000000
+    // -0800", new StringProvider());
+    testIngestion(
+        "TIMESTAMP_TZ",
+        "0001-12-31T11:11:11+03:00",
+        "0001-12-31 11:11:11.000000000 +0300",
+        new StringProvider());
+  }
+
+  @Test
+  public void testJulianGregorianGap() throws Exception {
+    // During switch from Julian to Gregorian calendars, there is a 10-day gap. The next day after
+    // 1582-10-04 was 1582-10-15.
+    // Snowflake doesn't have any special handling of this, these dates can be normally inserted.
     testJdbcTypeCompatibility(
-        "DATE", "1582-01-01", "1582-10-01", new StringProvider(), new StringProvider());
+        "DATE", "1582-10-04", "1582-10-04", new StringProvider(), new StringProvider());
     testJdbcTypeCompatibility(
-        "DATE", "1582-10-14", "1582-10-14", new StringProvider(), new StringProvider());
+        "DATE", "1582-10-08", "1582-10-08", new StringProvider(), new StringProvider());
+    testJdbcTypeCompatibility(
+        "DATE", "1582-10-15", "1582-10-15", new StringProvider(), new StringProvider());
   }
 
   @Test
   public void testFutureDates() throws Exception {
-    useLosAngelesTimeZone();
-
+    setJdbcSessionTimezone(TZ_LOS_ANGELES);
+    setChannelDefaultTimezone(TZ_LOS_ANGELES);
     testJdbcTypeCompatibility(
-        "DATE", "99999-12-31", "99999-12-31", new StringProvider(), new StringProvider());
+        "DATE", "9999-12-31", "9999-12-31", new StringProvider(), new StringProvider());
 
-    testJdbcTypeCompatibility( // SB16
+    // SB16
+    testJdbcTypeCompatibility(
         "TIMESTAMP_NTZ",
-        "9999-12-31 23:59:59.999999999",
+        "9999-12-31T23:59:59.999999999",
         "9999-12-31 23:59:59.999999999 Z",
         new StringProvider(),
         new StringProvider());
 
-    testJdbcTypeCompatibility( // SB8
+    // SB8
+    testJdbcTypeCompatibility(
         "TIMESTAMP_NTZ(7)",
-        "9999-12-31 23:59:59.999999999",
+        "9999-12-31T23:59:59.999999999",
         "9999-12-31 23:59:59.9999999 Z",
         new StringProvider(),
         new StringProvider());
 
-    testJdbcTypeCompatibility( // SB16
+    // SB16
+    testJdbcTypeCompatibility(
         "TIMESTAMP_LTZ",
-        "9999-12-31 23:59:59.999999999",
+        "9999-12-31T23:59:59.999999999",
         "9999-12-31 23:59:59.999999999 -0800",
         new StringProvider(),
         new StringProvider());
 
-    testJdbcTypeCompatibility( // SB8
+    // SB8
+    testJdbcTypeCompatibility(
         "TIMESTAMP_LTZ(7)",
-        "9999-12-31 23:59:59.999999999",
+        "9999-12-31T23:59:59.999999999",
         "9999-12-31 23:59:59.9999999 -0800",
         new StringProvider(),
         new StringProvider());
 
+    // SB16
     testJdbcTypeCompatibility(
         "TIMESTAMP_TZ",
-        "9999-12-31 23:59:59.999999999",
+        "9999-12-31T23:59:59.999999999",
         "9999-12-31 23:59:59.999999999 -0800",
         new StringProvider(),
         new StringProvider());
 
+    // SB8
     testJdbcTypeCompatibility(
         "TIMESTAMP_TZ(3)",
-        "9999-12-31 23:59:59.999999999",
+        "9999-12-31T23:59:59.999999999",
         "9999-12-31 23:59:59.999 -0800",
         new StringProvider(),
         new StringProvider());
@@ -1760,7 +1026,7 @@ public class DateTimeIT extends AbstractDataTypeTest {
    * To make assertions of timestamps without timezone to work, make sure JDBC connection session
    * time zone is the same as the streaming ingest default timezone
    */
-  private void useLosAngelesTimeZone() throws SQLException {
-    conn.createStatement().execute("alter session set timezone = 'America/Los_Angeles';");
+  private void setJdbcSessionTimezone(ZoneId timezone) throws SQLException {
+    conn.createStatement().execute(String.format("alter session set timezone = '%s';", timezone));
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
@@ -11,6 +11,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import net.snowflake.ingest.utils.Constants;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class DateTimeIT extends AbstractDataTypeTest {
@@ -23,9 +24,23 @@ public class DateTimeIT extends AbstractDataTypeTest {
     super(name, bdecVersion);
   }
 
+  @Before
+  public void setup() throws Exception {
+    // Set to a random time zone not to interfere with any of the tests
+    conn.createStatement().execute("alter session set timezone = 'America/New_York';");
+  }
+
   @After
   public void tearDown() throws Exception {
     conn.createStatement().execute("alter session unset timezone;");
+  }
+
+  @Test
+  public void testDefaultTimezone() throws Exception {
+    testIngestion(
+        "TIMESTAMP_TZ", "2000-01-01", "2000-01-01 00:00:00.000000000 -0800", new StringProvider());
+    testIngestion(
+        "TIMESTAMP_LTZ", "2000-01-01", "2000-01-01 03:00:00.000000000 -0500", new StringProvider());
   }
 
   @Test


### PR DESCRIPTION
`SnowflakeDateTimeFormat` has some issues. This PR implements the following changes to our date/time processing:

* We no longer depend on `SnowflakeDateTimeFormat`, custom validation and serialization of date/time values has been implemented. 
    * `java.time.OffsetDateTime` is the canonical representation of timestamps in the SDK. 
    * The following date/time values are going to be accepted: 
        * Types from `java.time` package (`LocalDate`, `LocalDateTime`, `OffsetDateTime`, `ZonedDateTime`, `Instant`, `LocalTime`, `OffsetTime`) 
        * Strings in ISO-8601 format such as _2011-12-03T10:15:30+01:00_. We attempt to parse one of the above-mentioned types using the `java.time.format.DateTimeFormatter`. 
        * Integer-stored strings
* Input values for `TIMESTAMP_TZ` and `TIMESTAMP_LTZ`, which do not carry timezone information, are by default interpreted in the timezone `America/Los_Angeles`. This can now be changed by calling `OpenChannelRequestBuilder#setDefaultTimezone`. 
    * Just like in Snowflake, integer-stored strings, as well as `java.time.Instant` in our case, are always interpreted in UTC.
* Detailed Javadoc for `insertRow()` has been added. It describes accepted values for all Snowflake types, so that users don't have to search the documentation.
* Comprehensive suite of integration tests has been added.

This PR fixes SNOW-663646, as well.