### PR TITLE
SNOW-715618: Improve build latency for high throughput case with many channels

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -274,7 +274,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
   @Override
   public InsertValidationResponse insertRows(
       Iterable<Map<String, Object>> rows, String offsetToken) {
-    float rowSize = 0F;
+    float rowsSize = 0F;
     if (!hasColumns()) {
       throw new SFException(ErrorCode.INTERNAL_ERROR, "Empty column fields");
     }
@@ -290,9 +290,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
               new InsertValidationResponse.InsertError(row, rowIndex);
           try {
             Set<String> inputColumnNames = verifyInputColumns(row, error);
-            rowSize += addRow(row, this.rowCount, this.statsMap, inputColumnNames);
+            rowsSize += addRow(row, this.rowCount, this.statsMap, inputColumnNames);
             this.rowCount++;
-            this.bufferSize += rowSize;
           } catch (SFException e) {
             error.setException(e);
             response.addError(error);
@@ -308,22 +307,21 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
         }
       } else {
         // If the on_error option is ABORT, simply throw the first exception
-        float tempRowSize = 0F;
+        float tempRowsSize = 0F;
         int tempRowCount = 0;
         for (Map<String, Object> row : rows) {
           Set<String> inputColumnNames = verifyInputColumns(row, null);
-          tempRowSize += addTempRow(row, tempRowCount, this.tempStatsMap, inputColumnNames);
+          tempRowsSize += addTempRow(row, tempRowCount, this.tempStatsMap, inputColumnNames);
           tempRowCount++;
         }
 
         moveTempRowsToActualBuffer(tempRowCount);
 
-        rowSize = tempRowSize;
+        rowsSize = tempRowsSize;
         if ((long) this.rowCount + tempRowCount >= Integer.MAX_VALUE) {
           throw new SFException(ErrorCode.INTERNAL_ERROR, "Row count reaches MAX value");
         }
         this.rowCount += tempRowCount;
-        this.bufferSize += rowSize;
         this.statsMap.forEach(
             (colName, stats) ->
                 this.statsMap.put(
@@ -331,8 +329,9 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
                     RowBufferStats.getCombinedStats(stats, this.tempStatsMap.get(colName))));
       }
 
+      this.bufferSize += rowsSize;
       this.channelState.setOffsetToken(offsetToken);
-      this.rowSizeMetric.accept(rowSize);
+      this.rowSizeMetric.accept(rowsSize);
     } finally {
       this.tempStatsMap.values().forEach(RowBufferStats::reset);
       clearTempRows();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -19,6 +19,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -33,6 +34,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
@@ -339,25 +341,28 @@ class FlushService<T> {
 
     while (itr.hasNext()) {
       List<List<ChannelData<T>>> blobData = new ArrayList<>();
-      float totalBufferSize = 0;
+      AtomicReference<Float> totalBufferSize = new AtomicReference<>((float) 0);
 
       final String filePath = getFilePath(this.targetStage.getClientPrefix());
 
       // Distribute work at table level, create a new blob if reaching the blob size limit
-      while (itr.hasNext() && totalBufferSize <= MAX_BLOB_SIZE_IN_BYTES) {
+      while (itr.hasNext() && totalBufferSize.get() <= MAX_BLOB_SIZE_IN_BYTES) {
         ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<T>> table =
             itr.next().getValue();
-        List<ChannelData<T>> channelsDataPerTable = new ArrayList<>();
-        // TODO: we could do parallel stream to get the channelData if needed
-        for (SnowflakeStreamingIngestChannelInternal<T> channel : table.values()) {
-          if (channel.isValid()) {
-            ChannelData<T> data = channel.getData(filePath);
-            if (data != null) {
-              channelsDataPerTable.add(data);
-              totalBufferSize += data.getBufferSize();
-            }
-          }
-        }
+        List<ChannelData<T>> channelsDataPerTable = Collections.synchronizedList(new ArrayList<>());
+        // Use parallel stream since getData could be the performance bottleneck when the number of
+        // channels are big
+        table.values().parallelStream()
+            .forEach(
+                channel -> {
+                  if (channel.isValid()) {
+                    ChannelData<T> data = channel.getData(filePath);
+                    if (data != null) {
+                      channelsDataPerTable.add(data);
+                      totalBufferSize.updateAndGet(v -> v + data.getBufferSize());
+                    }
+                  }
+                });
         if (!channelsDataPerTable.isEmpty()) {
           blobData.add(channelsDataPerTable);
         }

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -34,8 +34,8 @@ public class Constants {
       7L; // Don't change, should match server side
   public static final int BLOB_UPLOAD_TIMEOUT_IN_SEC = 5;
   public static final int INSERT_THROTTLE_MAX_RETRY_COUNT = 60;
-  public static final long MAX_BLOB_SIZE_IN_BYTES = 512000000L;
-  public static final long MAX_CHUNK_SIZE_IN_BYTES = 32000000L;
+  public static final long MAX_BLOB_SIZE_IN_BYTES = 256000000L;
+  public static final long MAX_CHUNK_SIZE_IN_BYTES = 16000000L;
   public static final int BLOB_TAG_SIZE_IN_BYTES = 4;
   public static final int BLOB_VERSION_SIZE_IN_BYTES = 1;
   public static final int BLOB_FILE_SIZE_SIZE_IN_BYTES = 8;


### PR DESCRIPTION
We're seeing some issue where the build time is high during high throughput case (20 million+ rows) with 10+ parallel channels going into the same table, and the root cause is that the buffer takes longer to transfer ownership and the next buffer already builds up with enough rows, so the file size becomes very big which is causing the compression time to be very high. In longer term, instead of checking the channel size, I think checking the allocator size per table would help this case. CC: @sfc-gh-azagrebin @sfc-gh-gdoci 

In this PR, it contains a few changes to improve the build time:
- Fix a wrong buffer size logic which causes the flush to be scheduled unexpectedly
- Use parallel stream to get the buffer data
- Reduce the channel size limit to schedule the flush faster