### PR TITLE
SNOW-733699 make Parquet the default blob format version instead of Arrow

### DIFF
--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -30,7 +30,8 @@ public class ParameterProvider {
   public static final long INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT = 1000;
   public static final int INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_DEFAULT = 10;
   public static final boolean SNOWPIPE_STREAMING_METRICS_DEFAULT = false;
-  public static final Constants.BdecVersion BLOB_FORMAT_VERSION_DEFAULT = Constants.BdecVersion.ONE;
+  public static final Constants.BdecVersion BLOB_FORMAT_VERSION_DEFAULT =
+      Constants.BdecVersion.THREE;
   public static final int IO_TIME_CPU_RATIO_DEFAULT = 2;
   public static final int BLOB_UPLOAD_MAX_RETRY_COUNT_DEFAULT = 24;
   public static final long MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT = -1L;

--- a/src/test/java/net/snowflake/ingest/TestUtils.java
+++ b/src/test/java/net/snowflake/ingest/TestUtils.java
@@ -150,15 +150,6 @@ public class TestUtils {
 
   /** @return list of Bdec versions for which to execute IT tests. */
   public static Collection<Object[]> getBdecVersionItCases() {
-    boolean enableParquetTests =
-        System.getProperty("enableParquetTests") != null
-            && Boolean.parseBoolean(System.getProperty("enableParquetTests"));
-    if (enableParquetTests) {
-      return Arrays.asList(
-          new Object[][] {
-            {"Arrow", Constants.BdecVersion.ONE}, {"Parquet", Constants.BdecVersion.THREE}
-          });
-    }
     return Arrays.asList(
         new Object[][] {
           {"Arrow", Constants.BdecVersion.ONE}, {"Parquet", Constants.BdecVersion.THREE}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -36,7 +36,6 @@ import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;
-import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -463,9 +462,9 @@ public class SnowflakeStreamingIngestChannelTest {
 
   @Test
   public void testInsertRow() {
-    SnowflakeStreamingIngestClientInternal<VectorSchemaRoot> client =
+    SnowflakeStreamingIngestClientInternal<ParquetChunkData> client =
         new SnowflakeStreamingIngestClientInternal<>("client");
-    SnowflakeStreamingIngestChannelInternal<VectorSchemaRoot> channel =
+    SnowflakeStreamingIngestChannelInternal<ParquetChunkData> channel =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel",
             "db",
@@ -494,7 +493,7 @@ public class SnowflakeStreamingIngestChannelTest {
     row.put("col", 1);
 
     // Get data before insert to verify that there is no row (data should be null)
-    ChannelData<VectorSchemaRoot> data = channel.getData("my_snowpipe_streaming.bdec");
+    ChannelData<ParquetChunkData> data = channel.getData("my_snowpipe_streaming.bdec");
     Assert.assertNull(data);
 
     long insertStartTimeInMs = System.currentTimeMillis();
@@ -508,7 +507,7 @@ public class SnowflakeStreamingIngestChannelTest {
     data = channel.getData("my_snowpipe_streaming.bdec");
     Assert.assertEquals(2, data.getRowCount());
     Assert.assertEquals((Long) 1L, data.getRowSequencer());
-    Assert.assertEquals(1, data.getVectors().getFieldVectors().size());
+    Assert.assertEquals(1, data.getVectors().rows.get(0).size()); // row has one column
     Assert.assertEquals("2", data.getOffsetToken());
     Assert.assertTrue(data.getBufferSize() > 0);
     Assert.assertTrue(insertStartTimeInMs <= data.getMinMaxInsertTimeInMs().getFirst());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -36,6 +36,7 @@ import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -462,9 +463,16 @@ public class SnowflakeStreamingIngestChannelTest {
 
   @Test
   public void testInsertRow() {
-    SnowflakeStreamingIngestClientInternal<ParquetChunkData> client =
-        new SnowflakeStreamingIngestClientInternal<>("client");
-    SnowflakeStreamingIngestChannelInternal<ParquetChunkData> channel =
+    SnowflakeStreamingIngestClientInternal<?> client;
+    boolean isArrowDefault =
+        ParameterProvider.BLOB_FORMAT_VERSION_DEFAULT == Constants.BdecVersion.ONE;
+    if (isArrowDefault) {
+      client = new SnowflakeStreamingIngestClientInternal<VectorSchemaRoot>("client_ARROW");
+    } else {
+      client = new SnowflakeStreamingIngestClientInternal<ParquetChunkData>("client_PARQUET");
+    }
+
+    SnowflakeStreamingIngestChannelInternal<?> channel =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel",
             "db",
@@ -493,7 +501,7 @@ public class SnowflakeStreamingIngestChannelTest {
     row.put("col", 1);
 
     // Get data before insert to verify that there is no row (data should be null)
-    ChannelData<ParquetChunkData> data = channel.getData("my_snowpipe_streaming.bdec");
+    ChannelData<?> data = channel.getData("my_snowpipe_streaming.bdec");
     Assert.assertNull(data);
 
     long insertStartTimeInMs = System.currentTimeMillis();
@@ -507,7 +515,11 @@ public class SnowflakeStreamingIngestChannelTest {
     data = channel.getData("my_snowpipe_streaming.bdec");
     Assert.assertEquals(2, data.getRowCount());
     Assert.assertEquals((Long) 1L, data.getRowSequencer());
-    Assert.assertEquals(1, data.getVectors().rows.get(0).size()); // row has one column
+    Assert.assertEquals(
+        1,
+        isArrowDefault
+            ? ((ChannelData<VectorSchemaRoot>) data).getVectors().getFieldVectors().size()
+            : ((ChannelData<ParquetChunkData>) data).getVectors().rows.get(0).size());
     Assert.assertEquals("2", data.getOffsetToken());
     Assert.assertTrue(data.getBufferSize() > 0);
     Assert.assertTrue(insertStartTimeInMs <= data.getMinMaxInsertTimeInMs().getFirst());


### PR DESCRIPTION
This PR switches the default blob format version from Arrow to Parquet.