### PR TITLE
[SNOW-726993] Ingest SDK Does Not Honor http.nonProxyHosts JVM Argument

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.15</version>
+            <version>3.13.18</version>
         </dependency>
 
         <!-- String collation-->

--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -407,7 +407,7 @@ public class SimpleIngestManager implements AutoCloseable {
     this.keyPair = keyPair;
 
     // make our client for sending requests
-    httpClient = HttpUtil.getHttpClient();
+    httpClient = HttpUtil.getHttpClient(account);
     // make the request builder we'll use to build messages to the service
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -101,6 +101,9 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
   // Name of the client
   private final String name;
 
+  // Account name
+  private String account;
+
   // Snowflake role for the client to use
   private String role;
 
@@ -165,8 +168,9 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
     this.parameterProvider = new ParameterProvider(parameterOverrides, prop);
 
     this.name = name;
+    this.account = accountURL.getAccount();
     this.isTestMode = isTestMode;
-    this.httpClient = httpClient == null ? HttpUtil.getHttpClient() : httpClient;
+    this.httpClient = httpClient == null ? HttpUtil.getHttpClient(account) : httpClient;
     this.channelCache = new ChannelCache<>();
     this.allocator = new RootAllocator();
     this.isClosed = false;

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -150,7 +150,7 @@ public class HttpUtil {
 
     // proxy settings
     if ("true".equalsIgnoreCase(System.getProperty(USE_PROXY))) {
-      if(!bypassProxy(account)) {
+      if("true".equalsIgnoreCase(System.getProperty(USE_PROXY)) && !bypassProxy(account)) {
         if (System.getProperty(PROXY_PORT) == null) {
           throw new IllegalArgumentException(
                   "proxy port number is not provided, please assign proxy port to http.proxyPort option");

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
@@ -6,6 +6,7 @@ import static net.snowflake.ingest.utils.HttpUtil.HTTP_PROXY_USER;
 import static net.snowflake.ingest.utils.HttpUtil.PROXY_HOST;
 import static net.snowflake.ingest.utils.HttpUtil.PROXY_PORT;
 import static net.snowflake.ingest.utils.HttpUtil.USE_PROXY;
+import static net.snowflake.ingest.utils.HttpUtil.NON_PROXY_HOSTS;
 import static net.snowflake.ingest.utils.HttpUtil.generateProxyPropertiesForJDBC;
 import static org.mockito.Mockito.times;
 
@@ -391,11 +392,13 @@ public class StreamingIngestStageTest {
     String oldProxyPort = System.getProperty(PROXY_PORT);
     String oldUser = System.getProperty(HTTP_PROXY_USER);
     String oldPassword = System.getProperty(HTTP_PROXY_PASSWORD);
+    String oldNonProxyHosts = System.getProperty(NON_PROXY_HOSTS);
 
     String proxyHost = "localhost";
     String proxyPort = "8080";
     String user = "admin";
     String password = "test";
+    String nonProxyHosts = "*.snowflakecomputing.com";
 
     try {
       // Test empty properties when USE_PROXY is NOT set;
@@ -407,6 +410,7 @@ public class StreamingIngestStageTest {
       System.setProperty(PROXY_PORT, proxyPort);
       System.setProperty(HTTP_PROXY_USER, user);
       System.setProperty(HTTP_PROXY_PASSWORD, password);
+      System.setProperty(NON_PROXY_HOSTS, nonProxyHosts);
 
       // Verify that properties are set
       props = generateProxyPropertiesForJDBC();
@@ -415,6 +419,7 @@ public class StreamingIngestStageTest {
       Assert.assertEquals(proxyPort, props.get(SFSessionProperty.PROXY_PORT.getPropertyKey()));
       Assert.assertEquals(user, props.get(SFSessionProperty.PROXY_USER.getPropertyKey()));
       Assert.assertEquals(password, props.get(SFSessionProperty.PROXY_PASSWORD.getPropertyKey()));
+      Assert.assertEquals(nonProxyHosts, props.get(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey()));
     } finally {
       // Cleanup
       if (oldUseProxy != null) {
@@ -425,6 +430,9 @@ public class StreamingIngestStageTest {
       if (oldUser != null) {
         System.setProperty(HTTP_PROXY_USER, oldUser);
         System.setProperty(HTTP_PROXY_PASSWORD, oldPassword);
+      }
+      if (oldNonProxyHosts != null) {
+        System.setProperty(NON_PROXY_HOSTS, oldNonProxyHosts);
       }
     }
   }


### PR DESCRIPTION
The JDBC driver was upgraded to 3.13.18 and the HttpUtil code was changed to take into account that a user may need to bypass the proxy by providing the -Dhttp.nonProxyHosts JVM argument