### PR TITLE
[SNOW-726993] Ingest SDK Does Not Honor http.nonProxyHosts JVM Argument

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.15</version>
+            <version>3.13.18</version>
         </dependency>
 
         <!-- jwt token for key pair authentication with GS -->

--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -407,7 +407,7 @@ public class SimpleIngestManager implements AutoCloseable {
     this.keyPair = keyPair;
 
     // make our client for sending requests
-    httpClient = HttpUtil.getHttpClient();
+    httpClient = HttpUtil.getHttpClient(account);
     // make the request builder we'll use to build messages to the service
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -101,6 +101,8 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
   // Name of the client
   private final String name;
 
+  private String accountName;
+
   // Snowflake role for the client to use
   private String role;
 
@@ -165,8 +167,9 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
     this.parameterProvider = new ParameterProvider(parameterOverrides, prop);
 
     this.name = name;
+    this.accountName = accountURL.getAccount();
     this.isTestMode = isTestMode;
-    this.httpClient = httpClient == null ? HttpUtil.getHttpClient() : httpClient;
+    this.httpClient = httpClient == null ? HttpUtil.getHttpClient(accountName) : httpClient;
     this.channelCache = new ChannelCache<>();
     this.allocator = new RootAllocator();
     this.isClosed = false;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -167,7 +167,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
     this.parameterProvider = new ParameterProvider(parameterOverrides, prop);
 
     this.name = name;
-    this.accountName = accountURL.getAccount();
+    this.accountName = accountURL == null ? null : accountURL.getAccount();
     this.isTestMode = isTestMode;
     this.httpClient = httpClient == null ? HttpUtil.getHttpClient(accountName) : httpClient;
     this.channelCache = new ChannelCache<>();

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -414,19 +414,21 @@ public class HttpUtil {
     return title;
   }
 
-  // Changes the account name to the format accountName.snowflakecomputing.com
-  // then returns a boolean to indicate if we should go through a proxy or not.
+  /**
+   * Changes the account name to the format accountName.snowflakecomputing.com then returns a
+   * boolean to indicate if we should go through a proxy or not.
+   */
   public static Boolean shouldBypassProxy(String accountName) {
     String targetHost = accountName + SNOWFLAKE_DOMAIN_NAME;
     return System.getProperty(NON_PROXY_HOSTS) != null && isInNonProxyHosts(targetHost);
   }
 
-  /* The target hostname input is compared with the hosts in the '|' separated
-    list provided by the http.nonProxyHosts parameter using regex. The nonProxyHosts
-    will be used as our Patterns, so we need to replace the '.' and '*' characters
-    since those are special regex constructs that mean 'any character,' and
-    'repeat 0 or more times.'
-  */
+  /**
+   * The target hostname input is compared with the hosts in the '|' separated list provided by the
+   * http.nonProxyHosts parameter using regex. The nonProxyHosts will be used as our Patterns, so we
+   * need to replace the '.' and '*' characters since those are special regex constructs that mean
+   * 'any character,' and 'repeat 0 or more times.'
+   */
   private static Boolean isInNonProxyHosts(String targetHost) {
     String nonProxyHosts =
         System.getProperty(NON_PROXY_HOSTS).replace(".", "\\.").replace("*", ".*");

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
 import net.snowflake.client.core.SFSessionProperty;
 import net.snowflake.client.jdbc.internal.apache.http.HttpHost;
@@ -47,9 +48,10 @@ public class HttpUtil {
   public static final String USE_PROXY = "http.useProxy";
   public static final String PROXY_HOST = "http.proxyHost";
   public static final String PROXY_PORT = "http.proxyPort";
-
+  public static final String NON_PROXY_HOSTS = "http.nonProxyHosts";
   public static final String HTTP_PROXY_USER = "http.proxyUser";
   public static final String HTTP_PROXY_PASSWORD = "http.proxyPassword";
+  private static final String SNOWFLAKE_DOMAIN_NAME = ".snowflakecomputing.com";
 
   private static final String PROXY_SCHEME = "http";
   private static final String FIRST_FAULT_TIMESTAMP = "FIRST_FAULT_TIMESTAMP";
@@ -84,11 +86,15 @@ public class HttpUtil {
   // Only connections that are currently owned, not checked out, are subject to idle timeouts.
   private static final int DEFAULT_IDLE_CONNECTION_TIMEOUT_SECONDS = 30;
 
-  public static CloseableHttpClient getHttpClient() {
+  /**
+   * @param {@code String} account name to connect to (excluding snowflakecomputing.com domain)
+   * @return Instance of CloseableHttpClient
+   */
+  public static CloseableHttpClient getHttpClient(String accountName) {
     if (httpClient == null) {
       synchronized (HttpUtil.class) {
         if (httpClient == null) {
-          initHttpClient();
+          initHttpClient(accountName);
         }
       }
     }
@@ -100,7 +106,7 @@ public class HttpUtil {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpUtil.class);
 
-  private static void initHttpClient() {
+  private static void initHttpClient(String accountName) {
 
     Security.setProperty("ocsp.enable", "true");
 
@@ -146,7 +152,7 @@ public class HttpUtil {
             .setDefaultRequestConfig(requestConfig);
 
     // proxy settings
-    if ("true".equalsIgnoreCase(System.getProperty(USE_PROXY))) {
+    if ("true".equalsIgnoreCase(System.getProperty(USE_PROXY)) && !shouldBypassProxy(accountName)) {
       if (System.getProperty(PROXY_PORT) == null) {
         throw new IllegalArgumentException(
             "proxy port number is not provided, please assign proxy port to http.proxyPort option");
@@ -316,6 +322,12 @@ public class HttpUtil {
         proxyProperties.put(SFSessionProperty.PROXY_USER.getPropertyKey(), proxyUser);
         proxyProperties.put(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), proxyPassword);
       }
+
+      // Check if http.nonProxyHosts was set
+      final String nonProxyHosts = System.getProperty(NON_PROXY_HOSTS);
+      if (!isNullOrEmpty(nonProxyHosts)) {
+        proxyProperties.put(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(), nonProxyHosts);
+      }
     }
     return proxyProperties;
   }
@@ -400,5 +412,30 @@ public class HttpUtil {
       return title + poolStats + "\n";
     }
     return title;
+  }
+
+  // Changes the account name to the format accountName.snowflakecomputing.com
+  // then returns a boolean to indicate if we should go through a proxy or not.
+  public static Boolean shouldBypassProxy(String accountName) {
+    String targetHost = accountName + SNOWFLAKE_DOMAIN_NAME;
+    return System.getProperty(NON_PROXY_HOSTS) != null && isInNonProxyHosts(targetHost);
+  }
+
+  /* The target hostname input is compared with the hosts in the '|' separated
+    list provided by the http.nonProxyHosts parameter using regex. The nonProxyHosts
+    will be used as our Patterns, so we need to replace the '.' and '*' characters
+    since those are special regex constructs that mean 'any character,' and
+    'repeat 0 or more times.'
+  */
+  private static Boolean isInNonProxyHosts(String targetHost) {
+    String nonProxyHosts =
+        System.getProperty(NON_PROXY_HOSTS).replace(".", "\\.").replace("*", ".*");
+    String[] nonProxyHostsArray = nonProxyHosts.split("\\|");
+    for (String i : nonProxyHostsArray) {
+      if (Pattern.compile(i).matcher(targetHost).matches()) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
@@ -3,10 +3,12 @@ package net.snowflake.ingest.streaming.internal;
 import static net.snowflake.client.core.Constants.CLOUD_STORAGE_CREDENTIALS_EXPIRED;
 import static net.snowflake.ingest.utils.HttpUtil.HTTP_PROXY_PASSWORD;
 import static net.snowflake.ingest.utils.HttpUtil.HTTP_PROXY_USER;
+import static net.snowflake.ingest.utils.HttpUtil.NON_PROXY_HOSTS;
 import static net.snowflake.ingest.utils.HttpUtil.PROXY_HOST;
 import static net.snowflake.ingest.utils.HttpUtil.PROXY_PORT;
 import static net.snowflake.ingest.utils.HttpUtil.USE_PROXY;
 import static net.snowflake.ingest.utils.HttpUtil.generateProxyPropertiesForJDBC;
+import static net.snowflake.ingest.utils.HttpUtil.shouldBypassProxy;
 import static org.mockito.Mockito.times;
 
 import java.io.ByteArrayInputStream;
@@ -391,11 +393,13 @@ public class StreamingIngestStageTest {
     String oldProxyPort = System.getProperty(PROXY_PORT);
     String oldUser = System.getProperty(HTTP_PROXY_USER);
     String oldPassword = System.getProperty(HTTP_PROXY_PASSWORD);
+    String oldNonProxyHosts = System.getProperty(NON_PROXY_HOSTS);
 
     String proxyHost = "localhost";
     String proxyPort = "8080";
     String user = "admin";
     String password = "test";
+    String nonProxyHosts = "*.snowflakecomputing.com";
 
     try {
       // Test empty properties when USE_PROXY is NOT set;
@@ -407,6 +411,7 @@ public class StreamingIngestStageTest {
       System.setProperty(PROXY_PORT, proxyPort);
       System.setProperty(HTTP_PROXY_USER, user);
       System.setProperty(HTTP_PROXY_PASSWORD, password);
+      System.setProperty(NON_PROXY_HOSTS, nonProxyHosts);
 
       // Verify that properties are set
       props = generateProxyPropertiesForJDBC();
@@ -415,6 +420,8 @@ public class StreamingIngestStageTest {
       Assert.assertEquals(proxyPort, props.get(SFSessionProperty.PROXY_PORT.getPropertyKey()));
       Assert.assertEquals(user, props.get(SFSessionProperty.PROXY_USER.getPropertyKey()));
       Assert.assertEquals(password, props.get(SFSessionProperty.PROXY_PASSWORD.getPropertyKey()));
+      Assert.assertEquals(
+          nonProxyHosts, props.get(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey()));
     } finally {
       // Cleanup
       if (oldUseProxy != null) {
@@ -426,6 +433,44 @@ public class StreamingIngestStageTest {
         System.setProperty(HTTP_PROXY_USER, oldUser);
         System.setProperty(HTTP_PROXY_PASSWORD, oldPassword);
       }
+      if (oldNonProxyHosts != null) {
+        System.setProperty(NON_PROXY_HOSTS, oldNonProxyHosts);
+      }
+    }
+  }
+
+  @Test
+  public void testShouldBypassProxy() {
+    String oldNonProxyHosts = System.getProperty(NON_PROXY_HOSTS);
+    String accountName = "accountName12345";
+    String accountDashName = "account-name12345";
+    String accountUnderscoreName = "account_name12345";
+    String nonProxyHosts = "*.snowflakecomputing.com|localhost";
+
+    System.setProperty(NON_PROXY_HOSTS, nonProxyHosts);
+    Assert.assertTrue(shouldBypassProxy(accountName));
+    Assert.assertTrue(shouldBypassProxy(accountDashName));
+    Assert.assertTrue(shouldBypassProxy(accountUnderscoreName));
+
+    String accountNamePrivateLink = "accountName12345.privatelink";
+    nonProxyHosts = "*.privatelink.snowflakecomputing.com|localhost";
+    System.setProperty(NON_PROXY_HOSTS, nonProxyHosts);
+    Assert.assertTrue(shouldBypassProxy(accountNamePrivateLink));
+
+    // Previous tests should return false with the new nonProxyHosts value
+    Assert.assertFalse(shouldBypassProxy(accountName));
+    Assert.assertFalse(shouldBypassProxy(accountDashName));
+    Assert.assertFalse(shouldBypassProxy(accountUnderscoreName));
+
+    // All tests should return false after clearing the nonProxyHosts property
+    System.clearProperty(NON_PROXY_HOSTS);
+    Assert.assertFalse(shouldBypassProxy(accountName));
+    Assert.assertFalse(shouldBypassProxy(accountDashName));
+    Assert.assertFalse(shouldBypassProxy(accountUnderscoreName));
+    Assert.assertFalse(shouldBypassProxy(accountNamePrivateLink));
+
+    if (oldNonProxyHosts != null) {
+      System.setProperty(NON_PROXY_HOSTS, oldNonProxyHosts);
     }
   }
 }


### PR DESCRIPTION
The JDBC driver was upgraded to 3.13.18 and the HttpUtil code was changed to take into account that a user may need to bypass the proxy by providing the -Dhttp.nonProxyHosts JVM argument