### PR TITLE
SNOW-731571 SimpleIngestIT runtime created database

### DIFF
--- a/src/test/java/net/snowflake/ingest/SimpleIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/SimpleIngestIT.java
@@ -82,6 +82,19 @@ public class SimpleIngestIT {
 
     stageWithPatternName = "ingest_sdk_test_stage_pattern" + RAND_NUM;
 
+
+    String databaseName = TestUtils.getDatabase();
+
+    String schemaName = TestUtils.getSchema();
+
+    TestUtils.executeQuery("create database if not exists " + databaseName);
+
+    TestUtils.executeQuery("create schema if not exists " + schemaName);
+
+    TestUtils.executeQuery("use database " + databaseName);
+
+    TestUtils.executeQuery("use schema " + schemaName);
+
     TestUtils.executeQuery("create or replace table " + tableName + " (str string, num int)");
 
     TestUtils.executeQuery("create or replace stage " + stageName);

--- a/src/test/java/net/snowflake/ingest/SimpleIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/SimpleIngestIT.java
@@ -82,7 +82,6 @@ public class SimpleIngestIT {
 
     stageWithPatternName = "ingest_sdk_test_stage_pattern" + RAND_NUM;
 
-
     String databaseName = TestUtils.getDatabase();
 
     String schemaName = TestUtils.getSchema();

--- a/src/test/java/net/snowflake/ingest/TestUtils.java
+++ b/src/test/java/net/snowflake/ingest/TestUtils.java
@@ -209,6 +209,20 @@ public class TestUtils {
     return keyPair;
   }
 
+  public static String getDatabase() throws Exception {
+    if (profile == null) {
+      init();
+    }
+    return database;
+  }
+
+  public static String getSchema() throws Exception {
+    if (profile == null) {
+      init();
+    }
+    return schema;
+  }
+
   public static Properties getProperties(Constants.BdecVersion bdecVersion) throws Exception {
     if (profile == null) {
       init();


### PR DESCRIPTION
Description
Previously SimpleIngestIT depends on pre-created database SNOWPIPE_SDK_DB. If database got deleted by accident it will cause the integration tests to fail. 
In this PR, we create a new database instead of using the pre-existing database each time when we run SimpleIngestIT.

Testing
Integration Test.

Test with a new database name and a schema name in configuration.

```
  "schema": "SNOWPIPE_LOZHANG_TEST_SCHEMA",
  "database": "SNOWPIPE_LOZHANG_TEST_DB",
```

The integration test can successfully pass.