### PR TITLE
Remove the dependency on JAXB-API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,15 +227,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException -->
-        <!-- https://stackoverflow.com/questions/43574426/how-to-resolve-java
-        -lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j/48404582-->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-
         <!-- JUnit so that we can make some basic unit tests -->
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
@@ -29,11 +29,11 @@ import java.util.zip.GZIPOutputStream;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
-import javax.xml.bind.DatatypeConverter;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.Cryptor;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.Pair;
+import org.apache.commons.codec.binary.Hex;
 
 /**
  * Build a single blob file that contains file header plus data. The header will be a
@@ -319,7 +319,7 @@ class BlobBuilder {
         MessageDigest.getInstance("MD5");
     md.update(data, 0, length);
     byte[] digest = md.digest();
-    return DatatypeConverter.printHexBinary(digest).toLowerCase();
+    return Hex.encodeHexString(digest);
   }
 
   /** Blob data to store in a file and register by server side. */

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
-import javax.xml.bind.DatatypeConverter;
 import net.snowflake.client.jdbc.internal.google.common.collect.Sets;
 import net.snowflake.client.jdbc.internal.snowflake.common.core.SFDate;
 import net.snowflake.client.jdbc.internal.snowflake.common.core.SFTimestamp;
@@ -45,6 +44,8 @@ import net.snowflake.ingest.streaming.internal.serialization.ByteArraySerializer
 import net.snowflake.ingest.streaming.internal.serialization.ZonedDateTimeSerializer;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
 
 /** Utility class for parsing and validating inputs based on Snowflake types */
 class DataValidationUtil {
@@ -553,8 +554,8 @@ class DataValidationUtil {
       output = (byte[]) input;
     } else if (input instanceof String) {
       try {
-        output = DatatypeConverter.parseHexBinary((String) input);
-      } catch (IllegalArgumentException e) {
+        output = Hex.decodeHex((String) input);
+      } catch (DecoderException e) {
         throw valueFormatNotAllowedException(columnName, input, "BINARY", "Not a valid hex string");
       }
     } else {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -39,10 +39,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.xml.bind.DatatypeConverter;
 import net.snowflake.client.jdbc.internal.snowflake.common.core.SFTimestamp;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -816,7 +817,7 @@ public class DataValidationUtilTest {
   }
 
   @Test
-  public void testValidateAndParseBinary() {
+  public void testValidateAndParseBinary() throws DecoderException {
     byte[] maxAllowedArray = new byte[BYTES_8_MB];
     byte[] maxAllowedArrayMinusOne = new byte[BYTES_8_MB - 1];
 
@@ -828,8 +829,7 @@ public class DataValidationUtilTest {
         new byte[] {-1, 0, 1},
         validateAndParseBinary("COL", new byte[] {-1, 0, 1}, Optional.empty()));
     assertArrayEquals(
-        DatatypeConverter.parseHexBinary(
-            "1234567890abcdef"), // pragma: allowlist secret NOT A SECRET
+        Hex.decodeHex("1234567890abcdef"), // pragma: allowlist secret NOT A SECRET
         validateAndParseBinary(
             "COL", "1234567890abcdef", Optional.empty())); // pragma: allowlist secret NOT A SECRET
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -776,6 +776,11 @@ public class FlushServiceTest {
     } else {
       Assert.assertArrayEquals(data, blob);
     }
+
+    // Verify BlobBuilder.computeMD5 returns as expected
+    Assert.assertEquals(
+        "08c8c3a0b5d92627f24fed878afd8325",
+        BlobBuilder.computeMD5("snowflake".getBytes(StandardCharsets.UTF_8)));
   }
 
   @Test


### PR DESCRIPTION
It was only being used for parsing and printing md5 hex strings. JAXB is notorious for having challenges with run-time bindings and relocations, as indicated in the StackOverflow post linked in the now-removed dependency.

Apache Commons Codec is already present, so we can switch to to using `o.a.c.codec.binary.Hex` instead.

Existing unit test coverage appears sufficient, but also added a new sanity check in `FlushServiceTest` that ensures `BlobBuilder.computeMD5` returns a lowercase value on a known input string. Can be validated in a terminal with:
`echo -n "snowflake" | md5 `