### PR TITLE
Remove JAXB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,15 +227,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException -->
-        <!-- https://stackoverflow.com/questions/43574426/how-to-resolve-java
-        -lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j/48404582-->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-
         <!-- JUnit so that we can make some basic unit tests -->
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
@@ -29,11 +29,11 @@ import java.util.zip.GZIPOutputStream;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
-import javax.xml.bind.DatatypeConverter;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.Cryptor;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.Pair;
+import org.apache.commons.codec.binary.Hex;
 
 /**
  * Build a single blob file that contains file header plus data. The header will be a
@@ -319,7 +319,7 @@ class BlobBuilder {
         MessageDigest.getInstance("MD5");
     md.update(data, 0, length);
     byte[] digest = md.digest();
-    return DatatypeConverter.printHexBinary(digest).toLowerCase();
+    return Hex.encodeHexString(digest);
   }
 
   /** Blob data to store in a file and register by server side. */

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -34,7 +34,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-import javax.xml.bind.DatatypeConverter;
+import net.snowflake.client.jdbc.internal.apache.commons.codec.DecoderException;
+import net.snowflake.client.jdbc.internal.apache.commons.codec.binary.Hex;
 import net.snowflake.client.jdbc.internal.google.common.collect.Sets;
 import net.snowflake.client.jdbc.internal.snowflake.common.core.SnowflakeDateTimeFormat;
 import net.snowflake.client.jdbc.internal.snowflake.common.util.Power10;
@@ -592,8 +593,8 @@ class DataValidationUtil {
       output = (byte[]) input;
     } else if (input instanceof String) {
       try {
-        output = DatatypeConverter.parseHexBinary((String) input);
-      } catch (IllegalArgumentException e) {
+        output = Hex.decodeHex((String) input);
+      } catch (DecoderException e) {
         throw valueFormatNotAllowedException(columnName, input, "BINARY", "Not a valid hex string");
       }
     } else {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -34,8 +34,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-import net.snowflake.client.jdbc.internal.apache.commons.codec.DecoderException;
-import net.snowflake.client.jdbc.internal.apache.commons.codec.binary.Hex;
 import net.snowflake.client.jdbc.internal.google.common.collect.Sets;
 import net.snowflake.client.jdbc.internal.snowflake.common.core.SnowflakeDateTimeFormat;
 import net.snowflake.client.jdbc.internal.snowflake.common.util.Power10;
@@ -43,6 +41,8 @@ import net.snowflake.ingest.streaming.internal.serialization.ByteArraySerializer
 import net.snowflake.ingest.streaming.internal.serialization.ZonedDateTimeSerializer;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
 
 /** Utility class for parsing and validating inputs based on Snowflake types */
 class DataValidationUtil {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -42,9 +42,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.xml.bind.DatatypeConverter;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -747,7 +748,7 @@ public class DataValidationUtilTest {
   }
 
   @Test
-  public void testValidateAndParseBinary() {
+  public void testValidateAndParseBinary() throws DecoderException {
     byte[] maxAllowedArray = new byte[BYTES_8_MB];
     byte[] maxAllowedArrayMinusOne = new byte[BYTES_8_MB - 1];
 
@@ -759,8 +760,7 @@ public class DataValidationUtilTest {
         new byte[] {-1, 0, 1},
         validateAndParseBinary("COL", new byte[] {-1, 0, 1}, Optional.empty()));
     assertArrayEquals(
-        DatatypeConverter.parseHexBinary(
-            "1234567890abcdef"), // pragma: allowlist secret NOT A SECRET
+        Hex.decodeHex("1234567890abcdef"), // pragma: allowlist secret NOT A SECRET
         validateAndParseBinary(
             "COL", "1234567890abcdef", Optional.empty())); // pragma: allowlist secret NOT A SECRET
 


### PR DESCRIPTION
This PR remove the dependency on `javax.xml.bind` that we used for hex/encoding decoding. We are going to use commons-codec instead.

PR is based on https://github.com/snowflakedb/snowflake-ingest-java/pull/328. 