### PR TITLE
SNOW-738614 improve uncompressed size estimate for Parquet row buffers

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
@@ -67,7 +67,7 @@ class ParquetValueParser {
               DataValidationUtil.validateAndParseBoolean(columnMetadata.getName(), value);
           value = intValue > 0;
           stats.addIntValue(BigInteger.valueOf(intValue));
-          estimatedParquetSize =
+          estimatedParquetSize +=
               0.125f; // Parquet uses BitPacking for encoding boolean, hence 1 bit
           break;
         case INT32:
@@ -81,7 +81,7 @@ class ParquetValueParser {
                   physicalType);
           value = intVal;
           stats.addIntValue(BigInteger.valueOf(intVal));
-          estimatedParquetSize = 4;
+          estimatedParquetSize += 4;
           break;
         case INT64:
           long longValue =
@@ -95,24 +95,24 @@ class ParquetValueParser {
                   defaultTimezone);
           value = longValue;
           stats.addIntValue(BigInteger.valueOf(longValue));
-          estimatedParquetSize = 8;
+          estimatedParquetSize += 8;
           break;
         case DOUBLE:
           double doubleValue =
               DataValidationUtil.validateAndParseReal(columnMetadata.getName(), value);
           value = doubleValue;
           stats.addRealValue(doubleValue);
-          estimatedParquetSize = 8;
+          estimatedParquetSize += 8;
           break;
         case BINARY:
           if (logicalType == AbstractRowBuffer.ColumnLogicalType.BINARY) {
             value = getBinaryValueForLogicalBinary(value, stats, columnMetadata);
-            estimatedParquetSize = ((byte[]) value).length;
+            estimatedParquetSize += ((byte[]) value).length;
           } else {
             String str = getBinaryValue(value, stats, columnMetadata);
             value = str;
             if (str != null) {
-              estimatedParquetSize = str.getBytes().length;
+              estimatedParquetSize += str.getBytes().length;
             }
             estimatedParquetSize +=
                 4; // Parquet stores length in 4 bytes before the actual data bytes

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
@@ -21,8 +21,29 @@ class ParquetValueParser {
   // Parquet uses BitPacking to encode boolean, hence 1 bit per value
   public static final float BIT_ENCODING_BYTE_LEN = 1.0f / 8;
 
-  /* (on average) 2 bytes / 8 values for the RLE+bitpack encoded definition level.
-  Since we don't have nested types, repetition level is always 0 and is not stored at all by Parquet. */
+  /**
+   * On average parquet needs 2 bytes / 8 values for the RLE+bitpack encoded definition level.
+   *
+   * <ul>
+   *   There are two cases how definition level (0 for null values, 1 for non-null values) is
+   *   encoded:
+   *   <li>If there are at least 8 repeated values in a row, they are run-length encoded (length +
+   *       value itself). E.g. 11111111 -> 8 1
+   *   <li>If there are less than 8 repeated values, they are written in group as part of a
+   *       bit-length encoded run, e.g. 1111 -> 15 A bit-length encoded run ends when either 64
+   *       groups of 8 values have been written or if a new RLE run starts.
+   *       <p>To distinguish between RLE and bitpack run, there is 1 extra bytes written as header
+   *       when a bitpack run starts.
+   * </ul>
+   *
+   * <ul>
+   *   For more details see ColumnWriterV1#createDLWriter and {@link
+   *   org.apache.parquet.column.values.rle.RunLengthBitPackingHybridEncoder#writeInt(int)}
+   * </ul>
+   *
+   * <p>Since we don't have nested types, repetition level is always 0 and is not stored at all by
+   * Parquet.
+   */
   public static final float DEFINITION_LEVEL_ENCODING_BYTE_LEN = 2.0f / 8;
 
   // Parquet stores length in 4 bytes before the actual data bytes

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
@@ -1,7 +1,9 @@
 package net.snowflake.ingest.streaming.internal;
 
 import static java.time.ZoneOffset.UTC;
-import static net.snowflake.ingest.streaming.internal.ParquetValueParser.*;
+import static net.snowflake.ingest.streaming.internal.ParquetValueParser.BIT_ENCODING_BYTE_LEN;
+import static net.snowflake.ingest.streaming.internal.ParquetValueParser.BYTE_ARRAY_LENGTH_ENCODING_BYTE_LEN;
+import static net.snowflake.ingest.streaming.internal.ParquetValueParser.DEFINITION_LEVEL_ENCODING_BYTE_LEN;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
@@ -14,6 +14,9 @@ import org.junit.Test;
 
 public class ParquetValueParserTest {
 
+  public static final float DEFINITION_LEVEL_ENCODING_BYTES = 1 + 1.0f / 8;
+  private static final int BYTE_ARRAY_LENGTH_ENCODING_BYTES = 4;
+
   @Test
   public void parseValueFixedSB1ToInt32() {
     ColumnMetadata testCol =
@@ -35,7 +38,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
         .expectedParsedValue(12)
-        .expectedSize(4.0f)
+        .expectedSize(4.0f + DEFINITION_LEVEL_ENCODING_BYTES)
         .expectedMinMax(BigInteger.valueOf(12))
         .assertMatches();
   }
@@ -61,7 +64,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
         .expectedParsedValue(1234)
-        .expectedSize(4.0f)
+        .expectedSize(4.0f + DEFINITION_LEVEL_ENCODING_BYTES)
         .expectedMinMax(BigInteger.valueOf(1234))
         .assertMatches();
   }
@@ -87,7 +90,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
         .expectedParsedValue(123456789)
-        .expectedSize(4.0f)
+        .expectedSize(4.0f + DEFINITION_LEVEL_ENCODING_BYTES)
         .expectedMinMax(BigInteger.valueOf(123456789))
         .assertMatches();
   }
@@ -117,7 +120,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Long.class)
         .expectedParsedValue(123456789987654321L)
-        .expectedSize(8.0f)
+        .expectedSize(8.0f + DEFINITION_LEVEL_ENCODING_BYTES)
         .expectedMinMax(BigInteger.valueOf(123456789987654321L))
         .assertMatches();
   }
@@ -179,7 +182,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Double.class)
         .expectedParsedValue(Double.valueOf("12345.54321"))
-        .expectedSize(8.0f)
+        .expectedSize(8.0f + DEFINITION_LEVEL_ENCODING_BYTES)
         .expectedMinMax(Double.valueOf("12345.54321"))
         .assertMatches();
   }
@@ -203,7 +206,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Double.class)
         .expectedParsedValue(Double.valueOf(12345.54321))
-        .expectedSize(8.0f)
+        .expectedSize(8.0f + DEFINITION_LEVEL_ENCODING_BYTES)
         .expectedMinMax(Double.valueOf(12345.54321))
         .assertMatches();
   }
@@ -227,7 +230,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Boolean.class)
         .expectedParsedValue(true)
-        .expectedSize(1.0f / 8) // 1 bit
+        .expectedSize(1.0f / 8 + DEFINITION_LEVEL_ENCODING_BYTES) // 1 bit
         .expectedMinMax(BigInteger.valueOf(1))
         .assertMatches();
   }
@@ -255,7 +258,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(byte[].class)
         .expectedParsedValue("1234abcd".getBytes())
-        .expectedSize(8.0f)
+        .expectedSize(8.0f + DEFINITION_LEVEL_ENCODING_BYTES)
         .expectedMinMax("1234abcd".getBytes(StandardCharsets.UTF_8))
         .assertMatches();
   }
@@ -291,7 +294,10 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(String.class)
         .expectedParsedValue(var)
-        .expectedSize(4 + var.getBytes().length) // 4 bytes for length before actual data bytes
+        .expectedSize(
+            BYTE_ARRAY_LENGTH_ENCODING_BYTES
+                + var.getBytes().length
+                + DEFINITION_LEVEL_ENCODING_BYTES) // 4 bytes for length before actual data bytes
         .expectedMinMax(null)
         .assertMatches();
   }
@@ -361,7 +367,10 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(String.class)
         .expectedParsedValue(resultArray)
-        .expectedSize(4 + resultArray.length()) // 4 bytes for length before actual data bytes
+        .expectedSize(
+            BYTE_ARRAY_LENGTH_ENCODING_BYTES
+                + resultArray.length()
+                + DEFINITION_LEVEL_ENCODING_BYTES) // 4 bytes for length before actual data bytes
         .expectedMinMax(null)
         .assertMatches();
   }
@@ -417,7 +426,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Long.class)
         .expectedParsedValue(1367182621000L)
-        .expectedSize(8.0f)
+        .expectedSize(8.0f + DEFINITION_LEVEL_ENCODING_BYTES)
         .expectedMinMax(BigInteger.valueOf(1367182621000L))
         .assertMatches();
   }
@@ -447,7 +456,8 @@ public class ParquetValueParserTest {
         .expectedValueClass(byte[].class)
         .expectedParsedValue(
             ParquetValueParser.getSb16Bytes(BigInteger.valueOf(1663538707123456789L)))
-        .expectedSize(16.0f + 1 + 1.0f / 8) // 1 byte + 1 bit for definition level encoding
+        .expectedSize(
+            16.0f + DEFINITION_LEVEL_ENCODING_BYTES) // 1 byte + 1 bit for definition level encoding
         .expectedMinMax(BigInteger.valueOf(1663538707123456789L))
         .assertMatches();
   }
@@ -472,7 +482,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
         .expectedParsedValue(Integer.valueOf(18628))
-        .expectedSize(4.0f)
+        .expectedSize(4.0f + DEFINITION_LEVEL_ENCODING_BYTES)
         .expectedMinMax(BigInteger.valueOf(18628))
         .assertMatches();
   }
@@ -497,7 +507,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
         .expectedParsedValue(3600)
-        .expectedSize(4.0f)
+        .expectedSize(4.0f + DEFINITION_LEVEL_ENCODING_BYTES)
         .expectedMinMax(BigInteger.valueOf(3600))
         .assertMatches();
   }
@@ -522,7 +532,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Long.class)
         .expectedParsedValue(3600123L)
-        .expectedSize(8.0f)
+        .expectedSize(8.0f + DEFINITION_LEVEL_ENCODING_BYTES)
         .expectedMinMax(BigInteger.valueOf(3600123))
         .assertMatches();
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
@@ -149,7 +149,7 @@ public class ParquetValueParserTest {
         .expectedParsedValue(
             ParquetValueParser.getSb16Bytes(
                 new BigInteger("91234567899876543219876543211234567891")))
-        .expectedSize(16.0f)
+        .expectedSize(16.0f + 1 + 1f / 8) // 1 byte + 1 bit for definition level encoding
         .expectedMinMax(new BigInteger("91234567899876543219876543211234567891"))
         .assertMatches();
   }
@@ -227,7 +227,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(Boolean.class)
         .expectedParsedValue(true)
-        .expectedSize(1.0f)
+        .expectedSize(1.0f / 8) // 1 bit
         .expectedMinMax(BigInteger.valueOf(1))
         .assertMatches();
   }
@@ -291,7 +291,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(String.class)
         .expectedParsedValue(var)
-        .expectedSize(var.getBytes().length)
+        .expectedSize(4 + var.getBytes().length) // 4 bytes for length before actual data bytes
         .expectedMinMax(null)
         .assertMatches();
   }
@@ -361,7 +361,7 @@ public class ParquetValueParserTest {
         .rowBufferStats(rowBufferStats)
         .expectedValueClass(String.class)
         .expectedParsedValue(resultArray)
-        .expectedSize(resultArray.length())
+        .expectedSize(4 + resultArray.length()) // 4 bytes for length before actual data bytes
         .expectedMinMax(null)
         .assertMatches();
   }
@@ -447,7 +447,7 @@ public class ParquetValueParserTest {
         .expectedValueClass(byte[].class)
         .expectedParsedValue(
             ParquetValueParser.getSb16Bytes(BigInteger.valueOf(1663538707123456789L)))
-        .expectedSize(16.0f)
+        .expectedSize(16.0f + 1 + 1.0f / 8) // 1 byte + 1 bit for definition level encoding
         .expectedMinMax(BigInteger.valueOf(1663538707123456789L))
         .assertMatches();
   }


### PR DESCRIPTION
In this PR we try to make better estimates of uncompressed, but encoded data that will be written in Parquet pages. It means taking into consideration extra data/metadata added by Parquet when encoding the values. This can lead to a more timely-accurate decision of when to flush the rows to BDEC files.

Parquet encoding details: https://parquet.apache.org/docs/file-format/data-pages/encodings/