### PR TITLE
SNOW-745946 SNOW-735517 Create defensive copy of ingested rows

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -91,14 +91,6 @@ class DataValidationUtil {
   }
 
   /**
-   * Creates a new SnowflakeDateTimeFormat. In order to avoid SnowflakeDateTimeFormat's
-   * synchronization blocks, we create a new instance when needed instead of sharing one instance.
-   */
-  private static SnowflakeDateTimeFormat createDateTimeFormatter() {
-    return SnowflakeDateTimeFormat.fromSqlFormat("auto");
-  }
-
-  /**
    * Validates and parses input as JSON. All types in the object tree must be valid variant types,
    * see {@link DataValidationUtil#isAllowedSemiStructuredType}.
    *
@@ -590,7 +582,12 @@ class DataValidationUtil {
       String columnName, Object input, Optional<Integer> maxLengthOptional) {
     byte[] output;
     if (input instanceof byte[]) {
-      output = (byte[]) input;
+      // byte[] is a mutable object, we need to create a defensive copy to protect against
+      // concurrent
+      // modifications of the array, which could lead to mismatch between data and metadata
+      byte[] originalInputArray = (byte[]) input;
+      output = new byte[originalInputArray.length];
+      System.arraycopy(originalInputArray, 0, output, 0, originalInputArray.length);
     } else if (input instanceof String) {
       try {
         output = Hex.decodeHex((String) input);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -583,8 +583,8 @@ class DataValidationUtil {
     byte[] output;
     if (input instanceof byte[]) {
       // byte[] is a mutable object, we need to create a defensive copy to protect against
-      // concurrent
-      // modifications of the array, which could lead to mismatch between data and metadata
+      // concurrent modifications of the array, which could lead to mismatch between data
+      // and metadata
       byte[] originalInputArray = (byte[]) input;
       output = new byte[originalInputArray.length];
       System.arraycopy(originalInputArray, 0, output, 0, originalInputArray.length);


### PR DESCRIPTION
As a protection against concurrent modifications of the input map,  this PR creates a defensive shallow copy of the map, as well as deep copy of its mutable values (currently only `byte[]` for `BINARY` columns). Concurrent modifications could cause issues like data/metadata mismatch or double counting of `null` values.

For semi-structured types, we accept more mutable values (`List` and `Map`), but for these values we do not calculate min/max EP values, so there is no risk of a mismatch between data and metadata.