### PR TITLE
SNOW-749216 Allow leading and trailing whitespace

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -343,7 +343,7 @@ class DataValidationUtil {
     }
 
     if (input instanceof String) {
-      String stringInput = (String) input;
+      String stringInput = ((String) input).trim();
       {
         // First, try to parse ZonedDateTime
         ZonedDateTime zoned = catchParsingError(() -> ZonedDateTime.parse(stringInput));
@@ -532,7 +532,8 @@ class DataValidationUtil {
       return BigDecimal.valueOf(((Number) input).doubleValue());
     } else if (input instanceof String) {
       try {
-        return new BigDecimal((String) input);
+        final String stringInput = ((String) input).trim();
+        return new BigDecimal(stringInput);
       } catch (NumberFormatException e) {
         throw valueFormatNotAllowedException(columnName, input, "NUMBER", "Not a valid number");
       }
@@ -590,7 +591,8 @@ class DataValidationUtil {
       System.arraycopy(originalInputArray, 0, output, 0, originalInputArray.length);
     } else if (input instanceof String) {
       try {
-        output = Hex.decodeHex((String) input);
+        String stringInput = ((String) input).trim();
+        output = Hex.decodeHex(stringInput);
       } catch (DecoderException e) {
         throw valueFormatNotAllowedException(columnName, input, "BINARY", "Not a valid hex string");
       }
@@ -627,7 +629,7 @@ class DataValidationUtil {
     } else if (input instanceof OffsetTime) {
       return validateAndParseTime(columnName, ((OffsetTime) input).toLocalTime(), scale);
     } else if (input instanceof String) {
-      String stringInput = (String) input;
+      String stringInput = ((String) input).trim();
       {
         // First, try to parse LocalTime
         LocalTime localTime = catchParsingError(() -> LocalTime.parse(stringInput));
@@ -712,7 +714,7 @@ class DataValidationUtil {
     } else if (input instanceof Number) {
       return ((Number) input).doubleValue();
     } else if (input instanceof String) {
-      String stringInput = (String) input;
+      String stringInput = ((String) input).trim();
       try {
         return Double.parseDouble(stringInput);
       } catch (NumberFormatException err) {
@@ -776,8 +778,8 @@ class DataValidationUtil {
       Sets.newHashSet("1", "0", "yes", "no", "y", "n", "t", "f", "true", "false", "on", "off");
 
   private static boolean convertStringToBoolean(String columnName, String value) {
-    String lowerCasedValue = value.toLowerCase();
-    if (!allowedBooleanStringsLowerCased.contains(lowerCasedValue)) {
+    String normalizedInput = value.toLowerCase().trim();
+    if (!allowedBooleanStringsLowerCased.contains(normalizedInput)) {
       throw valueFormatNotAllowedException(
           columnName,
           value,
@@ -786,12 +788,12 @@ class DataValidationUtil {
               + " https://docs.snowflake.com/en/sql-reference/data-types-logical.html#conversion-to-boolean"
               + " for the list of supported formats");
     }
-    return "1".equals(lowerCasedValue)
-        || "yes".equals(lowerCasedValue)
-        || "y".equals(lowerCasedValue)
-        || "t".equals(lowerCasedValue)
-        || "true".equals(lowerCasedValue)
-        || "on".equals(lowerCasedValue);
+    return "1".equals(normalizedInput)
+        || "yes".equals(normalizedInput)
+        || "y".equals(normalizedInput)
+        || "t".equals(normalizedInput)
+        || "true".equals(normalizedInput)
+        || "on".equals(normalizedInput);
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -360,9 +360,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
     // concurrently modified (e.g. byte[]). Before validation and EP calculation, we must make sure
     // that defensive copies of all mutable objects are created.
     final List<Map<String, Object>> rowsCopy = new LinkedList<>();
-    for (Map<String, Object> row : rows) {
-      rowsCopy.add(new HashMap<>(row));
-    }
+    rows.forEach(r -> rowsCopy.add(new HashMap<>(r)));
 
     InsertValidationResponse response = this.rowBuffer.insertRows(rowsCopy, offsetToken);
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
@@ -25,6 +25,7 @@ public class StringsIT extends AbstractDataTypeTest {
   public void testStrings() throws Exception {
     testJdbcTypeCompatibility("VARCHAR", "", new StringProvider());
     testJdbcTypeCompatibility("VARCHAR", "foo", new StringProvider());
+    testJdbcTypeCompatibility("VARCHAR", "  foo  \t\n", new StringProvider());
 
     // Test strings with limited size
     testJdbcTypeCompatibility("VARCHAR(1)", "", new StringProvider());


### PR DESCRIPTION
Allow surrounding whitespace around string input values for various data types, just like Snowflake Worksheets do. 