### PR TITLE
Clarify thread-safety guarantees in Javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Snowflake Ingest Service SDK allows users to ingest files into their
 Snowflake data warehouse in a programmatic fashion via key-pair
 authentication. Currently, we support ingestion through the following APIs:
 1. [Snowpipe](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-rest-gs.html#client-requirement-java-or-python-sdk)
-2. [Snowpipe Streaming](https://docs.snowflake.com/en/LIMITEDACCESS/snowpipe-streaming.html) - Under Private Preview
+2. [Snowpipe Streaming](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview) - Under Public Preview
 
 # Prerequisites
 

--- a/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestChannel.java
+++ b/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestChannel.java
@@ -13,8 +13,8 @@ import javax.annotation.Nullable;
  * A logical partition that represents a connection to a single Snowflake table, data will be
  * ingested into the channel, and then flushed to Snowflake table periodically in the background.
  *
- * <p>Channels are identified by their name and only one channel with the same name may ingest data at
- * the same time. When a new channel is opened, all previously opened channels with the same name
+ * <p>Channels are identified by their name and only one channel with the same name may ingest data
+ * at the same time. When a new channel is opened, all previously opened channels with the same name
  * are invalidated (this applies for the table globally. not just in a single JVM). In order to
  * ingest data from multiple threads/clients/applications, we recommend opening multiple channels,
  * each with a different name. There is no limit on the number of channels that can be opened.

--- a/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestChannel.java
+++ b/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestChannel.java
@@ -19,9 +19,7 @@ import javax.annotation.Nullable;
  * ingest data from multiple threads/clients/applications, we recommend opening multiple channels,
  * each with a different name. There is no limit on the number of channels that can be opened.
  *
- * <p>Thread safety note: Implementations of this interface are required to be thread safe, one
- * instance of a channel can be used to ingest data from multiple threads. The recommended way,
- * however, would be to open a new channel in every thread.
+ * <p>Thread safety note: Implementations of this interface are required to be thread safe.
  */
 public interface SnowflakeStreamingIngestChannel {
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestClient.java
+++ b/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestClient.java
@@ -9,6 +9,8 @@ package net.snowflake.ingest.streaming;
  * maps to exactly one account in Snowflake; however, multiple clients can point to the same
  * account. Each client will contain information for Snowflake authentication and authorization, and
  * it will be used to create one or more {@link SnowflakeStreamingIngestChannel}
+ *
+ * <p>Thread safety note: Implementations of this interface are required to be thread safe.
  */
 public interface SnowflakeStreamingIngestClient extends AutoCloseable {
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -386,7 +386,6 @@ class DataValidationUtil {
       }
 
       // Couldn't parse anything, throw an exception
-      // TODO Change URL when out of private preview
       throw valueFormatNotAllowedException(
           columnName,
           input.toString(),
@@ -657,7 +656,6 @@ class DataValidationUtil {
         }
       }
 
-      // TODO Change URL when out of private preview
       throw valueFormatNotAllowedException(
           columnName,
           input,

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -392,7 +392,7 @@ class DataValidationUtil {
           input.toString(),
           typeName,
           "Not a valid value, see"
-              + " https://docs.snowflake.com/en/LIMITEDACCESS/snowpipe-streaming.html"
+              + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview"
               + " for the list of supported formats");
     }
 
@@ -663,7 +663,7 @@ class DataValidationUtil {
           input,
           "TIME",
           "Not a valid time, see"
-              + " https://docs.snowflake.com/en/LIMITEDACCESS/snowpipe-streaming.html"
+              + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview"
               + " for the list of supported formats");
 
     } else {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -932,8 +932,8 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
             + " Snowflake column COL of type DATE: Not a valid value, see"
-            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview for the list of"
-            + " supported formats",
+            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview for"
+            + " the list of supported formats",
         () -> validateAndParseDate("COL", "abc"));
 
     // TIMESTAMP_NTZ
@@ -947,8 +947,8 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
             + " Snowflake column COL of type TIMESTAMP: Not a valid value, see"
-            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview for the list of"
-            + " supported formats",
+            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview for"
+            + " the list of supported formats",
         () -> validateAndParseTimestamp("COL", "abc", 3, UTC, true));
 
     // TIMESTAMP_LTZ
@@ -962,8 +962,8 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
             + " Snowflake column COL of type TIMESTAMP: Not a valid value, see"
-            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview for the list of"
-            + " supported formats",
+            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview for"
+            + " the list of supported formats",
         () -> validateAndParseTimestamp("COL", "abc", 3, UTC, false));
 
     // TIMESTAMP_TZ
@@ -977,8 +977,8 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
             + " Snowflake column COL of type TIMESTAMP: Not a valid value, see"
-            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview for the list of"
-            + " supported formats",
+            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview for"
+            + " the list of supported formats",
         () -> validateAndParseTimestamp("COL", "abc", 3, UTC, false));
 
     // NUMBER

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -917,7 +917,7 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
             + " Snowflake column COL of type TIME: Not a valid time, see"
-            + " https://docs.snowflake.com/en/LIMITEDACCESS/snowpipe-streaming.html"
+            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview"
             + " for the list of supported formats",
         () -> validateAndParseTime("COL", "abc", 10));
 
@@ -932,7 +932,7 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
             + " Snowflake column COL of type DATE: Not a valid value, see"
-            + " https://docs.snowflake.com/en/LIMITEDACCESS/snowpipe-streaming.html for the list of"
+            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview for the list of"
             + " supported formats",
         () -> validateAndParseDate("COL", "abc"));
 
@@ -947,7 +947,7 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
             + " Snowflake column COL of type TIMESTAMP: Not a valid value, see"
-            + " https://docs.snowflake.com/en/LIMITEDACCESS/snowpipe-streaming.html for the list of"
+            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview for the list of"
             + " supported formats",
         () -> validateAndParseTimestamp("COL", "abc", 3, UTC, true));
 
@@ -962,7 +962,7 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
             + " Snowflake column COL of type TIMESTAMP: Not a valid value, see"
-            + " https://docs.snowflake.com/en/LIMITEDACCESS/snowpipe-streaming.html for the list of"
+            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview for the list of"
             + " supported formats",
         () -> validateAndParseTimestamp("COL", "abc", 3, UTC, false));
 
@@ -977,7 +977,7 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_ROW,
         "The given row cannot be converted to Arrow format: abc. Value cannot be ingested into"
             + " Snowflake column COL of type TIMESTAMP: Not a valid value, see"
-            + " https://docs.snowflake.com/en/LIMITEDACCESS/snowpipe-streaming.html for the list of"
+            + " https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview for the list of"
             + " supported formats",
         () -> validateAndParseTimestamp("COL", "abc", 3, UTC, false));
 


### PR DESCRIPTION
This PR add Javadocs to user-facing types, which clarify thread-safety guarantees. 

For `SnowflakeStreamingIngestChannel`, the Javadocs previously stated that only one thread may ingest data into the same channel, which is not true because one channel instance can be shared between threads.

This PR also changes the documentation link to PuPr URL. 