### PR TITLE
SNOW-735517 Remove nullCount <= rowCount sanity check

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/EpInfo.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/EpInfo.java
@@ -26,14 +26,6 @@ class EpInfo {
     for (Map.Entry<String, FileColumnProperties> entry : columnEps.entrySet()) {
       String colName = entry.getKey();
       FileColumnProperties colEp = entry.getValue();
-      // Make sure the null count should always smaller than the total row count
-      if (colEp.getNullCount() > rowCount) {
-        throw new SFException(
-            ErrorCode.INTERNAL_ERROR,
-            String.format(
-                "Null count bigger than total row count on col=%s, nullCount=%s, rowCount=%s",
-                colName, colEp.getNullCount(), rowCount));
-      }
 
       // Make sure the NDV should always be -1
       if (colEp.getDistinctValues() != EP_NDV_UNKNOWN) {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -578,31 +578,6 @@ public class RowBufferTest {
   }
 
   @Test
-  public void testInvalidEPInfo() {
-    Map<String, RowBufferStats> colStats = new HashMap<>();
-
-    RowBufferStats stats1 = new RowBufferStats("intColumn");
-    stats1.addIntValue(BigInteger.valueOf(2));
-    stats1.addIntValue(BigInteger.valueOf(10));
-    stats1.addIntValue(BigInteger.valueOf(1));
-
-    RowBufferStats stats2 = new RowBufferStats("strColumn");
-    stats2.addStrValue("alice");
-    stats2.incCurrentNullCount();
-    stats2.incCurrentNullCount();
-
-    colStats.put("intColumn", stats1);
-    colStats.put("strColumn", stats2);
-
-    try {
-      AbstractRowBuffer.buildEpInfoFromStats(1, colStats);
-      Assert.fail("should fail when row count is smaller than null count.");
-    } catch (SFException e) {
-      Assert.assertEquals(ErrorCode.INTERNAL_ERROR.getMessageCode(), e.getVendorCode());
-    }
-  }
-
-  @Test
   public void testE2E() {
     testE2EHelper(this.rowBufferOnErrorAbort);
     testE2EHelper(this.rowBufferOnErrorContinue);


### PR DESCRIPTION
In order to be notified when SNOW-735517 occurs, remove the check from SDK. It is going to be caught server-side during blob registration request.