### PR TITLE
SNOW-761399: exclude nimbus-jose-jwt from hadoop-common dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,10 @@
                     <artifactId>spotbugs-annotations</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.nimbusds</groupId>
+                    <artifactId>nimbus-jose-jwt</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-core</artifactId>
                 </exclusion>


### PR DESCRIPTION
This is to exclude nimbus-jose-jwt from hadoop-common dependency as we already introduces a newer version of nimbus-jose-jwt in direct dependency 