### PR TITLE
@snow SNOW-759764 Streaming Ingest Parquet: use Snowflake column ordinal

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ColumnMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ColumnMetadata.java
@@ -22,6 +22,12 @@ class ColumnMetadata {
   private boolean nullable;
   private String collation;
 
+  /**
+   * The column ordinal is an internal id of the column used by server scanner for the column
+   * identification.
+   */
+  private Integer ordinal;
+
   @JsonProperty("name")
   void setName(String name) {
     this.name = name;
@@ -111,6 +117,15 @@ class ColumnMetadata {
 
   boolean getNullable() {
     return this.nullable;
+  }
+
+  @JsonProperty("ordinal")
+  void setOrdinal(Integer ordinal) {
+    this.ordinal = ordinal;
+  }
+
+  public Integer getOrdinal() {
+    return ordinal;
   }
 
   String getInternalName() {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -90,9 +90,6 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
     metadata.clear();
     metadata.put("sfVer", "1,1");
     List<Type> parquetTypes = new ArrayList<>();
-    // Snowflake column id that corresponds to the order in 'columns' received from server
-    // id is required to pack column metadata for the server scanner, e.g. decimal scale and
-    // precision
     int id = 1;
     for (ColumnMetadata column : columns) {
       validateColumnCollation(column);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
@@ -60,10 +60,11 @@ public class ParquetTypeGenerator {
    * side.
    *
    * @param column column metadata as received from server side
-   * @param id column id
+   * @param id column id if column.getOrdinal() is not available
    * @return column parquet type
    */
   static ParquetTypeInfo generateColumnParquetTypeInfo(ColumnMetadata column, int id) {
+    id = column.getOrdinal() == null ? id : column.getOrdinal();
     ParquetTypeInfo res = new ParquetTypeInfo();
     Type parquetType;
     Map<String, String> metadata = new HashMap<>();

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ColumnMetadataBuilder.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ColumnMetadataBuilder.java
@@ -17,6 +17,8 @@ public class ColumnMetadataBuilder {
   private boolean nullable;
   private String collation;
 
+  private Integer ordinal;
+
   /**
    * Returns a new ColumnMetadata builder
    *
@@ -143,6 +145,17 @@ public class ColumnMetadataBuilder {
   }
 
   /**
+   * Set column ordinal
+   *
+   * @param ordinal ordinal
+   * @return columnMetadataBuilder object
+   */
+  public ColumnMetadataBuilder ordinal(int ordinal) {
+    this.ordinal = ordinal;
+    return this;
+  }
+
+  /**
    * Build a columnMetadata object from the set values
    *
    * @return columnMetadata object
@@ -159,6 +172,7 @@ public class ColumnMetadataBuilder {
     colMetadata.setScale(scale);
     colMetadata.setPrecision(precision);
     colMetadata.setCollation(collation);
+    colMetadata.setOrdinal(ordinal);
     return colMetadata;
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetTypeGeneratorTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetTypeGeneratorTest.java
@@ -8,11 +8,12 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class ParquetTypeGeneratorTest {
+  private static final int COL_ORDINAL = 11;
 
   @Test
   public void buildFieldFixedSB1() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("FIXED")
             .physicalType("SB1")
             .nullable(true)
@@ -20,10 +21,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(4)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
         .expectedLogicalTypeAnnotation(
@@ -39,7 +39,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldFixedSB2() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("FIXED")
             .physicalType("SB2")
             .nullable(false)
@@ -47,10 +47,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(4)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
         .expectedLogicalTypeAnnotation(
@@ -66,7 +65,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldFixedSB4() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("FIXED")
             .physicalType("SB4")
             .nullable(true)
@@ -74,10 +73,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(4)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
         .expectedLogicalTypeAnnotation(
@@ -93,7 +91,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldFixedSB8() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("FIXED")
             .physicalType("SB8")
             .nullable(true)
@@ -101,10 +99,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(8)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
         .expectedLogicalTypeAnnotation(
@@ -120,7 +117,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldFixedSB16() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("FIXED")
             .physicalType("SB16")
             .nullable(true)
@@ -128,10 +125,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(16)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
         .expectedLogicalTypeAnnotation(
@@ -147,7 +143,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldLobVariant() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("VARIANT")
             .physicalType("LOB")
             .nullable(true)
@@ -155,10 +151,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(0)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.BINARY)
         .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.stringType())
@@ -169,13 +164,13 @@ public class ParquetTypeGeneratorTest {
                 + AbstractRowBuffer.ColumnPhysicalType.LOB.getOrdinal())
         .assertMatches();
 
-    Assert.assertEquals("1", typeInfo.getMetadata().get(0 + ":obj_enc"));
+    Assert.assertEquals("1", typeInfo.getMetadata().get(COL_ORDINAL + ":obj_enc"));
   }
 
   @Test
   public void buildFieldTimestampNtzSB8() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("TIMESTAMP_NTZ")
             .physicalType("SB8")
             .nullable(true)
@@ -183,10 +178,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(8)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
         .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 18))
@@ -201,7 +195,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldTimestampNtzSB16() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("TIMESTAMP_NTZ")
             .physicalType("SB16")
             .nullable(true)
@@ -209,10 +203,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(16)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
         .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 38))
@@ -227,7 +220,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldTimestampTzSB8() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("TIMESTAMP_TZ")
             .physicalType("SB8")
             .nullable(true)
@@ -235,10 +228,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(8)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
         .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 18))
@@ -253,7 +245,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldTimestampTzSB16() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("TIMESTAMP_TZ")
             .physicalType("SB16")
             .nullable(true)
@@ -261,10 +253,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(16)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
         .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 38))
@@ -279,7 +270,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldDate() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("DATE")
             .physicalType("SB8")
             .nullable(true)
@@ -287,10 +278,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(0)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
         .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.dateType())
@@ -305,7 +295,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldTimeSB4() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("TIME")
             .physicalType("SB4")
             .nullable(true)
@@ -313,10 +303,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(4)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT32)
         .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 9))
@@ -331,7 +320,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldTimeSB8() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("TIME")
             .physicalType("SB8")
             .nullable(true)
@@ -339,10 +328,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(8)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.INT64)
         .expectedLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(testCol.getScale(), 18))
@@ -357,7 +345,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldBoolean() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("BOOLEAN")
             .physicalType("BINARY")
             .nullable(true)
@@ -365,10 +353,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(0)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.BOOLEAN)
         .expectedLogicalTypeAnnotation(null)
@@ -383,7 +370,7 @@ public class ParquetTypeGeneratorTest {
   @Test
   public void buildFieldRealSB16() {
     ColumnMetadata testCol =
-        ColumnMetadataBuilder.newBuilder()
+        createColumnMetadataBuilder()
             .logicalType("REAL")
             .physicalType("SB16")
             .nullable(true)
@@ -391,10 +378,9 @@ public class ParquetTypeGeneratorTest {
 
     ParquetTypeGenerator.ParquetTypeInfo typeInfo =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(testCol, 0);
-    ParquetTypeInfoAssertionBuilder.newBuilder()
+    createParquetTypeInfoAssertionBuilder()
         .typeInfo(typeInfo)
         .expectedFieldName("TESTCOL")
-        .expectedFieldId(0)
         .expectedTypeLength(0)
         .expectedPrimitiveTypeName(PrimitiveType.PrimitiveTypeName.DOUBLE)
         .expectedLogicalTypeAnnotation(null)
@@ -476,5 +462,13 @@ public class ParquetTypeGeneratorTest {
       Assert.assertEquals(repetition, type.getRepetition());
       Assert.assertEquals(colMetadata, metadata.get(type.getId().toString()));
     }
+  }
+
+  private static ColumnMetadataBuilder createColumnMetadataBuilder() {
+    return ColumnMetadataBuilder.newBuilder().ordinal(COL_ORDINAL);
+  }
+
+  private static ParquetTypeInfoAssertionBuilder createParquetTypeInfoAssertionBuilder() {
+    return ParquetTypeInfoAssertionBuilder.newBuilder().expectedFieldId(COL_ORDINAL);
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -3,6 +3,8 @@ package net.snowflake.ingest.streaming.internal;
 import static net.snowflake.ingest.utils.Constants.BLOB_NO_HEADER;
 import static net.snowflake.ingest.utils.Constants.COMPRESS_BLOB_TWICE;
 import static net.snowflake.ingest.utils.Constants.ROLE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -39,6 +41,7 @@ import net.snowflake.ingest.utils.SFException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -994,6 +997,131 @@ public class StreamingIngestIT {
     Assert.fail("Row sequencer not updated before timeout");
   }
 
+  @Ignore
+  @Test
+  public void testTableColumnEvolution() throws Exception {
+    final int rowNum = 100;
+    final String tableName = TEST_TABLE + "_TEST_COL_EVOL";
+    final String tableFullName = String.format("%s.%s.%s", testDb, TEST_SCHEMA, tableName);
+    final String streamName =
+        String.format("%s.%s.%s", testDb, TEST_SCHEMA, "STREAM_TEST_COL_EVOL");
+
+    executeQuery("create or replace table %s (c1 varchar, c2 varchar, c3 varchar);", tableName);
+    int channelNum = 1;
+
+    // insert first 3 columns
+    ingestByColIndexAndVerifyTable(tableName, channelNum, Arrays.asList(1, 2, 3), rowNum);
+    channelNum++;
+
+    // add one column
+    executeQuery(String.format("alter table %s add column c4 varchar;", tableFullName));
+    ingestByColIndexAndVerifyTable(tableName, channelNum, Arrays.asList(1, 2, 3, 4), rowNum);
+    channelNum++;
+
+    // remove first column
+    executeQuery(String.format("alter table %s drop column c1;", tableFullName));
+    ingestByColIndexAndVerifyTable(tableName, channelNum, Arrays.asList(2, 3, 4), rowNum);
+    channelNum++;
+
+    // remove last column
+    executeQuery(String.format("alter table %s drop column c4;", tableFullName));
+    ingestByColIndexAndVerifyTable(tableName, channelNum, Arrays.asList(2, 3), rowNum);
+    channelNum++;
+
+    // add last column
+    executeQuery(String.format("alter table %s add column c5 varchar;", tableFullName));
+    ingestByColIndexAndVerifyTable(tableName, channelNum, Arrays.asList(2, 3, 5), rowNum);
+    channelNum++;
+
+    // create stream on table to append change tracking columns
+    executeQuery(String.format("create or replace stream %s on table %s;", streamName, tableName));
+    ingestByColIndexAndVerifyTable(tableName, channelNum, Arrays.asList(2, 3, 5), rowNum);
+    channelNum++;
+
+    // add one more column after change tracking columns
+    executeQuery(String.format("alter table %s add column c6 varchar;", tableFullName));
+    ingestByColIndexAndVerifyTable(tableName, channelNum, Arrays.asList(2, 3, 5, 6), rowNum);
+  }
+
+  /**
+   * Ingests rows into a table and verifies them by querying the table.
+   *
+   * <p>The test opens channel 'channel<channelNum>' for ingestion.
+   *
+   * <p>Expected table schema is ('C<index1>' varchar, 'C<index2>' varchar) where indexes are from
+   * {@code columnIndexes}.
+   *
+   * <p>The ingested text values have the format: 'v<col_index1>_<row_index>'. The row index is from
+   * range [(channelNum - 1) * numberOfRows, numberOfRows].
+   *
+   * @param tableName table full name
+   * @param channelNum channel number to open
+   * @param columnIndexes indexes of columns to ingest
+   * @param numberOfRows to ingest
+   */
+  private void ingestByColIndexAndVerifyTable(
+      String tableName, int channelNum, List<Integer> columnIndexes, int numberOfRows)
+      throws InterruptedException, SQLException {
+    final String valueFormat = "v%01d_%03d";
+    final String channelName = "channel" + channelNum;
+    final int startIndex = (channelNum - 1) * numberOfRows;
+
+    // ingest rows
+    SnowflakeStreamingIngestChannel channel = openChannel(tableName, channelName);
+    for (int i = 0; i < numberOfRows; i++) {
+      Map<String, Object> row = new HashMap<>();
+      for (int col : columnIndexes) {
+        String value = String.format(valueFormat, col, startIndex + i);
+        row.put("c" + col, value);
+      }
+      verifyInsertValidationResponse(channel.insertRow(row, Integer.toString(i)));
+    }
+    TestUtils.waitForOffset(channel, Integer.toString(numberOfRows - 1));
+    channel.close();
+
+    // query them and verify
+    int firstColNum = columnIndexes.get(0);
+    try (ResultSet result =
+        jdbcConnection
+            .createStatement()
+            .executeQuery(
+                String.format(
+                    "select * from %s.%s.%s where c%d >= 'v%01d_%03d' and c%d < 'v%01d_%03d' order"
+                        + " by c%d",
+                    testDb,
+                    TEST_SCHEMA,
+                    tableName,
+                    firstColNum,
+                    firstColNum,
+                    startIndex,
+                    firstColNum,
+                    firstColNum,
+                    startIndex + numberOfRows,
+                    firstColNum))) {
+      for (int i = 0; i < numberOfRows; i++) {
+        result.next();
+        for (int col : columnIndexes) {
+          String value = result.getString("C" + col);
+          String expectedValue = String.format(valueFormat, col, startIndex + i);
+          String errorMessage =
+              String.format(
+                  "Ingested value mismatch: table %s, startIndex %d, column %s, index %d",
+                  tableName, startIndex, "c" + col, i);
+          assertThat(errorMessage, value, is(expectedValue));
+        }
+      }
+    }
+  }
+
+  private void executeQuery(String sqlFmt, Object... args) {
+    String sql = String.format(sqlFmt, args);
+    try {
+      jdbcConnection.createStatement().executeQuery(sql);
+    } catch (SQLException e) {
+      throw new RuntimeException("SQL query failed : " + sql, e);
+    }
+  }
+
   /** Verify the insert validation response and throw the exception if needed */
   private void verifyInsertValidationResponse(InsertValidationResponse response) {
     if (response.hasErrors()) {
@@ -1019,7 +1147,7 @@ public class StreamingIngestIT {
             .setDBName(testDb)
             .setSchemaName(TEST_SCHEMA)
             .setTableName(tableName)
-            .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
+            .setOnErrorOption(OpenChannelRequest.OnErrorOption.ABORT)
             .build();
 
     // Open a streaming ingest channel from the given client


### PR DESCRIPTION
Currently, Parquet file generator does not use Snowflake internal column ordinal.
It uses the column index from the column list that comes from server side.
It works when the table just created because the original ordinals are initially the column indexes.
Nonetheless, this breaks table column evolution (add/drop) because the column ordinal is not the index anymore.

@test
`StreamingIngestIT.testTableColumnEvolution`
the test is disabled until the server side fix is released in 7.10.