### PR TITLE
SNOW-766522 Cache unquoted column names

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/LiteralQuoteUtils.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/LiteralQuoteUtils.java
@@ -46,7 +46,9 @@ class LiteralQuoteUtils {
       return unquotedColumnNamesCache.get(columnName);
     } catch (ExecutionException e) {
       throw new SFException(
-          e, ErrorCode.INTERNAL_ERROR, String.format("Exception thrown while unquoting column name %s", columnName));
+          e,
+          ErrorCode.INTERNAL_ERROR,
+          String.format("Exception thrown while unquoting column name %s", columnName));
     }
   }
 


### PR DESCRIPTION
The SDK is unnecessarily unquoting column names from user input again and again, even though they are (likely) always the same in each row. This PR introduces a loading cache of already computed unquoted column names to avoid unnecessary re-computations.