### PR TITLE
SNOW-766522 Avoid duplicate calls to unquoteColumnName

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,11 +346,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-netty</artifactId>
       <version>${arrow.version}</version>
@@ -394,6 +389,11 @@
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
       <version>2.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,11 @@
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
         <version>${snappy.version}</version>
@@ -339,6 +344,11 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>

--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -232,7 +232,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
    * Verify that the input row columns are all valid.
    *
    * <p>Checks that the columns, specified in the row, are present in the table and values for all
-   * non-nullable columns are specified. It also changes the input row by unquoting input column names
+   * non-nullable columns are specified. It also changes the input row by unquoting input column
+   * names
    *
    * @param row the input row
    * @param error the insert error that we return to the customer
@@ -254,12 +255,13 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
     }
 
     /**
-     * In-place replace all items in the input map => column names are replaced with unquoted column names
+     * In-place replace all items in the input map => column names are replaced with unquoted column
+     * names
      */
     for (Map.Entry<String, String> entry : inputColNamesMap.entrySet()) {
       String unquotedColName = entry.getKey();
       String userInputColName = entry.getValue();
-      
+
       Object value = row.remove(userInputColName);
       row.put(unquotedColName, value);
     }
@@ -444,7 +446,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
    * @param statsMap column stats map
    * @return row size
    */
-  abstract float addRow(Map<String, Object> row, int curRowIndex, Map<String, RowBufferStats> statsMap);
+  abstract float addRow(
+      Map<String, Object> row, int curRowIndex, Map<String, RowBufferStats> statsMap);
 
   /**
    * Add an input row to the temporary row buffer.
@@ -457,7 +460,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
    * @param statsMap column stats map
    * @return row size
    */
-  abstract float addTempRow(Map<String, Object> row, int curRowIndex, Map<String, RowBufferStats> statsMap);
+  abstract float addTempRow(
+      Map<String, Object> row, int curRowIndex, Map<String, RowBufferStats> statsMap);
 
   /** Move rows from the temporary buffer to the current row buffer. */
   abstract void moveTempRowsToActualBuffer(int tempRowCount);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -317,6 +317,7 @@ public class RowBufferTest {
     InsertValidationResponse response = rowBuffer.insertRows(Collections.singletonList(row), null);
     Assert.assertFalse(response.hasErrors());
 
+    row = new HashMap<>();
     row.put("colTinyInt", (byte) 1);
     row.put("\"colTinyInt\"", (byte) 1);
     row.put("colSmallInt", (short) 2);


### PR DESCRIPTION
During the lifetime of an input row, we are calling `unquote` for each column name twice. Even though the values are cached now, it is unnecessary because in the input row, we can in-place replace the input column names with their unquoted variants.