### PR TITLE
@snow SNOW-779794 Client SDK Parquet buffer: fix perf degradation due to calling suboptimal lib method per row

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -559,7 +559,6 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       String fullyQualifiedChannelName,
       Consumer<Float> rowSizeMetric,
       ChannelRuntimeState channelRuntimeState,
-      boolean bufferForTests,
       boolean enableParquetMemoryOptimization) {
     switch (bdecVersion) {
       case ONE:
@@ -582,7 +581,6 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
                 fullyQualifiedChannelName,
                 rowSizeMetric,
                 channelRuntimeState,
-                bufferForTests,
                 enableParquetMemoryOptimization);
       default:
         throw new SFException(

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -22,11 +22,8 @@ import net.snowflake.client.jdbc.internal.google.common.collect.Sets;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
-import net.snowflake.ingest.utils.Logging;
-import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.hadoop.BdecParquetWriter;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
@@ -37,11 +34,9 @@ import org.apache.parquet.schema.Type;
  * converted to Parquet format for faster processing
  */
 public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
-  private static final Logging logger = new Logging(ParquetRowBuffer.class);
-
   private static final String PARQUET_MESSAGE_TYPE_NAME = "bdec";
 
-  private final Map<String, Pair<ColumnMetadata, Integer>> fieldIndex;
+  private final Map<String, ParquetColumn> fieldIndex;
 
   /* map that contains metadata like typeinfo for columns and other information needed by the server scanner */
   private final Map<String, String> metadata;
@@ -56,7 +51,6 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   private final String channelName;
 
   private MessageType schema;
-  private final boolean bufferForTests;
   private final boolean enableParquetInternalBuffering;
   /** Construct a ParquetRowBuffer object. */
   ParquetRowBuffer(
@@ -66,7 +60,6 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       String fullyQualifiedChannelName,
       Consumer<Float> rowSizeMetric,
       ChannelRuntimeState channelRuntimeState,
-      boolean bufferForTests,
       boolean enableParquetInternalBuffering) {
     super(
         onErrorOption,
@@ -80,7 +73,6 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
     data = new ArrayList<>();
     tempData = new ArrayList<>();
     channelName = fullyQualifiedChannelName;
-    this.bufferForTests = bufferForTests;
     this.enableParquetInternalBuffering = enableParquetInternalBuffering;
   }
 
@@ -97,7 +89,10 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
           ParquetTypeGenerator.generateColumnParquetTypeInfo(column, id);
       parquetTypes.add(typeInfo.getParquetType());
       this.metadata.putAll(typeInfo.getMetadata());
-      fieldIndex.put(column.getInternalName(), new Pair<>(column, parquetTypes.size() - 1));
+      int columnIndex = parquetTypes.size() - 1;
+      fieldIndex.put(
+          column.getInternalName(),
+          new ParquetColumn(column, columnIndex, typeInfo.getPrimitiveTypeName()));
       if (!column.getNullable()) {
         addNonNullableFieldName(column.getInternalName());
       }
@@ -144,8 +139,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       Map<String, RowBufferStats> statsMap,
       Set<String> formattedInputColumnNames,
       final long insertRowIndex) {
-    return addRow(
-        row, bufferedRowIndex, this::writeRow, statsMap, formattedInputColumnNames, insertRowIndex);
+    return addRow(row, bufferedRowIndex, this::writeRow, statsMap, formattedInputColumnNames);
   }
 
   void writeRow(List<Object> row) {
@@ -163,8 +157,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       Map<String, RowBufferStats> statsMap,
       Set<String> formattedInputColumnNames,
       long insertRowIndex) {
-    return addRow(
-        row, curRowIndex, tempData::add, statsMap, formattedInputColumnNames, insertRowIndex);
+    return addRow(row, curRowIndex, tempData::add, statsMap, formattedInputColumnNames);
   }
 
   /**
@@ -182,8 +175,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       int curRowIndex,
       Consumer<List<Object>> out,
       Map<String, RowBufferStats> statsMap,
-      Set<String> inputColumnNames,
-      final long insertRowIndex) {
+      Set<String> inputColumnNames) {
     Object[] indexedRow = new Object[fieldIndex.size()];
     float size = 0F;
 
@@ -194,16 +186,14 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       String key = entry.getKey();
       Object value = entry.getValue();
       String columnName = LiteralQuoteUtils.unquoteColumnName(key);
-      int colIndex = fieldIndex.get(columnName).getSecond();
+      ParquetColumn parquetColumn = fieldIndex.get(columnName);
+      int colIndex = parquetColumn.index;
       RowBufferStats forkedStats = statsMap.get(columnName).forkEmpty();
       forkedStatsMap.put(columnName, forkedStats);
-      ColumnMetadata column = fieldIndex.get(columnName).getFirst();
-      ColumnDescriptor columnDescriptor = schema.getColumns().get(colIndex);
-      PrimitiveType.PrimitiveTypeName typeName =
-          columnDescriptor.getPrimitiveType().getPrimitiveTypeName();
+      ColumnMetadata column = parquetColumn.columnMetadata;
       ParquetValueParser.ParquetBufferValue valueWithSize =
           ParquetValueParser.parseColumnValueToParquet(
-              value, column, typeName, forkedStats, defaultTimezone, curRowIndex);
+              value, column, parquetColumn.type, forkedStats, defaultTimezone, curRowIndex);
       indexedRow[colIndex] = valueWithSize.getValue();
       size += valueWithSize.getSize();
     }
@@ -262,9 +252,9 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
     if (data == null) {
       return null;
     }
-    int colIndex = fieldIndex.get(column).getSecond();
+    int colIndex = fieldIndex.get(column).index;
     Object value = data.get(index).get(colIndex);
-    ColumnMetadata columnMetadata = fieldIndex.get(column).getFirst();
+    ColumnMetadata columnMetadata = fieldIndex.get(column).columnMetadata;
     String physicalTypeStr = columnMetadata.getPhysicalType();
     ColumnPhysicalType physicalType = ColumnPhysicalType.valueOf(physicalTypeStr);
     String logicalTypeStr = columnMetadata.getLogicalType();
@@ -314,5 +304,18 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   @Override
   public Flusher<ParquetChunkData> createFlusher() {
     return new ParquetFlusher(schema, enableParquetInternalBuffering);
+  }
+
+  private static class ParquetColumn {
+    final ColumnMetadata columnMetadata;
+    final int index;
+    final PrimitiveType.PrimitiveTypeName type;
+
+    private ParquetColumn(
+        ColumnMetadata columnMetadata, int index, PrimitiveType.PrimitiveTypeName type) {
+      this.columnMetadata = columnMetadata;
+      this.index = index;
+      this.type = type;
+    }
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
@@ -42,6 +42,10 @@ public class ParquetTypeGenerator {
     public void setMetadata(Map<String, String> metadata) {
       this.metadata = metadata;
     }
+
+    public PrimitiveType.PrimitiveTypeName getPrimitiveTypeName() {
+      return parquetType.asPrimitiveType().getPrimitiveTypeName();
+    }
   }
 
   private static final Set<AbstractRowBuffer.ColumnPhysicalType> TIME_SUPPORTED_PHYSICAL_TYPES =

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -129,7 +129,6 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
             getFullyQualifiedName(),
             this::collectRowSize,
             channelState,
-            false,
             owningClient != null
                 ? owningClient.getParameterProvider().getEnableParquetInternalBuffering()
                 : ParameterProvider.ENABLE_PARQUET_INTERNAL_BUFFERING_DEFAULT);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -130,7 +130,6 @@ public class RowBufferTest {
         "test.buffer",
         rs -> {},
         initialState,
-        true,
         enableParquetMemoryOptimization);
   }
 


### PR DESCRIPTION
Calling this Parquet lib method in addRow() turned to be very expensive as its implementation is subotimal, `MessageType#getColumns`:
```
ColumnDescriptor columnDescriptor = schema.getColumns().get(colIndex);
      PrimitiveType.PrimitiveTypeName typeName =
          columnDescriptor.getPrimitiveType().getPrimitiveTypeName();
```
Instead we can just cache `PrimitiveTypeName` that we derived in setup method in column metadata index.

@test run DEW locally + precommit