### PR TITLE
@no-snow print stack trace for failing test (StreamingIngestChannelTe…

### DIFF
--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -571,6 +571,7 @@ public class SnowflakeStreamingIngestChannelTest {
       Assert.fail("the insert should be throttled.");
     } catch (TimeoutException ignored) {
     } catch (Exception e) {
+      e.printStackTrace();
       Assert.fail("unexpected exception encountered.");
     }
 
@@ -580,6 +581,7 @@ public class SnowflakeStreamingIngestChannelTest {
     try {
       future.get(5L, TimeUnit.SECONDS);
     } catch (Exception e) {
+      e.printStackTrace();
       Assert.fail("unexpected exception encountered.");
     }
   }


### PR DESCRIPTION
…st.testInsertRowThrottling) on windows.
Occasionally the `Snowpipe Java SDK Tests / build-windows (8) (pull_request)` merge gate fails unexpectedly with 
```
Failed tests: 
  SnowflakeStreamingIngestChannelTest.testInsertRowThrottling:583 unexpected exception encountered.
 ```
 This PR prints the stack trace in the test case.

 