### PR TITLE
@no-snow fix bug in OnErrorOption.Abort for Parquet

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -156,10 +156,6 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
     }
   }
 
-  void writeTempRow(List<Object> row) {
-    tempData.add(row);
-  }
-
   @Override
   float addTempRow(
       Map<String, Object> row,
@@ -168,7 +164,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       Set<String> formattedInputColumnNames,
       long insertRowIndex) {
     return addRow(
-        row, curRowIndex, this::writeTempRow, statsMap, formattedInputColumnNames, insertRowIndex);
+        row, curRowIndex, tempData::add, statsMap, formattedInputColumnNames, insertRowIndex);
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -156,6 +156,10 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
     }
   }
 
+  void writeTempRow(List<Object> row) {
+    tempData.add(row);
+  }
+
   @Override
   float addTempRow(
       Map<String, Object> row,
@@ -164,7 +168,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       Set<String> formattedInputColumnNames,
       long insertRowIndex) {
     return addRow(
-        row, curRowIndex, this::writeRow, statsMap, formattedInputColumnNames, insertRowIndex);
+        row, curRowIndex, this::writeTempRow, statsMap, formattedInputColumnNames, insertRowIndex);
   }
 
   /**


### PR DESCRIPTION
This PR fixes a bug for OnErrorOption.Abort for Parquet. There the rows were being added directly into the data buffer and not in the temporary buffer.