### PR TITLE
NO-SNOW Fix bug for ParquetRowBuffer regarding row Index

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
@@ -199,7 +199,7 @@ class ParquetValueParser {
    * @param precision data type precision
    * @param logicalType Snowflake logical type
    * @param physicalType Snowflake physical type
-   * @param insertRowsCurrIndex
+   * @param insertRowsCurrIndex Used for logging the row of index given in insertRows API
    * @return parsed int32 value
    */
   private static int getInt32Value(
@@ -358,6 +358,7 @@ class ParquetValueParser {
    * @param value value to parse
    * @param stats column stats to update
    * @param columnMetadata column metadata
+   * @param insertRowsCurrIndex Used for logging the row of index given in insertRows API
    * @return string representation
    */
   private static String getBinaryValue(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Constants;
@@ -281,7 +282,7 @@ public class RowBufferTest {
   }
 
   @Test
-  public void testRowIndexWithMultipleRowsWithErrorr() {
+  public void testRowIndexWithMultipleRowsWithError() {
     List<Map<String, Object>> rows = new ArrayList<>();
     Map<String, Object> row = new HashMap<>();
 
@@ -303,6 +304,27 @@ public class RowBufferTest {
     // second row out of the rows we sent was having bad data.
     // so InsertError corresponds to second row.
     Assert.assertEquals(1, response.getInsertErrors().get(0).getRowIndex());
+
+    Assert.assertTrue(response.getInsertErrors().get(0).getException() != null);
+
+    Assert.assertTrue(
+        Objects.equals(
+            response.getInsertErrors().get(0).getException().getVendorCode(),
+            ErrorCode.INVALID_VALUE_ROW.getMessageCode()));
+
+    Assert.assertEquals(1, response.getInsertErrors().get(0).getRowIndex());
+
+    Assert.assertTrue(
+        response
+            .getInsertErrors()
+            .get(0)
+            .getException()
+            .getMessage()
+            .equalsIgnoreCase(
+                "The given row cannot be converted to the internal format due to invalid value:"
+                    + " Value cannot be ingested into Snowflake column COLCHAR of type STRING, Row"
+                    + " Index: 1, reason: String too long: length=22 characters maxLength=11"
+                    + " characters"));
   }
 
   private void testStringLengthHelper(AbstractRowBuffer<?> rowBuffer) {


### PR DESCRIPTION
- Andrey pointed out this. Thanks @sfc-gh-azagrebin 
  - There are two indices used - bufferedRowIndex and insertRowIndex. BufferedRow index was not used in parquetBuffer but was used in arrow. insertRowIndex was introduced earlier 1310e0591491647696aeb755d5b4ecbf0d1b1c67 but was incorrectly used in parquet buffer. The index used there was bufferedRowIndex. Since we didnt use the bufferedRowIndex anywhere in parquetBuffer, I replaced it with `insertRowsBuffer`