### PR TITLE
SNOW-796657 Avoid unnecessary String#getBytes allocations

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowRowBuffer.java
@@ -505,7 +505,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
           case TEXT:
             {
               String maxLengthString = field.getMetadata().get(COLUMN_CHAR_LENGTH);
-              String str =
+              byte[] str =
                   DataValidationUtil.validateAndParseString(
                       forkedStats.getColumnDisplayName(),
                       value,
@@ -513,13 +513,13 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
                       insertRowsCurrIndex);
               Text text = new Text(str);
               ((VarCharVector) vector).setSafe(bufferedRowIndex, text);
-              forkedStats.addStrValue(str);
+              forkedStats.addBinaryValue(str);
               rowBufferSize += text.getBytes().length;
               break;
             }
           case OBJECT:
             {
-              String str =
+              byte[] str =
                   DataValidationUtil.validateAndParseObject(
                       forkedStats.getColumnDisplayName(), value, insertRowsCurrIndex);
               Text text = new Text(str);
@@ -529,7 +529,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
             }
           case ARRAY:
             {
-              String str =
+              byte[] str =
                   DataValidationUtil.validateAndParseArray(
                       forkedStats.getColumnDisplayName(), value, insertRowsCurrIndex);
               Text text = new Text(str);
@@ -539,7 +539,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
             }
           case VARIANT:
             {
-              String str =
+              byte[] str =
                   DataValidationUtil.validateAndParseVariant(
                       forkedStats.getColumnDisplayName(), value, insertRowsCurrIndex);
               if (str != null) {
@@ -803,7 +803,7 @@ class ArrowRowBuffer extends AbstractRowBuffer<VectorSchemaRoot> {
   @Override
   Object getVectorValueAt(String column, int index) {
     Object value = vectorsRoot.getVector(column).getObject(index);
-    return (value instanceof Text) ? new String(((Text) value).getBytes()) : value;
+    return (value instanceof Text) ? ((Text) value).getBytes() : value;
   }
 
   @VisibleForTesting

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -8,7 +8,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -272,9 +271,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
         value = new BigDecimal(new BigInteger((byte[]) value), columnMetadata.getScale());
       }
     }
-    if (logicalType == ColumnLogicalType.BINARY && value != null) {
-      value = value instanceof String ? ((String) value).getBytes(StandardCharsets.UTF_8) : value;
-    }
+
     return value;
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetValueParser.java
@@ -147,10 +147,10 @@ class ParquetValueParser {
                 getBinaryValueForLogicalBinary(value, stats, columnMetadata, insertRowsCurrIndex);
             length = ((byte[]) value).length;
           } else {
-            String str = getBinaryValue(value, stats, columnMetadata, insertRowsCurrIndex);
+            byte[] str = getBinaryValue(value, stats, columnMetadata, insertRowsCurrIndex);
             value = str;
             if (str != null) {
-              length = str.getBytes().length;
+              length = str.length;
             }
           }
           if (value != null) {
@@ -361,14 +361,14 @@ class ParquetValueParser {
    * @param insertRowsCurrIndex Used for logging the row of index given in insertRows API
    * @return string representation
    */
-  private static String getBinaryValue(
+  private static byte[] getBinaryValue(
       Object value,
       RowBufferStats stats,
       ColumnMetadata columnMetadata,
       final long insertRowsCurrIndex) {
     AbstractRowBuffer.ColumnLogicalType logicalType =
         AbstractRowBuffer.ColumnLogicalType.valueOf(columnMetadata.getLogicalType());
-    String str;
+    byte[] str;
     if (logicalType.isObject()) {
       switch (logicalType) {
         case OBJECT:
@@ -398,7 +398,7 @@ class ParquetValueParser {
               value,
               Optional.of(maxLengthString).map(Integer::parseInt),
               insertRowsCurrIndex);
-      stats.addStrValue(str);
+      stats.addBinaryValue(str);
     }
     return str;
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -7,7 +7,6 @@ package net.snowflake.ingest.streaming.internal;
 import static net.snowflake.ingest.utils.Constants.EP_NDV_UNKNOWN;
 
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
@@ -104,10 +103,7 @@ class RowBufferStats {
     return combined;
   }
 
-  void addStrValue(String value) {
-    addBinaryValue(value.getBytes(StandardCharsets.UTF_8));
-  }
-
+  /** Add statistics for binary or varchar column */
   void addBinaryValue(byte[] valueBytes) {
     this.setCurrentMaxLength(valueBytes.length);
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelDataTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelDataTest.java
@@ -94,11 +94,11 @@ public class ChannelDataTest {
     rightStats1.addIntValue(new BigInteger("13"));
     rightStats1.addIntValue(new BigInteger("17"));
 
-    leftStats2.addStrValue("10");
-    leftStats2.addStrValue("15");
-    rightStats2.addStrValue("11");
-    rightStats2.addStrValue("13");
-    rightStats2.addStrValue("17");
+    leftStats2.addBinaryValue("10".getBytes(StandardCharsets.UTF_8));
+    leftStats2.addBinaryValue("15".getBytes(StandardCharsets.UTF_8));
+    rightStats2.addBinaryValue("11".getBytes(StandardCharsets.UTF_8));
+    rightStats2.addBinaryValue("13".getBytes(StandardCharsets.UTF_8));
+    rightStats2.addBinaryValue("17".getBytes(StandardCharsets.UTF_8));
 
     Map<String, RowBufferStats> result = ChannelData.getCombinedColumnStatsMap(left, right);
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -383,16 +383,21 @@ public class DataValidationUtilTest {
 
   @Test
   public void testValidateAndParseString() {
-    assertEquals("honk", validateAndParseString("COL", "honk", Optional.empty(), 0));
+    assertArrayEquals(
+        "honk".getBytes(StandardCharsets.UTF_8),
+        validateAndParseString("COL", "honk", Optional.empty(), 0));
 
     // Check max byte length
     String maxString = buildString("a", BYTES_16_MB);
-    assertEquals(maxString, validateAndParseString("COL", maxString, Optional.empty(), 0));
+    assertArrayEquals(
+        maxString.getBytes(StandardCharsets.UTF_8),
+        validateAndParseString("COL", maxString, Optional.empty(), 0));
 
     // max byte length - 1 should also succeed
     String maxStringMinusOne = buildString("a", BYTES_16_MB - 1);
-    assertEquals(
-        maxStringMinusOne, validateAndParseString("COL", maxStringMinusOne, Optional.empty(), 0));
+    assertArrayEquals(
+        maxStringMinusOne.getBytes(StandardCharsets.UTF_8),
+        validateAndParseString("COL", maxStringMinusOne, Optional.empty(), 0));
 
     // max byte length + 1 should fail
     expectError(
@@ -400,10 +405,18 @@ public class DataValidationUtilTest {
         () -> validateAndParseString("COL", maxString + "a", Optional.empty(), 0));
 
     // Test that max character length validation counts characters and not bytes
-    assertEquals("a", validateAndParseString("COL", "a", Optional.of(1), 0));
-    assertEquals("č", validateAndParseString("COL", "č", Optional.of(1), 0));
-    assertEquals("❄", validateAndParseString("COL", "❄", Optional.of(1), 0));
-    assertEquals("🍞", validateAndParseString("COL", "🍞", Optional.of(1), 0));
+    assertArrayEquals(
+        "a".getBytes(StandardCharsets.UTF_8),
+        validateAndParseString("COL", "a", Optional.of(1), 0));
+    assertArrayEquals(
+        "č".getBytes(StandardCharsets.UTF_8),
+        validateAndParseString("COL", "č", Optional.of(1), 0));
+    assertArrayEquals(
+        "❄".getBytes(StandardCharsets.UTF_8),
+        validateAndParseString("COL", "❄", Optional.of(1), 0));
+    assertArrayEquals(
+        "🍞".getBytes(StandardCharsets.UTF_8),
+        validateAndParseString("COL", "🍞", Optional.of(1), 0));
 
     // Test max character length rejection
     expectError(
@@ -438,35 +451,52 @@ public class DataValidationUtilTest {
 
   @Test
   public void testValidateAndParseVariant() throws Exception {
-    assertEquals("1", validateAndParseVariant("COL", 1, 0));
-    assertEquals("1", validateAndParseVariant("COL", "1", 0));
-    assertEquals("1", validateAndParseVariant("COL", "                          1   ", 0));
+    assertArrayEquals("1".getBytes(StandardCharsets.UTF_8), validateAndParseVariant("COL", 1, 0));
+    assertArrayEquals("1".getBytes(StandardCharsets.UTF_8), validateAndParseVariant("COL", "1", 0));
+    assertArrayEquals(
+        "1".getBytes(StandardCharsets.UTF_8),
+        validateAndParseVariant("COL", "                          1   ", 0));
     String stringVariant = "{\"key\":1}";
-    assertEquals(stringVariant, validateAndParseVariant("COL", stringVariant, 0));
-    assertEquals(stringVariant, validateAndParseVariant("COL", "  " + stringVariant + " \t\n", 0));
+    assertArrayEquals(
+        stringVariant.getBytes(StandardCharsets.UTF_8),
+        validateAndParseVariant("COL", stringVariant, 0));
+    assertArrayEquals(
+        stringVariant.getBytes(StandardCharsets.UTF_8),
+        validateAndParseVariant("COL", "  " + stringVariant + " \t\n", 0));
 
     // Test custom serializers
-    assertEquals(
-        "[-128,0,127]",
+    assertArrayEquals(
+        "[-128,0,127]".getBytes(StandardCharsets.UTF_8),
         validateAndParseVariant("COL", new byte[] {Byte.MIN_VALUE, 0, Byte.MAX_VALUE}, 0));
-    assertEquals(
-        "\"2022-09-28T03:04:12.123456789-07:00\"",
+    assertArrayEquals(
+        "\"2022-09-28T03:04:12.123456789-07:00\"".getBytes(StandardCharsets.UTF_8),
         validateAndParseVariant(
             "COL",
             ZonedDateTime.of(2022, 9, 28, 3, 4, 12, 123456789, ZoneId.of("America/Los_Angeles")),
             0));
 
     // Test valid JSON tokens
-    assertEquals("null", validateAndParseVariant("COL", null, 0));
-    assertEquals("null", validateAndParseVariant("COL", "null", 0));
-    assertEquals("true", validateAndParseVariant("COL", true, 0));
-    assertEquals("true", validateAndParseVariant("COL", "true", 0));
-    assertEquals("false", validateAndParseVariant("COL", false, 0));
-    assertEquals("false", validateAndParseVariant("COL", "false", 0));
-    assertEquals("{}", validateAndParseVariant("COL", "{}", 0));
-    assertEquals("[]", validateAndParseVariant("COL", "[]", 0));
-    assertEquals("[\"foo\",1,null]", validateAndParseVariant("COL", "[\"foo\",1,null]", 0));
-    assertEquals("\"\"", validateAndParseVariant("COL", "\"\"", 0));
+    assertArrayEquals(
+        "null".getBytes(StandardCharsets.UTF_8), validateAndParseVariant("COL", null, 0));
+    assertArrayEquals(
+        "null".getBytes(StandardCharsets.UTF_8), validateAndParseVariant("COL", "null", 0));
+    assertArrayEquals(
+        "true".getBytes(StandardCharsets.UTF_8), validateAndParseVariant("COL", true, 0));
+    assertArrayEquals(
+        "true".getBytes(StandardCharsets.UTF_8), validateAndParseVariant("COL", "true", 0));
+    assertArrayEquals(
+        "false".getBytes(StandardCharsets.UTF_8), validateAndParseVariant("COL", false, 0));
+    assertArrayEquals(
+        "false".getBytes(StandardCharsets.UTF_8), validateAndParseVariant("COL", "false", 0));
+    assertArrayEquals(
+        "{}".getBytes(StandardCharsets.UTF_8), validateAndParseVariant("COL", "{}", 0));
+    assertArrayEquals(
+        "[]".getBytes(StandardCharsets.UTF_8), validateAndParseVariant("COL", "[]", 0));
+    assertArrayEquals(
+        "[\"foo\",1,null]".getBytes(StandardCharsets.UTF_8),
+        validateAndParseVariant("COL", "[\"foo\",1,null]", 0));
+    assertArrayEquals(
+        "\"\"".getBytes(StandardCharsets.UTF_8), validateAndParseVariant("COL", "\"\"", 0));
 
     // Test missing values are null instead of empty string
     assertNull(validateAndParseVariant("COL", "", 0));
@@ -504,41 +534,62 @@ public class DataValidationUtilTest {
   }
 
   @Test
-  public void testValidateAndParseArray() throws Exception {
-    assertEquals("[1]", validateAndParseArray("COL", 1, 0));
-    assertEquals("[1]", validateAndParseArray("COL", "1", 0));
-    assertEquals("[1]", validateAndParseArray("COL", "                          1   ", 0));
-    assertEquals("[1,2,3]", validateAndParseArray("COL", "[1, 2, 3]", 0));
-    assertEquals("[1,2,3]", validateAndParseArray("COL", "  [1, 2, 3] \t\n", 0));
+  public void testValidateAndParseArray() {
+    assertArrayEquals("[1]".getBytes(StandardCharsets.UTF_8), validateAndParseArray("COL", 1, 0));
+    assertArrayEquals("[1]".getBytes(StandardCharsets.UTF_8), validateAndParseArray("COL", "1", 0));
+    assertArrayEquals(
+        "[1]".getBytes(StandardCharsets.UTF_8),
+        validateAndParseArray("COL", "                          1   ", 0));
+    assertArrayEquals(
+        "[1,2,3]".getBytes(StandardCharsets.UTF_8), validateAndParseArray("COL", "[1, 2, 3]", 0));
+    assertArrayEquals(
+        "[1,2,3]".getBytes(StandardCharsets.UTF_8),
+        validateAndParseArray("COL", "  [1, 2, 3] \t\n", 0));
     int[] intArray = new int[] {1, 2, 3};
-    assertEquals("[1,2,3]", validateAndParseArray("COL", intArray, 0));
+    assertArrayEquals(
+        "[1,2,3]".getBytes(StandardCharsets.UTF_8), validateAndParseArray("COL", intArray, 0));
 
     String[] stringArray = new String[] {"a", "b", "c"};
-    assertEquals("[\"a\",\"b\",\"c\"]", validateAndParseArray("COL", stringArray, 0));
+    assertArrayEquals(
+        "[\"a\",\"b\",\"c\"]".getBytes(StandardCharsets.UTF_8),
+        validateAndParseArray("COL", stringArray, 0));
 
     Object[] objectArray = new Object[] {1, 2, 3};
-    assertEquals("[1,2,3]", validateAndParseArray("COL", objectArray, 0));
+    assertArrayEquals(
+        "[1,2,3]".getBytes(StandardCharsets.UTF_8), validateAndParseArray("COL", objectArray, 0));
 
     Object[] ObjectArrayWithNull = new Object[] {1, null, 3};
-    assertEquals("[1,null,3]", validateAndParseArray("COL", ObjectArrayWithNull, 0));
+    assertArrayEquals(
+        "[1,null,3]".getBytes(StandardCharsets.UTF_8),
+        validateAndParseArray("COL", ObjectArrayWithNull, 0));
 
     Object[][] nestedArray = new Object[][] {{1, 2, 3}, null, {4, 5, 6}};
-    assertEquals("[[1,2,3],null,[4,5,6]]", validateAndParseArray("COL", nestedArray, 0));
+    assertArrayEquals(
+        "[[1,2,3],null,[4,5,6]]".getBytes(StandardCharsets.UTF_8),
+        validateAndParseArray("COL", nestedArray, 0));
 
     List<Integer> intList = Arrays.asList(1, 2, 3);
-    assertEquals("[1,2,3]", validateAndParseArray("COL", intList, 0));
+    assertArrayEquals(
+        "[1,2,3]".getBytes(StandardCharsets.UTF_8), validateAndParseArray("COL", intList, 0));
 
     List<Object> objectList = Arrays.asList(1, 2, 3);
-    assertEquals("[1,2,3]", validateAndParseArray("COL", objectList, 0));
+    assertArrayEquals(
+        "[1,2,3]".getBytes(StandardCharsets.UTF_8), validateAndParseArray("COL", objectList, 0));
 
     List<Object> nestedList = Arrays.asList(Arrays.asList(1, 2, 3), 2, 3);
-    assertEquals("[[1,2,3],2,3]", validateAndParseArray("COL", nestedList, 0));
+    assertArrayEquals(
+        "[[1,2,3],2,3]".getBytes(StandardCharsets.UTF_8),
+        validateAndParseArray("COL", nestedList, 0));
 
     // Test null values
-    assertEquals("[null]", validateAndParseArray("COL", "", 0));
-    assertEquals("[null]", validateAndParseArray("COL", " ", 0));
-    assertEquals("[null]", validateAndParseArray("COL", "null", 0));
-    assertEquals("[null]", validateAndParseArray("COL", null, 0));
+    assertArrayEquals(
+        "[null]".getBytes(StandardCharsets.UTF_8), validateAndParseArray("COL", "", 0));
+    assertArrayEquals(
+        "[null]".getBytes(StandardCharsets.UTF_8), validateAndParseArray("COL", " ", 0));
+    assertArrayEquals(
+        "[null]".getBytes(StandardCharsets.UTF_8), validateAndParseArray("COL", "null", 0));
+    assertArrayEquals(
+        "[null]".getBytes(StandardCharsets.UTF_8), validateAndParseArray("COL", null, 0));
 
     // Test that invalid UTF-8 strings cannot be ingested
     expectError(
@@ -572,8 +623,12 @@ public class DataValidationUtilTest {
   @Test
   public void testValidateAndParseObject() throws Exception {
     String stringObject = "{\"key\":1}";
-    assertEquals(stringObject, validateAndParseObject("COL", stringObject, 0));
-    assertEquals(stringObject, validateAndParseObject("COL", "  " + stringObject + " \t\n", 0));
+    assertArrayEquals(
+        stringObject.getBytes(StandardCharsets.UTF_8),
+        validateAndParseObject("COL", stringObject, 0));
+    assertArrayEquals(
+        stringObject.getBytes(StandardCharsets.UTF_8),
+        validateAndParseObject("COL", "  " + stringObject + " \t\n", 0));
 
     String badObject = "foo";
     try {
@@ -845,7 +900,7 @@ public class DataValidationUtilTest {
         Hex.decodeHex("1234567890abcdef"), // pragma: allowlist secret NOT A SECRET
         validateAndParseBinary(
             "COL",
-            "1234567890abcdef",
+            "1234567890abcdef", // pragma: allowlist secret NOT A SECRET
             Optional.empty(),
             0)); // pragma: allowlist secret NOT A SECRET
     assertArrayEquals(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FileColumnPropertiesTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FileColumnPropertiesTest.java
@@ -1,5 +1,6 @@
 package net.snowflake.ingest.streaming.internal;
 
+import java.nio.charset.StandardCharsets;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -9,8 +10,8 @@ public class FileColumnPropertiesTest {
   public void testFileColumnPropertiesConstructor() {
     // Test simple construction
     RowBufferStats stats = new RowBufferStats("COL");
-    stats.addStrValue("bcd");
-    stats.addStrValue("abcde");
+    stats.addBinaryValue("bcd".getBytes(StandardCharsets.UTF_8));
+    stats.addBinaryValue("abcde".getBytes(StandardCharsets.UTF_8));
     FileColumnProperties props = new FileColumnProperties(stats);
     Assert.assertEquals("6162636465", props.getMinStrValue());
     Assert.assertNull(props.getMinStrNonCollated());
@@ -19,7 +20,7 @@ public class FileColumnPropertiesTest {
 
     // Test that truncation is performed
     stats = new RowBufferStats("COL");
-    stats.addStrValue("aßßßßßßßßßßßßßßßß");
+    stats.addBinaryValue("aßßßßßßßßßßßßßßßß".getBytes(StandardCharsets.UTF_8));
     Assert.assertEquals(33, stats.getCurrentMinStrValue().length);
     props = new FileColumnProperties(stats);
     Assert.assertNull(props.getMinStrNonCollated());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
@@ -297,8 +297,8 @@ public class ParquetValueParserTest {
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
-        .expectedValueClass(String.class)
-        .expectedParsedValue(var)
+        .expectedValueClass(byte[].class)
+        .expectedParsedValue(var.getBytes(StandardCharsets.UTF_8))
         .expectedSize(
             BYTE_ARRAY_LENGTH_ENCODING_BYTE_LEN
                 + var.getBytes().length
@@ -365,16 +365,16 @@ public class ParquetValueParserTest {
         ParquetValueParser.parseColumnValueToParquet(
             input, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0);
 
-    String resultArray = "[{\"a\":\"1\",\"b\":\"2\",\"c\":\"3\"}]";
+    byte[] resultArray = "[{\"a\":\"1\",\"b\":\"2\",\"c\":\"3\"}]".getBytes(StandardCharsets.UTF_8);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
-        .expectedValueClass(String.class)
+        .expectedValueClass(byte[].class)
         .expectedParsedValue(resultArray)
         .expectedSize(
             BYTE_ARRAY_LENGTH_ENCODING_BYTE_LEN
-                + resultArray.length()
+                + resultArray.length
                 + DEFINITION_LEVEL_ENCODING_BYTE_LEN)
         .expectedMinMax(null)
         .assertMatches();
@@ -402,8 +402,8 @@ public class ParquetValueParserTest {
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
-        .expectedValueClass(String.class)
-        .expectedParsedValue(result)
+        .expectedValueClass(byte[].class)
+        .expectedParsedValue(result.getBytes(StandardCharsets.UTF_8))
         .expectedSize(
             BYTE_ARRAY_LENGTH_ENCODING_BYTE_LEN
                 + result.length()
@@ -669,7 +669,7 @@ public class ParquetValueParserTest {
         Assert.assertArrayEquals((byte[]) minMaxStat, rowBufferStats.getCurrentMinStrValue());
         Assert.assertArrayEquals((byte[]) minMaxStat, rowBufferStats.getCurrentMaxStrValue());
         return;
-      } else if (valueClass.equals(String.class)) {
+      } else if (valueClass.equals(byte[].class)) {
         // String can have null min/max stats for variant data types
         Object min =
             rowBufferStats.getCurrentMinStrValue() != null

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
@@ -27,18 +27,18 @@ public class RowBufferStatsTest {
   public void testMinMaxStrNonCol() throws Exception {
     RowBufferStats stats = new RowBufferStats("COL1");
 
-    stats.addStrValue("bob");
+    stats.addBinaryValue("bob".getBytes(StandardCharsets.UTF_8));
     Assert.assertArrayEquals("bob".getBytes(StandardCharsets.UTF_8), stats.getCurrentMinStrValue());
     Assert.assertArrayEquals("bob".getBytes(StandardCharsets.UTF_8), stats.getCurrentMaxStrValue());
     Assert.assertEquals(-1, stats.getDistinctValues());
 
-    stats.addStrValue("charlie");
+    stats.addBinaryValue("charlie".getBytes(StandardCharsets.UTF_8));
     Assert.assertArrayEquals("bob".getBytes(StandardCharsets.UTF_8), stats.getCurrentMinStrValue());
     Assert.assertArrayEquals(
         "charlie".getBytes(StandardCharsets.UTF_8), stats.getCurrentMaxStrValue());
     Assert.assertEquals(-1, stats.getDistinctValues());
 
-    stats.addStrValue("alice");
+    stats.addBinaryValue("alice".getBytes(StandardCharsets.UTF_8));
     Assert.assertArrayEquals(
         "alice".getBytes(StandardCharsets.UTF_8), stats.getCurrentMinStrValue());
     Assert.assertArrayEquals(
@@ -188,17 +188,17 @@ public class RowBufferStatsTest {
     one = new RowBufferStats("COL1");
     two = new RowBufferStats("COL1");
 
-    one.addStrValue("alpha");
-    one.addStrValue("d");
-    one.addStrValue("f");
-    one.addStrValue("g");
+    one.addBinaryValue("alpha".getBytes(StandardCharsets.UTF_8));
+    one.addBinaryValue("d".getBytes(StandardCharsets.UTF_8));
+    one.addBinaryValue("f".getBytes(StandardCharsets.UTF_8));
+    one.addBinaryValue("g".getBytes(StandardCharsets.UTF_8));
     one.incCurrentNullCount();
     one.setCurrentMaxLength(5);
 
-    two.addStrValue("a");
-    two.addStrValue("b");
-    two.addStrValue("c");
-    two.addStrValue("d");
+    two.addBinaryValue("a".getBytes(StandardCharsets.UTF_8));
+    two.addBinaryValue("b".getBytes(StandardCharsets.UTF_8));
+    two.addBinaryValue("c".getBytes(StandardCharsets.UTF_8));
+    two.addBinaryValue("d".getBytes(StandardCharsets.UTF_8));
     two.incCurrentNullCount();
     two.setCurrentMaxLength(1);
 
@@ -262,10 +262,10 @@ public class RowBufferStatsTest {
     one = new RowBufferStats("COL1");
     two = new RowBufferStats("COL1");
 
-    one.addStrValue("alpha");
-    one.addStrValue("d");
-    one.addStrValue("f");
-    one.addStrValue("g");
+    one.addBinaryValue("alpha".getBytes(StandardCharsets.UTF_8));
+    one.addBinaryValue("d".getBytes(StandardCharsets.UTF_8));
+    one.addBinaryValue("f".getBytes(StandardCharsets.UTF_8));
+    one.addBinaryValue("g".getBytes(StandardCharsets.UTF_8));
     one.incCurrentNullCount();
 
     result = RowBufferStats.getCombinedStats(one, two);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -536,8 +536,8 @@ public class RowBufferTest {
     stats1.addIntValue(BigInteger.valueOf(1));
 
     RowBufferStats stats2 = new RowBufferStats("strColumn");
-    stats2.addStrValue("alice");
-    stats2.addStrValue("bob");
+    stats2.addBinaryValue("alice".getBytes(StandardCharsets.UTF_8));
+    stats2.addBinaryValue("bob".getBytes(StandardCharsets.UTF_8));
     stats2.incCurrentNullCount();
 
     colStats.put("intColumn", stats1);
@@ -611,7 +611,7 @@ public class RowBufferTest {
     stats1.addIntValue(BigInteger.valueOf(1));
 
     RowBufferStats stats2 = new RowBufferStats("strColumn");
-    stats2.addStrValue("alice");
+    stats2.addBinaryValue("alice".getBytes(StandardCharsets.UTF_8));
     stats2.incCurrentNullCount();
     stats2.incCurrentNullCount();
 
@@ -651,7 +651,8 @@ public class RowBufferTest {
     Assert.assertEquals(3, rowBuffer.getVectorValueAt("COLINT", 0));
     Assert.assertEquals(4L, rowBuffer.getVectorValueAt("COLBIGINT", 0));
     Assert.assertEquals(new BigDecimal("4.00"), rowBuffer.getVectorValueAt("COLDECIMAL", 0));
-    Assert.assertEquals("2", rowBuffer.getVectorValueAt("COLCHAR", 0));
+    Assert.assertArrayEquals(
+        "2".getBytes(StandardCharsets.UTF_8), (byte[]) rowBuffer.getVectorValueAt("COLCHAR", 0));
   }
 
   @Test
@@ -1433,9 +1434,15 @@ public class RowBufferTest {
     // Check data was inserted into the buffer correctly
     Assert.assertNull(null, innerBuffer.getVectorValueAt("COLVARIANT", 0));
     Assert.assertNull(null, innerBuffer.getVectorValueAt("COLVARIANT", 1));
-    Assert.assertEquals("null", innerBuffer.getVectorValueAt("COLVARIANT", 2));
-    Assert.assertEquals("{\"key\":1}", innerBuffer.getVectorValueAt("COLVARIANT", 3));
-    Assert.assertEquals("3", innerBuffer.getVectorValueAt("COLVARIANT", 4));
+    Assert.assertArrayEquals(
+        "null".getBytes(StandardCharsets.UTF_8),
+        (byte[]) innerBuffer.getVectorValueAt("COLVARIANT", 2));
+    Assert.assertArrayEquals(
+        "{\"key\":1}".getBytes(StandardCharsets.UTF_8),
+        (byte[]) innerBuffer.getVectorValueAt("COLVARIANT", 3));
+    Assert.assertArrayEquals(
+        "3".getBytes(StandardCharsets.UTF_8),
+        (byte[]) innerBuffer.getVectorValueAt("COLVARIANT", 4));
 
     // Check stats generation
     ChannelData<?> result = innerBuffer.flush("my_snowpipe_streaming.bdec");
@@ -1467,7 +1474,9 @@ public class RowBufferTest {
     Assert.assertFalse(response.hasErrors());
 
     // Check data was inserted into the buffer correctly
-    Assert.assertEquals("{\"key\":1}", innerBuffer.getVectorValueAt("COLOBJECT", 0));
+    Assert.assertArrayEquals(
+        "{\"key\":1}".getBytes(StandardCharsets.UTF_8),
+        (byte[]) innerBuffer.getVectorValueAt("COLOBJECT", 0));
 
     // Check stats generation
     ChannelData<?> result = innerBuffer.flush("my_snowpipe_streaming.bdec");
@@ -1512,10 +1521,18 @@ public class RowBufferTest {
 
     // Check data was inserted into the buffer correctly
     Assert.assertNull(innerBuffer.getVectorValueAt("COLARRAY", 0));
-    Assert.assertEquals("[null]", innerBuffer.getVectorValueAt("COLARRAY", 1));
-    Assert.assertEquals("[null]", innerBuffer.getVectorValueAt("COLARRAY", 2));
-    Assert.assertEquals("[{\"key\":1}]", innerBuffer.getVectorValueAt("COLARRAY", 3));
-    Assert.assertEquals("[1,2,3]", innerBuffer.getVectorValueAt("COLARRAY", 4));
+    Assert.assertArrayEquals(
+        "[null]".getBytes(StandardCharsets.UTF_8),
+        (byte[]) innerBuffer.getVectorValueAt("COLARRAY", 1));
+    Assert.assertArrayEquals(
+        "[null]".getBytes(StandardCharsets.UTF_8),
+        (byte[]) innerBuffer.getVectorValueAt("COLARRAY", 2));
+    Assert.assertArrayEquals(
+        "[{\"key\":1}]".getBytes(StandardCharsets.UTF_8),
+        (byte[]) innerBuffer.getVectorValueAt("COLARRAY", 3));
+    Assert.assertArrayEquals(
+        "[1,2,3]".getBytes(StandardCharsets.UTF_8),
+        (byte[]) innerBuffer.getVectorValueAt("COLARRAY", 4));
 
     // Check stats generation
     ChannelData<?> result = innerBuffer.flush("my_snowpipe_streaming.bdec");
@@ -1581,22 +1598,23 @@ public class RowBufferTest {
             ((ParquetChunkData) innerBufferOnErrorContinue.getSnapshot("fake/filePath").get()).rows;
         // validRows and only the good row from mixedRows are in the buffer
         Assert.assertEquals(2, snapshotContinueParquet.size());
-        Assert.assertEquals(Arrays.asList("a"), snapshotContinueParquet.get(0));
-        Assert.assertEquals(Arrays.asList("b"), snapshotContinueParquet.get(1));
+        Assert.assertEquals(1, snapshotContinueParquet.get(0).size());
+        Assert.assertEquals(1, snapshotContinueParquet.get(1).size());
+        Assert.assertArrayEquals(
+            "a".getBytes(StandardCharsets.UTF_8), (byte[]) snapshotContinueParquet.get(0).get(0));
+        Assert.assertArrayEquals(
+            "b".getBytes(StandardCharsets.UTF_8), (byte[]) snapshotContinueParquet.get(1).get(0));
 
         List<List<Object>> snapshotAbortParquet =
             ((ParquetChunkData) innerBufferOnErrorAbort.getSnapshot("fake/filePath").get()).rows;
         // only validRows and none of the mixedRows are in the buffer
         Assert.assertEquals(1, snapshotAbortParquet.size());
-        Assert.assertEquals(Arrays.asList("a"), snapshotAbortParquet.get(0));
+        Assert.assertEquals(1, snapshotAbortParquet.get(0).size());
+        Assert.assertArrayEquals(
+            "a".getBytes(StandardCharsets.UTF_8), (byte[]) snapshotAbortParquet.get(0).get(0));
         break;
       default:
         throw new NotImplementedException("Unsupported version!");
-    }
-    if (bdecVersion == Constants.BdecVersion.THREE) {
-
-    } else if (bdecVersion == Constants.BdecVersion.ONE) {
-
     }
   }
 }


### PR DESCRIPTION
Some calls to `String#getBytes` we are making are not necessary. This PR restructures the code, so that we can String#getBytes once early after receiving the string from the user. 

Affected data types are `VARCHAR`, `VARIANT`, `OBJECT` and `ARRAY`.