### PR TITLE
NO-SNOW Fix flaky Windows test

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProvider.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProvider.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+/** Provider information about available system memory */
+public interface MemoryInfoProvider {
+  long getMaxMemory();
+
+  long getTotalMemory();
+
+  long getFreeMemory();
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProvider.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProvider.java
@@ -6,9 +6,12 @@ package net.snowflake.ingest.streaming.internal;
 
 /** Provider information about available system memory */
 public interface MemoryInfoProvider {
+  /** @return Max memory the JVM can allocate */
   long getMaxMemory();
 
+  /** @return Total allocated JVM memory so far */
   long getTotalMemory();
 
+  /** @return Free JVM memory */
   long getFreeMemory();
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProviderFromRuntime.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProviderFromRuntime.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+/** Reads memory information from JVM runtime */
+public class MemoryInfoProviderFromRuntime implements MemoryInfoProvider {
+  @Override
+  public long getMaxMemory() {
+    return Runtime.getRuntime().maxMemory();
+  }
+
+  @Override
+  public long getTotalMemory() {
+    return Runtime.getRuntime().totalMemory();
+  }
+
+  @Override
+  public long getFreeMemory() {
+    return Runtime.getRuntime().freeMemory();
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -346,7 +346,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   @Override
   public InsertValidationResponse insertRows(
       Iterable<Map<String, Object>> rows, String offsetToken) {
-    throttleInsertIfNeeded(Runtime.getRuntime());
+    throttleInsertIfNeeded(new MemoryInfoProviderFromRuntime());
     checkValidation();
 
     if (isClosed()) {
@@ -399,11 +399,11 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   }
 
   /** Check whether we need to throttle the insertRows API */
-  void throttleInsertIfNeeded(Runtime runtime) {
+  void throttleInsertIfNeeded(MemoryInfoProvider memoryInfoProvider) {
     int retry = 0;
     long insertThrottleIntervalInMs =
         this.owningClient.getParameterProvider().getInsertThrottleIntervalInMs();
-    while ((hasLowRuntimeMemory(runtime)
+    while ((hasLowRuntimeMemory(memoryInfoProvider)
             || (this.owningClient.getFlushService() != null
                 && this.owningClient.getFlushService().throttleDueToQueuedFlushTasks()))
         && retry < INSERT_THROTTLE_MAX_RETRY_COUNT) {
@@ -425,7 +425,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   }
 
   /** Check whether we have a low runtime memory condition */
-  private boolean hasLowRuntimeMemory(Runtime runtime) {
+  private boolean hasLowRuntimeMemory(MemoryInfoProvider memoryInfoProvider) {
     int insertThrottleThresholdInBytes =
         this.owningClient.getParameterProvider().getInsertThrottleThresholdInBytes();
     int insertThrottleThresholdInPercentage =
@@ -434,9 +434,11 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
         this.owningClient.getParameterProvider().getMaxMemoryLimitInBytes();
     long maxMemory =
         maxMemoryLimitInBytes == MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT
-            ? runtime.maxMemory()
+            ? memoryInfoProvider.getMaxMemory()
             : maxMemoryLimitInBytes;
-    long freeMemory = runtime.freeMemory() + (runtime.maxMemory() - runtime.totalMemory());
+    long freeMemory =
+        memoryInfoProvider.getFreeMemory()
+            + (memoryInfoProvider.getMaxMemory() - memoryInfoProvider.getTotalMemory());
     boolean hasLowRuntimeMemory =
         freeMemory < insertThrottleThresholdInBytes
             && freeMemory * 100 / maxMemory < insertThrottleThresholdInPercentage;


### PR DESCRIPTION
The test `SnowflakeStreamingIngestChannelTest#testInsertRowThrottling` is flaky on Windows. The reason is that we are using mockito to mock methods from java.lang.Runtime in one thread and read them in another. These changes are not always guaranteed to be visible in the other thread.

This PR introduces a new interface with two implementations to provide memory info, so we don't need to mock anything anymore.