### PR TITLE
Revert "SNOW-787565: Use dynamic scaling thread pool instead of fixed…

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -320,13 +319,7 @@ class FlushService<T> {
                 * (1 + this.owningClient.getParameterProvider().getIOTimeCpuRatio()),
             MAX_THREAD_COUNT);
     this.buildUploadWorkers =
-        new ThreadPoolExecutor(
-            1,
-            buildUploadThreadCount,
-            60L,
-            TimeUnit.SECONDS,
-            new SynchronousQueue<Runnable>(),
-            buildUploadThreadFactory);
+        Executors.newFixedThreadPool(buildUploadThreadCount, buildUploadThreadFactory);
 
     logger.logInfo(
         "Create {} threads for build/upload blobs for client={}, total available processors={}",


### PR DESCRIPTION
… thread pool (#470)"

This reverts commit eb51202b3a16720f29ab7238b3c4f1b955e580cc since it's causing a lot more channel invalidations during low internet cases 