### PR TITLE
SNOW-806047 fix logged uncompressedSize for Parquet

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ArrowFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ArrowFlusher.java
@@ -34,6 +34,7 @@ public class ArrowFlusher implements Flusher<VectorSchemaRoot> {
     ByteArrayOutputStream chunkData = new ByteArrayOutputStream();
     List<ChannelMetadata> channelsMetadataList = new ArrayList<>();
     long rowCount = 0L;
+    float chunkUncompressedSize = 0f;
     VectorSchemaRoot root = null;
     ArrowWriter arrowWriter = null;
     VectorLoader loader = null;
@@ -94,6 +95,7 @@ public class ArrowFlusher implements Flusher<VectorSchemaRoot> {
         // Write channel data using the stream writer
         arrowWriter.writeBatch();
         rowCount += data.getRowCount();
+        chunkUncompressedSize += data.getBufferSize();
 
         logger.logDebug(
             "Finish building channel={}, rowCount={}, bufferSize={} in blob={}",
@@ -112,6 +114,7 @@ public class ArrowFlusher implements Flusher<VectorSchemaRoot> {
         channelsMetadataList,
         columnEpStatsMapCombined,
         rowCount,
+        chunkUncompressedSize,
         chunkData,
         chunkMinMaxInsertTimeInMs);
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
@@ -147,7 +147,7 @@ class BlobBuilder {
             firstChannelFlushContext.getFullyQualifiedTableName(),
             serializedChunk.rowCount,
             startOffset,
-            chunkData.size(),
+            serializedChunk.chunkUncompressedSize,
             compressedChunkLength,
             encryptedCompressedChunkDataSize,
             bdecVersion);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChunkMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChunkMetadata.java
@@ -32,7 +32,7 @@ class ChunkMetadata {
     private String schemaName;
     private String tableName;
     private Long chunkStartOffset;
-    private Integer chunkLength;
+    private Integer chunkLength; // compressedChunkLength
     private List<ChannelMetadata> channels;
     private String chunkMD5;
     private EpInfo epInfo;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
@@ -34,6 +34,7 @@ public interface Flusher<T> {
     final List<ChannelMetadata> channelsMetadataList;
     final Map<String, RowBufferStats> columnEpStatsMapCombined;
     final long rowCount;
+    final float chunkUncompressedSize;
     final ByteArrayOutputStream chunkData;
     final Pair<Long, Long> chunkMinMaxInsertTimeInMs;
 
@@ -41,11 +42,13 @@ public interface Flusher<T> {
         List<ChannelMetadata> channelsMetadataList,
         Map<String, RowBufferStats> columnEpStatsMapCombined,
         long rowCount,
+        float chunkUncompressedSize,
         ByteArrayOutputStream chunkData,
         Pair<Long, Long> chunkMinMaxInsertTimeInMs) {
       this.channelsMetadataList = channelsMetadataList;
       this.columnEpStatsMapCombined = columnEpStatsMapCombined;
       this.rowCount = rowCount;
+      this.chunkUncompressedSize = chunkUncompressedSize;
       this.chunkData = chunkData;
       this.chunkMinMaxInsertTimeInMs = chunkMinMaxInsertTimeInMs;
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -50,6 +50,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       throws IOException {
     List<ChannelMetadata> channelsMetadataList = new ArrayList<>();
     long rowCount = 0L;
+    float chunkUncompressedSize = 0f;
     String firstChannelFullyQualifiedTableName = null;
     Map<String, RowBufferStats> columnEpStatsMapCombined = null;
     BdecParquetWriter mergedChannelWriter = null;
@@ -100,6 +101,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       }
 
       rowCount += data.getRowCount();
+      chunkUncompressedSize += data.getBufferSize();
 
       logger.logDebug(
           "Parquet Flusher: Finish building channel={}, rowCount={}, bufferSize={} in blob={}",
@@ -116,6 +118,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
         channelsMetadataList,
         columnEpStatsMapCombined,
         rowCount,
+        chunkUncompressedSize,
         mergedChunkData,
         chunkMinMaxInsertTimeInMs);
   }
@@ -125,6 +128,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       throws IOException {
     List<ChannelMetadata> channelsMetadataList = new ArrayList<>();
     long rowCount = 0L;
+    float chunkUncompressedSize = 0f;
     String firstChannelFullyQualifiedTableName = null;
     Map<String, RowBufferStats> columnEpStatsMapCombined = null;
     List<List<Object>> rows = null;
@@ -176,6 +180,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       rows.addAll(data.getVectors().rows);
 
       rowCount += data.getRowCount();
+      chunkUncompressedSize += data.getBufferSize();
 
       logger.logDebug(
           "Parquet Flusher: Finish building channel={}, rowCount={}, bufferSize={} in blob={},"
@@ -183,7 +188,8 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
           data.getChannelContext().getFullyQualifiedName(),
           data.getRowCount(),
           data.getBufferSize(),
-          filePath);
+          filePath,
+          enableParquetInternalBuffering);
     }
 
     Map<String, String> metadata = channelsDataPerTable.get(0).getVectors().metadata;
@@ -196,6 +202,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
         channelsMetadataList,
         columnEpStatsMapCombined,
         rowCount,
+        chunkUncompressedSize,
         mergedData,
         chunkMinMaxInsertTimeInMs);
   }


### PR DESCRIPTION
This PR fixes the uncompressed size that we log. Previously it had an incorrect value for Parquet.