### PR TITLE
SNOW-807102 Disable OpenManyChannelsIT

### DIFF
--- a/src/test/java/net/snowflake/ingest/streaming/internal/OpenManyChannelsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/OpenManyChannelsIT.java
@@ -20,12 +20,13 @@ import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /** Tries to open several thousand channels into the same table from multiple threads in parallel */
+@Ignore("Will be reimplemented in dew: SNOW-807102")
 public class OpenManyChannelsIT {
   private static final int THREAD_COUNT = 20;
   private static final int CHANNELS_PER_THREAD = 250;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/OpenManyChannelsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/OpenManyChannelsIT.java
@@ -20,6 +20,7 @@ import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;


### PR DESCRIPTION
The `OpenManyChannelsIT` integration test takes a very long time and generates a large log output. It is not a good fit for SDK integration tests running with each PR and will be re-implemented in dew.