### PR TITLE
Fix shading class relocation: net.snowflake.ingest.shade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/main/resources/log4j.properties
 src/test/resources/log4j.properties
 testOutput/
 .cache/
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -465,6 +465,11 @@
           <version>3.0.0-M5</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>4.0.0-M8</version>
+        </plugin>
+        <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${jacoco.version}</version>
@@ -493,11 +498,6 @@
               </configuration>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>4.0.0-M8</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <!-- Arifact name and version information -->
   <groupId>net.snowflake</groupId>
   <artifactId>snowflake-ingest-sdk</artifactId>
-  <version>1.1.3</version>
+  <version>1.1.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Snowflake Ingest SDK</name>
   <description>Snowflake Ingest SDK</description>
@@ -57,7 +57,7 @@
     <objenesis.version>3.1</objenesis.version>
     <parquet.version>1.12.3</parquet.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <shadeBase>net.snowflake.ingest.internal</shadeBase>
+    <shadeBase>net.snowflake.ingest.shade</shadeBase>
     <slf4j.version>1.7.36</slf4j.version>
     <snappy.version>1.1.8.3</snappy.version>
     <snowjdbc.version>3.13.29</snowjdbc.version>
@@ -384,7 +384,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>
@@ -495,6 +494,11 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>4.0.0-M8</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -510,7 +514,7 @@
           <sortDependencyExclusions>groupId,artifactId</sortDependencyExclusions>
           <sortExecutions>true</sortExecutions>
           <sortModules>true</sortModules>
-          <sortPlugins>groupId,artifactId</sortPlugins>
+          <sortPlugins>groupId</sortPlugins>
           <sortProperties>true</sortProperties>
           <verifyFail>stop</verifyFail>
           <verifyFailOn>strict</verifyFailOn>
@@ -676,7 +680,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <exclude>**/TestSimpleIngestLocal.java</exclude>
@@ -724,7 +728,6 @@
       </activation>
       <build>
         <plugins>
-          <!-- Relocate all dependencies to internal to solve dependency conflict problem -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
@@ -732,58 +735,41 @@
             <configuration>
               <relocations>
                 <relocation>
-                  <pattern>com.nimbusds</pattern>
-                  <shadedPattern>${shadeBase}.com.nimbusds</shadedPattern>
+                  <pattern>com</pattern>
+                  <shadedPattern>${shadeBase}.com</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>net.jcip</pattern>
-                  <shadedPattern>${shadeBase}.net.jcip</shadedPattern>
+                  <pattern>io</pattern>
+                  <shadedPattern>${shadeBase}.io</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>net.minidev</pattern>
-                  <shadedPattern>${shadeBase}.net.minidev</shadedPattern>
+                  <pattern>javax</pattern>
+                  <shadedPattern>${shadeBase}.javax</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.objectweb</pattern>
-                  <shadedPattern>${shadeBase}.org.objectweb</shadedPattern>
+                  <pattern>jersey</pattern>
+                  <shadedPattern>${shadeBase}.jersey</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.fasterxml</pattern>
-                  <shadedPattern>${shadeBase}.fasterxml</shadedPattern>
+                  <pattern>net</pattern>
+                  <shadedPattern>${shadeBase}.net</shadedPattern>
+                  <excludes>
+                    <exclude>net.snowflake.ingest.**</exclude>
+                  </excludes>
                 </relocation>
                 <relocation>
-                  <pattern>org.apache</pattern>
-                  <shadedPattern>${shadeBase}.apache</shadedPattern>
+                  <pattern>org</pattern>
+                  <shadedPattern>${shadeBase}.org</shadedPattern>
+                </relocation>
+                <relocation>
+                  <!--
+                    this is the parquet shade location
+                    https://github.com/apache/parquet-mr/blob/master/pom.xml#LL72C6-L72C18
+                  -->
+                  <pattern>shaded.parquet</pattern>
+                  <shadedPattern>${shadeBase}.shaded.parquet</shadedPattern>
                 </relocation>
               </relocations>
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/LICENSE*</exclude>
-                    <exclude>META-INF/NOTICE*</exclude>
-                    <exclude>META-INF/DEPENDENCIES</exclude>
-                    <exclude>META-INF/maven/**</exclude>
-                    <exclude>META-INF/services/com.fasterxml.*</exclude>
-                    <exclude>META-INF/*.xml</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>commons-logging:commons-logging</artifact>
-                  <excludes>
-                    <exclude>org/apache/commons/logging/impl/AvalonLogger.class</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>org.slf4j:slf4j-simple</artifact>
-                  <excludes>
-                    <exclude>org/slf4j/**</exclude>
-                  </excludes>
-                </filter>
-              </filters>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
@@ -795,6 +781,33 @@
                   <goal>shade</goal>
                 </goals>
                 <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <!-- hacky META-INF/versions shade relocation -->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <target>
+                    <unzip dest="${project.build.directory}/tmp" src="${project.build.directory}/${project.build.finalName}.jar"/>
+                    <mkdir dir="${project.build.directory}/tmp/META-INF/versions/9/net/snowflake/ingest/shade/net/snowflake/client"/>
+                    <mkdir dir="${project.build.directory}/tmp/META-INF/versions/11/net/snowflake/ingest/shade/net/snowflake/client"/>
+                    <mkdir dir="${project.build.directory}/tmp/META-INF/versions/15/net/snowflake/ingest/shade/net/snowflake/client"/>
+                    <move file="${project.build.directory}/tmp/META-INF/versions/9/net/snowflake/client" todir="${project.build.directory}/tmp/META-INF/versions/9/net/snowflake/ingest/shade/net/snowflake/"/>
+                    <move file="${project.build.directory}/tmp/META-INF/versions/11/net/snowflake/client" todir="${project.build.directory}/tmp/META-INF/versions/9/net/snowflake/ingest/shade/net/snowflake/"/>
+                    <move file="${project.build.directory}/tmp/META-INF/versions/15/net/snowflake/client" todir="${project.build.directory}/tmp/META-INF/versions/9/net/snowflake/ingest/shade/net/snowflake/"/>
+                    <zip basedir="${project.build.directory}/tmp" destfile="${project.build.directory}/${project.build.finalName}.jar"/>
+                    <delete dir="${project.build.directory}/tmp"/>
+                  </target>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/scripts/check_content.sh
+++ b/scripts/check_content.sh
@@ -1,33 +1,39 @@
-#!/bin/bash -e
+#!/bin/bash
 
-# scripts used to check if all dependency is shaded into snowflake internal path
-
+set -o errexit
+set -o nounset
 set -o pipefail
 
+# no-op comment
+: <<'EOF'
+This script checks the shade tar and verifies that it only contains classes
+under the package net.snowflake.ingest. This is to prevent class conflicts
+when the shaded jar is used in other projects.
+EOF
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-if jar tvf $DIR/../target/snowflake-ingest-sdk.jar  | awk '{print $8}' | grep -v -E "^(net|com)/snowflake" \
-    | grep -v -E "(com|net)/\$" | grep -v -E "^META-INF" | grep -v -E "^mozilla" | grep -v mime.types \
-    | grep -v project.properties | grep -v -E "javax" | grep -v -E "^org/" | grep -v -E "^com/google" \
-    | grep -v -E "^com/sun" | grep -v "log4j.properties" | grep -v "git.properties" | grep -v "io/" \
-    | grep -v "codegen/" | grep -v "com/codahale/" | grep -v "com/ibm/" | grep -v "LICENSE" | grep -v "aix/" \
-    | grep -v "darwin/" | grep -v "win/" | grep -v "freebsd/" | grep -v "linux/" | grep -v "com/github/" \
-    | grep -v -E "shaded/" | grep -v "webapps/"  | grep -v "microsoft/" | grep -v "com/ctc/" | grep -v "jersey/" \
-    | grep -v "edu/" | grep -v "com/jcraft/" | grep -v "contribs/" | grep -v "com/zaxxer/"  | grep -v "com/squareup/" \
-    | grep -v "com/thoughtworks/" | grep -v "com/jamesmurty/"  | grep -v "net/iharder/" \
-    | grep -v -E "^core-default.xml" \
-    | grep -v "yarn-version-info.properties" | grep -v "yarn-version-info.properties" \
-    | grep -v "about.html" | grep -v "jetty-dir.css" \
-    | grep -v "krb5_udp-template.conf" | grep -v "krb5-template.conf" \
-    | grep -v "ccache.txt" | grep -v "keytab.txt" \
-    | grep -v "common-version-info.properties" | grep -v "LocalizedFormats_fr.properties" \
-    | grep -v "org.apache.hadoop.application-classloader.properties" | grep -v "assets/" | grep -v "ehcache-core.xsd" \
-    | grep -v "ehcache-107ext.xsd" | grep -v "parquet.thrift" | grep -v "mapred-default.xml" \
-    | grep -v "yarn-default.xml" | grep -v ".keep"  | grep -v "NOTICE" | grep -v "digesterRules.xml" \
-    | grep -v "properties.dtd" | grep -v "PropertyList-1.0.dtd"  \
-    | grep -v "about.html" | grep -v "jetty-dir.css" | grep -v "krb5-template.conf" \
-    | grep -v "krb5_udp-template.conf" | grep -v "ccache.txt" | grep -v "keytab.txt" \
-    | grep -v "lookup.class" | grep -v "update.class" | grep -v "dig.class" | grep -v "jnamed"  \
-    ; then
-  echo "[ERROR] Ingest SDK jar includes class not under the snowflake namespace"
+
+# List all the files in the shaded snowflake-ingest-sdk.jar
+# filter for .class files
+# filter out all files under net/snowflake/ingest
+# filter out the packageless files from dnsjava
+# if any files remain, throw an error
+
+REMAINING_CLASS_FILES=$(jar tvf "${DIR}/../target/snowflake-ingest-sdk.jar" |
+  awk '{print $8}' |
+  fgrep .class |
+  egrep -v '^net/snowflake/ingest/' |
+  egrep -v '^META-INF/versions/[0-9]+/net/snowflake/ingest/' |
+  egrep -v '(dig|lookup|update|jnamed(\$[0-9])?)\.class' |
+  egrep -v 'META-INF/versions/9/module-info.class' || true)
+
+
+# error if there are any remaining class files
+# ${REMAINING_CLASS_FILES} must be quoted to print newlines instead of spaces
+# echo adds a newline so "-eq 1" means empty
+if ! [ $(echo "${REMAINING_CLASS_FILES}" | wc -l) -eq 1 ]; then
+  echo "[ERROR] Ingest SDK jar includes classes outside net.snowflake.ingest"
+  echo "Found classes in jar:"
+  echo "${REMAINING_CLASS_FILES}"
   exit 1
 fi


### PR DESCRIPTION
- Relocate all dependency classes under net.snowflake.ingest.shade

As of release 1.1.3 the shaded jar contains a large number of unrelocated classes. This is problematic for library consumers that include any of the same dependencies in their projects that snowflake-ingest-sdk uses in addition to snowflake-ingest-sdk. This can result in duplicate classes in a project and confusing errors for users depending on dependency ordering of their project. When duplicate classes are present on the classpath the first class found wins.

This means that for consumers of snowflake-ingest-sdk if it's a dependency listed high in a pom.xml's dependency section, its duplicate classes take precedence, overriding any other dependency definitions in their project.

Here's a short example of the problem. If I have a project using the ingest SDK with a pom.xml as follows:

```
      <dependency>
        <groupId>net.snowflake</groupId>
        <artifactId>snowflake-ingest-sdk</artifactId>
        <version>1.1.3</version>
      </dependency>
      <dependency>
        <groupId>com.google.protobuf</groupId>
        <artifactId>protobuf-java</artifactId>
        <version>3.22.3</version>
      </dependency>
```

snowflake-ingest-sdk includes class files from
com.google.protobuf:protobuf-java:2.5.0 which is pulled in transitively from hadoop-common. For any class files that are duplicates of protobuf-java 3.22.3 the class files of 2.5.0 will take precedence at runtime due to snowflake-ingest-sdk being first in the pom.xml and therefore first on the classpath.

Conversely if snowflake-ingest-sdk is last then protobuf-java 3.22.3 will be active which may cause runtime issues with snowflake-ingest-sdk if it depends on APIs only present in 2.5.0.

Fixes #356