### PR TITLE
SNOW-811371 Shade and Relocate Snowflake JDBC Classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -788,15 +788,18 @@
             <artifactId>maven-shade-plugin</artifactId>
             <version>3.4.1</version>
             <configuration>
-              <artifactSet>
-                <excludes>
-                  <exclude>net.snowflake:snowflake-jdbc</exclude>
-                </excludes>
-              </artifactSet>
               <relocations>
                 <relocation>
                   <pattern>com.nimbusds</pattern>
                   <shadedPattern>${shadeBase}.com.nimbusds</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>net.snowflake.client</pattern>
+                  <shadedPattern>${shadeBase}.net.snowflake.client</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.snowflake.client</pattern>
+                  <shadedPattern>${shadeBase}.com.snowflake.client</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>net.jcip</pattern>


### PR DESCRIPTION
Users may run more than one application in a single JVM for different purposes. If one application is built with the ingest SDK and another one with the JDBC driver, then class conflicts will occur. Excluding the JDBC driver is a breaking change as well that would impact these applications and potentially the Snowflake Kafka Connector as well.