### PR TITLE
NO-SNOW Upgrade JDBC to 3.13.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <shadeBase>net.snowflake.ingest.internal</shadeBase>
     <slf4j.version>1.7.36</slf4j.version>
     <snappy.version>1.1.8.3</snappy.version>
-    <snowjdbc.version>3.13.29</snowjdbc.version>
+    <snowjdbc.version>3.13.30</snowjdbc.version>
     <yetus.version>0.13.0</yetus.version>
   </properties>
 


### PR DESCRIPTION
- Please note, this is just upgrading JDBC to 3.13.30, no other changes.
- Required for 
  - Future Ingest SDK's support for downscope token. 
  - To use 3.13.30 in Kafka Connector. 
  - (Issue with shaded library that even after explicitly mentioning the use of 3.13.30 in KC, it still uses 3.13.29 from ingest SDK)


I will push this to master as well push this to a branch on top of 1.1.3