### PR TITLE
Fix 'Connection reset' build errors by caching mvn dependencies

### DIFF
--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -19,9 +19,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
+          cache: maven
 
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
         env:
@@ -51,9 +53,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
+          cache: maven
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }} on Windows Powershell
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}


### PR DESCRIPTION
Our builds are occasionally failing with the following exception:

```
2023-05-17T14:20:16.7749209Z [ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.3.0:analyze-only (analyze) on project snowflake-ingest-sdk: Execution analyze of goal org.apache.maven.plugins:maven-dependency-plugin:3.3.0:analyze-only failed: Plugin org.apache.maven.plugins:maven-dependency-plugin:3.3.0 or one of its dependencies could not be resolved: Failed to collect dependencies at org.apache.maven.plugins:maven-dependency-plugin:jar:3.3.0 -> org.apache.maven.reporting:maven-reporting-impl:jar:3.1.0: Failed to read artifact descriptor for org.apache.maven.reporting:maven-reporting-impl:jar:3.1.0: Could not transfer artifact org.apache.maven.reporting:maven-reporting-impl:pom:3.1.0 from/to central (https://repo.maven.apache.org/maven2): Connection reset -> [Help 1]
2023-05-17T14:20:16.7750525Z [ERROR] 
2023-05-17T14:20:16.7751258Z [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
2023-05-17T14:20:16.7751862Z [ERROR] Re-run Maven using the -X switch to enable full debug logging.
2023-05-17T14:20:16.7752246Z [ERROR] 
2023-05-17T14:20:16.7752692Z [ERROR] For more information about the errors and possible solutions, please read the following articles:
2023-05-17T14:20:16.7753256Z [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException
2023-05-17T14:20:17.1158309Z ##[error]Process completed with exit code 1.
```

Our builds always download all dependencies from Maven, so if maven is temporarily down or the connection gets closed, the build fails. This PR introduces caching of Maven artifacts, which is natively supported in the `setup-java@2` GitHub action.