### PR TITLE
Revert "SNOW-811371 Shade and Relocate Snowflake JDBC Classes (#494)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -794,18 +794,15 @@
             <artifactId>maven-shade-plugin</artifactId>
             <version>3.4.1</version>
             <configuration>
+              <artifactSet>
+                <excludes>
+                  <exclude>net.snowflake:snowflake-jdbc</exclude>
+                </excludes>
+              </artifactSet>
               <relocations>
                 <relocation>
                   <pattern>com.nimbusds</pattern>
                   <shadedPattern>${shadeBase}.com.nimbusds</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>net.snowflake.client</pattern>
-                  <shadedPattern>${shadeBase}.net.snowflake.client</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.snowflake.client</pattern>
-                  <shadedPattern>${shadeBase}.com.snowflake.client</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>net.jcip</pattern>


### PR DESCRIPTION
This PR reverts relocating `snowflake-jdbc` driver in the shaded JAR. Relocation caused test failures and didn't solve the problem it was supposed to - not having any impact on existing users. Existing users who depended on the JDBC driver without declaring it in their pom.xml, would still see errors.

We should release this change as 2.0.0, so that it is clear from the version number that some dependencies have changes. 
Also, we will be releasing an unshaded variant in every release.

To sum up, the final state is: JDBC driver is not shaded, not relocated, it will be declared as a dependency in the final reduced pom.xml.