### PR TITLE
NO-SNOW Enforce allowed DATE and TIMESTAMP range

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -454,6 +454,11 @@ class DataValidationUtil {
     if (trimTimezone) {
       offsetDateTime = offsetDateTime.withOffsetSameLocal(ZoneOffset.UTC);
     }
+    if (offsetDateTime.getYear() < 1 || offsetDateTime.getYear() > 9999) {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_ROW,
+          "Timestamp out of representable inclusive range of years between 1 and 9999");
+    }
     return new TimestampWrapper(offsetDateTime, scale);
   }
 
@@ -579,6 +584,13 @@ class DataValidationUtil {
   static int validateAndParseDate(String columnName, Object input, long insertRowIndex) {
     OffsetDateTime offsetDateTime =
         inputToOffsetDateTime(columnName, "DATE", input, ZoneOffset.UTC, insertRowIndex);
+
+    if (offsetDateTime.getYear() < -9999 || offsetDateTime.getYear() > 9999) {
+      throw new SFException(
+          ErrorCode.INVALID_VALUE_ROW,
+          "Date out of representable inclusive range of years between -9999 and 9999");
+    }
+
     return Math.toIntExact(offsetDateTime.toLocalDate().toEpochDay());
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -118,6 +118,14 @@ public class DataValidationUtilTest {
     // Time input is not supported
     expectError(ErrorCode.INVALID_VALUE_ROW, () -> validateAndParseDate("COL", "20:57:01", 0));
 
+    // Test values out of range
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () -> validateAndParseDate("COL", LocalDateTime.of(10000, 2, 2, 2, 2), 0));
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () -> validateAndParseDate("COL", LocalDateTime.of(-10000, 2, 2, 2, 2), 0));
+
     // Test forbidden values
     expectError(ErrorCode.INVALID_FORMAT_ROW, () -> validateAndParseDate("COL", new Object(), 0));
     expectError(
@@ -261,6 +269,19 @@ public class DataValidationUtilTest {
     expectError(
         ErrorCode.INVALID_VALUE_ROW,
         () -> validateAndParseTimestamp("COL", "20:57:01", 3, UTC, false, 0));
+
+    // Test values out of range
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () ->
+            validateAndParseTimestamp(
+                "COL", LocalDateTime.of(10000, 2, 2, 2, 2), 3, UTC, false, 0));
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () -> validateAndParseTimestamp("COL", LocalDateTime.of(0, 2, 2, 2, 2), 3, UTC, false, 0));
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () -> validateAndParseTimestamp("COL", LocalDateTime.of(-1, 2, 2, 2, 2), 3, UTC, false, 0));
 
     // Test forbidden values
     expectError(
@@ -845,7 +866,7 @@ public class DataValidationUtilTest {
         Hex.decodeHex("1234567890abcdef"), // pragma: allowlist secret NOT A SECRET
         validateAndParseBinary(
             "COL",
-            "1234567890abcdef",
+            "1234567890abcdef", // pragma: allowlist secret NOT A SECRET
             Optional.empty(),
             0)); // pragma: allowlist secret NOT A SECRET
     assertArrayEquals(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
@@ -947,19 +947,56 @@ public class DateTimeIT extends AbstractDataTypeTest {
 
   @Test
   public void testOldTimestamps() throws Exception {
-    testIngestion("DATE", "0001-12-31", "0001-12-31", new StringProvider());
-    testIngestion(
+    // DATE
+    testJdbcTypeCompatibility("DATE", "0001-12-31", new StringProvider());
+    testJdbcTypeCompatibility("DATE", "0000-01-01", new StringProvider());
+    testJdbcTypeCompatibility("DATE", "-0001-01-01", new StringProvider());
+    testJdbcTypeCompatibility("DATE", "-9999-01-01", new StringProvider());
+
+    // TIMESTAMP_NTZ
+    testJdbcTypeCompatibility(
         "TIMESTAMP_NTZ",
         "0001-12-31T11:11:11",
         "0001-12-31 11:11:11.000000000 Z",
+        new StringProvider(),
         new StringProvider());
-    // TODO uncomment once SNOW-727474 is resolved
-    //        testIngestion("TIMESTAMP_LTZ", "0001-12-31T11:11:11", "0001-12-31 03:11:11.000000000
-    // -0800", new StringProvider());
-    testIngestion(
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_NTZ",
+        "0001-01-01T00:00:00",
+        "0001-01-01 00:00:00.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+
+    // TIMESTAMP_TZ
+    testJdbcTypeCompatibility(
         "TIMESTAMP_TZ",
         "0001-12-31T11:11:11+03:00",
         "0001-12-31 11:11:11.000000000 +0300",
+        new StringProvider(),
+        new StringProvider());
+
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_TZ",
+        "0001-01-01T00:00:00+03:00",
+        "0001-01-01 00:00:00.000000000 +0300",
+        new StringProvider(),
+        new StringProvider());
+
+    // TIMESTAMP_LTZ
+    conn.createStatement()
+        .execute("alter session set timezone = 'UTC';"); // workaround for SNOW-727474
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "0001-12-31T11:11:11+00:00",
+        "0001-12-31 11:11:11.000000000 Z",
+        new StringProvider(),
+        new StringProvider());
+    testJdbcTypeCompatibility(
+        "TIMESTAMP_LTZ",
+        "0001-01-01T00:00:00+00:00",
+        "0001-01-01 00:00:00.000000000 Z",
+        new StringProvider(),
         new StringProvider());
   }
 


### PR DESCRIPTION
This PR introduces enforcement of min and max allowed dates and timestamps. For dates, we allow the range [-9999..9999], for timestamps we allow [1..9999].