### PR TITLE
[SNOW-843760] Upgrade netty-common in response to CVE vulnerability 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <net.minidev.version>2.4.9</net.minidev.version>
-    <netty.version>4.1.82.Final</netty.version>
+    <netty.version>4.1.94.Final</netty.version>
     <nimbusds.version>9.9.3</nimbusds.version>
     <objenesis.version>3.1</objenesis.version>
     <parquet.version>1.12.3</parquet.version>


### PR DESCRIPTION
Blackduck scans of Kafka Connector revealed a netty-common vulnerability in 4.1.80.Final. Though we use 4.1.82.Final, lets upgrade to the latest

https://mvnrepository.com/artifact/io.netty/netty-common