### PR TITLE
SNOW-851351 Retry javax.net.ssl.SSLException

### DIFF
--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -266,8 +266,8 @@ public class HttpUtil {
   }
 
   /**
-   * Retry handler logic. Retry at most {@link HttpUtil.MAX_RETRIES} times if any of the following exceptions is thrown by
-   * request execution:
+   * Retry handler logic. Retry at most {@link HttpUtil.MAX_RETRIES} times if any of the following
+   * exceptions is thrown by request execution:
    *
    * <ul>
    *   <li>No response from Service exception (NoHttpResponseException)
@@ -276,7 +276,7 @@ public class HttpUtil {
    *
    * @return retryHandler to add to http client.
    */
-  private static HttpRequestRetryHandler getHttpRequestRetryHandler() {
+  static HttpRequestRetryHandler getHttpRequestRetryHandler() {
     return (exception, executionCount, httpContext) -> {
       final String requestURI = getRequestUriFromContext(httpContext);
       if (executionCount > MAX_RETRIES) {

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -266,7 +266,7 @@ public class HttpUtil {
   }
 
   /**
-   * Retry handler logic. Retry at most 3 times if any of the following exceptions is thrown by
+   * Retry handler logic. Retry at most {@link HttpUtil.MAX_RETRIES} times if any of the following exceptions is thrown by
    * request execution:
    *
    * <ul>

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -73,6 +73,12 @@ public class HttpUtil {
   private static final int DEFAULT_CONNECTION_TIMEOUT_MINUTES = 1;
   private static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT_MINUTES = 5;
 
+  /**
+   * After how many seconds of inactivity should be idle connections evicted from the connection
+   * pool.
+   */
+  private static final int DEFAULT_EVICT_IDLE_AFTER_SECONDS = 60;
+
   // Default is 2, but scaling it up to 100 to match with default_max_connections
   private static final int DEFAULT_MAX_CONNECTIONS_PER_ROUTE = 100;
 
@@ -146,6 +152,7 @@ public class HttpUtil {
     HttpClientBuilder clientBuilder =
         HttpClientBuilder.create()
             .setConnectionManager(connectionManager)
+            .evictIdleConnections(DEFAULT_EVICT_IDLE_AFTER_SECONDS, TimeUnit.SECONDS)
             .setSSLSocketFactory(f)
             .setServiceUnavailableRetryStrategy(getServiceUnavailableRetryStrategy())
             .setRetryHandler(getHttpRequestRetryHandler())
@@ -259,7 +266,13 @@ public class HttpUtil {
   }
 
   /**
-   * Retry handler logic. Retry if No response from Service exception. (NoHttpResponseException)
+   * Retry handler logic. Retry at most 3 times if any of the following exceptions is thrown by
+   * request execution:
+   *
+   * <ul>
+   *   <li>No response from Service exception (NoHttpResponseException)
+   *   <li>javax.net.ssl.SSLException: Connection reset.
+   * </ul>
    *
    * @return retryHandler to add to http client.
    */
@@ -270,16 +283,17 @@ public class HttpUtil {
         LOGGER.info("Max retry exceeded for requestURI:{}", requestURI);
         return false;
       }
-      if (exception instanceof NoHttpResponseException) {
+      if (exception instanceof NoHttpResponseException
+          || exception instanceof javax.net.ssl.SSLException) {
         LOGGER.info(
-            "Retrying request which caused No HttpResponse Exception with "
-                + "URI:{}, retryCount:{} and maxRetryCount:{}",
+            "Retrying request which caused {} with " + "URI:{}, retryCount:{} and maxRetryCount:{}",
+            exception.getClass().getName(),
             requestURI,
             executionCount,
             MAX_RETRIES);
         return true;
       }
-      LOGGER.info("No retry for URI:{} with exception", requestURI, exception);
+      LOGGER.info("No retry for URI:{} with exception {}", requestURI, exception.toString());
       return false;
     };
   }

--- a/src/test/java/net/snowflake/ingest/utils/HttpUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/utils/HttpUtilTest.java
@@ -1,0 +1,41 @@
+package net.snowflake.ingest.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+
+import java.io.IOException;
+import javax.net.ssl.SSLException;
+import net.snowflake.client.jdbc.internal.apache.http.HttpRequest;
+import net.snowflake.client.jdbc.internal.apache.http.NoHttpResponseException;
+import net.snowflake.client.jdbc.internal.apache.http.RequestLine;
+import net.snowflake.client.jdbc.internal.apache.http.client.HttpRequestRetryHandler;
+import net.snowflake.client.jdbc.internal.apache.http.client.protocol.HttpClientContext;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class HttpUtilTest {
+  @Test
+  public void testRequestRetryHandler() {
+    HttpRequestRetryHandler httpRequestRetryHandler = HttpUtil.getHttpRequestRetryHandler();
+
+    HttpClientContext httpContextMock = Mockito.mock(HttpClientContext.class);
+    RequestLine requestLine = Mockito.mock(RequestLine.class);
+    HttpRequest httpRequest = Mockito.mock(HttpRequest.class);
+
+    doReturn(httpRequest).when(httpContextMock).getRequest();
+    doReturn(requestLine).when(httpRequest).getRequestLine();
+    doReturn("/api/v1/status").when(requestLine).getUri();
+
+    assertTrue(
+        httpRequestRetryHandler.retryRequest(
+            new NoHttpResponseException("Test exception"), 1, httpContextMock));
+    assertTrue(
+        httpRequestRetryHandler.retryRequest(
+            new SSLException("Test exception"), 1, httpContextMock));
+    assertFalse(
+        httpRequestRetryHandler.retryRequest(
+            new SSLException("Test exception"), 4, httpContextMock));
+    assertFalse(httpRequestRetryHandler.retryRequest(new IOException(), 1, httpContextMock));
+  }
+}


### PR DESCRIPTION
This PR retries SSLException, which we have been seeing in client logs. It additionally evicts idle connections after 60s of inactivity.