### PR TITLE
SNOW-855191 Race condition causing NPE

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -309,7 +309,6 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   /** Close the row buffer by releasing its internal resources. */
   @Override
   void closeInternal() {
-    this.fieldIndex.clear();
     if (bdecParquetWriter != null) {
       try {
         bdecParquetWriter.close();

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -421,25 +421,6 @@ public class RowBufferTest {
   }
 
   @Test
-  public void testClose() {
-    this.rowBufferOnErrorContinue.close("testClose");
-    Map<String, Object> row = new HashMap<>();
-    row.put("colTinyInt", (byte) 1);
-    row.put("colSmallInt", (short) 2);
-    row.put("colInt", 3);
-    row.put("colBigInt", 4L);
-    row.put("colDecimal", 1.23);
-    row.put("colChar", "2");
-
-    try {
-      this.rowBufferOnErrorContinue.insertRows(Collections.singletonList(row), null);
-      Assert.fail("Insert should fail after buffer is closed");
-    } catch (SFException e) {
-      Assert.assertEquals(ErrorCode.INTERNAL_ERROR.getMessageCode(), e.getVendorCode());
-    }
-  }
-
-  @Test
   public void testFlush() {
     testFlushHelper(this.rowBufferOnErrorAbort);
     testFlushHelper(this.rowBufferOnErrorContinue);


### PR DESCRIPTION
There is a race condition, which leads to a NPE when one thread invalidates the channel, while another thread is inside of insertRows(). The problem is that channel invalidation clears fieldIndex, which may still be used in threads concurrently inserting rows.

There is no need to clear the fieldIndex during invalidation, it is enough to mark the channel as invalid and it won't be flushed. When channel is reopened, setupSchema() will clear fieldIndex and reinitialize the schema.