### PR TITLE
NO-SNOW Retry failed requests more aggressively

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtils.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtils.java
@@ -34,9 +34,40 @@ public class StreamingIngestUtils {
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
+  /**
+   * How many milliseconds of exponential backoff to sleep before retrying the request again:
+   *
+   * <ul>
+   *   <li>0 or 1 failure => no sleep
+   *   <li>2 failures => 1s
+   *   <li>3 failures => 2s
+   *   <li>4 or more failures => 4s
+   * </ul>
+   *
+   * @param executionCount How many unsuccessful attempts have been attempted
+   * @return Sleep time in ms
+   */
+  static long getSleepForRetryMs(int executionCount) {
+    if (executionCount < 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              "executionCount must be a non-negative integer, passed: %d", executionCount));
+    } else if (executionCount < 2) {
+      return 0;
+    } else {
+      final int effectiveExecutionCount = Math.min(executionCount, 4);
+      return (1 << (effectiveExecutionCount - 2)) * 1000L;
+    }
+  }
+
   static void sleepForRetry(int executionCount) {
+    long sleepForRetryMs = getSleepForRetryMs(executionCount);
+    if (sleepForRetryMs == 0) {
+      return;
+    }
+
     try {
-      Thread.sleep((1 << (executionCount + 1)) * 1000);
+      Thread.sleep(sleepForRetryMs);
     } catch (InterruptedException e) {
       throw new SFException(ErrorCode.INTERNAL_ERROR, e.getMessage());
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtils.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtils.java
@@ -60,7 +60,7 @@ public class StreamingIngestUtils {
     }
   }
 
-  static void sleepForRetry(int executionCount) {
+  public static void sleepForRetry(int executionCount) {
     long sleepForRetryMs = getSleepForRetryMs(executionCount);
     if (sleepForRetryMs == 0) {
       return;

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -39,6 +39,7 @@ import net.snowflake.client.jdbc.internal.apache.http.impl.conn.PoolingHttpClien
 import net.snowflake.client.jdbc.internal.apache.http.pool.PoolStats;
 import net.snowflake.client.jdbc.internal.apache.http.protocol.HttpContext;
 import net.snowflake.client.jdbc.internal.apache.http.ssl.SSLContexts;
+import net.snowflake.ingest.streaming.internal.StreamingIngestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -296,6 +297,7 @@ public class HttpUtil {
           requestURI,
           executionCount,
           MAX_RETRIES);
+      StreamingIngestUtils.sleepForRetry(executionCount);
       return true;
     };
   }

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -20,7 +20,6 @@ import net.snowflake.client.core.SFSessionProperty;
 import net.snowflake.client.jdbc.internal.apache.http.HttpHost;
 import net.snowflake.client.jdbc.internal.apache.http.HttpRequest;
 import net.snowflake.client.jdbc.internal.apache.http.HttpResponse;
-import net.snowflake.client.jdbc.internal.apache.http.NoHttpResponseException;
 import net.snowflake.client.jdbc.internal.apache.http.auth.AuthScope;
 import net.snowflake.client.jdbc.internal.apache.http.auth.Credentials;
 import net.snowflake.client.jdbc.internal.apache.http.auth.UsernamePasswordCredentials;
@@ -57,7 +56,14 @@ public class HttpUtil {
   private static final String FIRST_FAULT_TIMESTAMP = "FIRST_FAULT_TIMESTAMP";
   private static final Duration TOTAL_RETRY_DURATION = Duration.of(120, ChronoUnit.SECONDS);
   private static final Duration RETRY_INTERVAL = Duration.of(3, ChronoUnit.SECONDS);
-  private static final int MAX_RETRIES = 3;
+
+  /**
+   * How many times to retry when an IO exception is thrown. Value here is chosen to match the total
+   * value of {@link HttpUtil.TOTAL_RETRY_DURATION} when exponential backoff of up to 4 seconds per
+   * retry is used.
+   */
+  private static final int MAX_RETRIES = 30;
+
   private static volatile CloseableHttpClient httpClient;
 
   private static PoolingHttpClientConnectionManager connectionManager;
@@ -283,18 +289,14 @@ public class HttpUtil {
         LOGGER.info("Max retry exceeded for requestURI:{}", requestURI);
         return false;
       }
-      if (exception instanceof NoHttpResponseException
-          || exception instanceof javax.net.ssl.SSLException) {
-        LOGGER.info(
-            "Retrying request which caused {} with " + "URI:{}, retryCount:{} and maxRetryCount:{}",
-            exception.getClass().getName(),
-            requestURI,
-            executionCount,
-            MAX_RETRIES);
-        return true;
-      }
-      LOGGER.info("No retry for URI:{} with exception {}", requestURI, exception.toString());
-      return false;
+
+      LOGGER.info(
+          "Retrying request which caused {} with " + "URI:{}, retryCount:{} and maxRetryCount:{}",
+          exception.getClass().getName(),
+          requestURI,
+          executionCount,
+          MAX_RETRIES);
+      return true;
     };
   }
 

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -40,6 +40,7 @@ import net.snowflake.client.jdbc.internal.apache.http.impl.conn.PoolingHttpClien
 import net.snowflake.client.jdbc.internal.apache.http.pool.PoolStats;
 import net.snowflake.client.jdbc.internal.apache.http.protocol.HttpContext;
 import net.snowflake.client.jdbc.internal.apache.http.ssl.SSLContexts;
+import net.snowflake.ingest.streaming.internal.StreamingIngestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -300,6 +301,7 @@ public class HttpUtil {
             requestURI,
             executionCount,
             MAX_RETRIES);
+        StreamingIngestUtils.sleepForRetry(executionCount);
         return true;
       }
       LOGGER.info("No retry for URI:{} with exception {}", requestURI, exception.toString());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtilsTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtilsTest.java
@@ -2,6 +2,7 @@ package net.snowflake.ingest.streaming.internal;
 
 import static net.snowflake.ingest.connection.ServiceResponseHandler.ApiName.STREAMING_CHANNEL_STATUS;
 import static net.snowflake.ingest.streaming.internal.StreamingIngestUtils.executeWithRetries;
+import static net.snowflake.ingest.streaming.internal.StreamingIngestUtils.getSleepForRetryMs;
 import static net.snowflake.ingest.utils.Constants.CHANNEL_STATUS_ENDPOINT;
 import static net.snowflake.ingest.utils.Constants.RESPONSE_ERR_GENERAL_EXCEPTION_RETRY_REQUEST;
 import static net.snowflake.ingest.utils.Constants.RESPONSE_SUCCESS;
@@ -161,5 +162,21 @@ public class StreamingIngestUtilsTest {
         .generateStreamingIngestPostRequest(Mockito.anyString(), Mockito.any(), Mockito.any());
 
     Assert.assertEquals("honkSuccess", result.getMessage());
+  }
+
+  @Test
+  public void testGetSleepForRetry() {
+    Assert.assertEquals(0, getSleepForRetryMs(0));
+    Assert.assertEquals(0, getSleepForRetryMs(1));
+    Assert.assertEquals(1000, getSleepForRetryMs(2));
+    Assert.assertEquals(2000, getSleepForRetryMs(3));
+    Assert.assertEquals(4000, getSleepForRetryMs(4));
+    Assert.assertEquals(4000, getSleepForRetryMs(5));
+    Assert.assertEquals(4000, getSleepForRetryMs(100000));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetSleepForRetryNegative() {
+    getSleepForRetryMs(-1);
   }
 }

--- a/src/test/java/net/snowflake/ingest/utils/HttpUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/utils/HttpUtilTest.java
@@ -5,7 +5,11 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 
 import java.io.IOException;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import javax.net.ssl.SSLException;
 import net.snowflake.client.jdbc.internal.apache.http.HttpRequest;
+import net.snowflake.client.jdbc.internal.apache.http.NoHttpResponseException;
 import net.snowflake.client.jdbc.internal.apache.http.RequestLine;
 import net.snowflake.client.jdbc.internal.apache.http.client.HttpRequestRetryHandler;
 import net.snowflake.client.jdbc.internal.apache.http.client.protocol.HttpClientContext;
@@ -27,12 +31,19 @@ public class HttpUtilTest {
 
     assertTrue(
         httpRequestRetryHandler.retryRequest(
-            new IOException("Test exception"), 0, httpContextMock));
+            new NoHttpResponseException("Test exception"), 1, httpContextMock));
     assertTrue(
         httpRequestRetryHandler.retryRequest(
-            new IOException("Test exception"), 30, httpContextMock));
+            new SSLException("Test exception"), 1, httpContextMock));
+    assertTrue(
+        httpRequestRetryHandler.retryRequest(
+            new SocketException("Test exception"), 1, httpContextMock));
+    assertTrue(
+        httpRequestRetryHandler.retryRequest(
+            new UnknownHostException("Test exception"), 1, httpContextMock));
     assertFalse(
         httpRequestRetryHandler.retryRequest(
-            new IOException("Test exception"), 31, httpContextMock));
+            new SSLException("Test exception"), 11, httpContextMock));
+    assertFalse(httpRequestRetryHandler.retryRequest(new IOException(), 1, httpContextMock));
   }
 }

--- a/src/test/java/net/snowflake/ingest/utils/HttpUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/utils/HttpUtilTest.java
@@ -5,9 +5,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 
 import java.io.IOException;
-import javax.net.ssl.SSLException;
 import net.snowflake.client.jdbc.internal.apache.http.HttpRequest;
-import net.snowflake.client.jdbc.internal.apache.http.NoHttpResponseException;
 import net.snowflake.client.jdbc.internal.apache.http.RequestLine;
 import net.snowflake.client.jdbc.internal.apache.http.client.HttpRequestRetryHandler;
 import net.snowflake.client.jdbc.internal.apache.http.client.protocol.HttpClientContext;
@@ -29,13 +27,12 @@ public class HttpUtilTest {
 
     assertTrue(
         httpRequestRetryHandler.retryRequest(
-            new NoHttpResponseException("Test exception"), 1, httpContextMock));
+            new IOException("Test exception"), 0, httpContextMock));
     assertTrue(
         httpRequestRetryHandler.retryRequest(
-            new SSLException("Test exception"), 1, httpContextMock));
+            new IOException("Test exception"), 30, httpContextMock));
     assertFalse(
         httpRequestRetryHandler.retryRequest(
-            new SSLException("Test exception"), 4, httpContextMock));
-    assertFalse(httpRequestRetryHandler.retryRequest(new IOException(), 1, httpContextMock));
+            new IOException("Test exception"), 31, httpContextMock));
   }
 }


### PR DESCRIPTION
Currently, we have resilient retries when the cause of the error is unavailable service (e.g. 503 or 429 returned from the server side) - we retry every 3 seconds for up to 2 minutes in total. However, when an `IOException` is thrown by the http client, we only retry specific exceptions up to 3 times. This PR makes sure we all retry previously seen `IOException` up to 10x.

This PR should reduce the number of channel invalidations due to incorrect row sequencer (`status_code=21`) as reported in #547.