### PR TITLE
SNOW-861190 Add warning for large batches in insertRows

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -38,9 +38,6 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
   // side scanner
   private static final int INVALID_SERVER_SIDE_DATA_TYPE_ORDINAL = -1;
 
-  // Maximum number of rows we recommend to pass to insertRows()
-  private static final int RECOMMENDED_MAX_BATCH_SIZE = 10_000;
-
   // Snowflake table column logical type
   enum ColumnLogicalType {
     ANY,

--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -575,11 +575,13 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
   }
 
   private void checkBatchSizeRecommendedMaximum(float batchSizeInBytes) {
-    logger.logWarn(
-        "Too large batch of rows passed to 'insertRows': {} bytes. The recommended max batch size"
-            + " is {} bytes. We recommend splitting large batches into multiple smaller ones and"
-            + " call insertRows for each smaller batch separately.",
-        batchSizeInBytes,
-        insertRowsRecommendedMaxSizeInBytes);
+    if (batchSizeInBytes > insertRowsRecommendedMaxSizeInBytes) {
+      logger.logWarn(
+          "Too large batch of rows passed to 'insertRows': {} bytes. The recommended max batch size"
+              + " is {} bytes. We recommend splitting large batches into multiple smaller ones and"
+              + " call insertRows for each smaller batch separately.",
+          batchSizeInBytes,
+          insertRowsRecommendedMaxSizeInBytes);
+    }
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -64,17 +64,14 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       ChannelRuntimeState channelRuntimeState,
       boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
-      long maxAllowedRowSizeInBytes,
-      long insertRowsRecommendedMaxSizeInBytes,
-      long insertRowsEnforcedMaxSizeInBytes) {
+      long maxAllowedRowSizeInBytes) {
     super(
         onErrorOption,
         defaultTimezone,
         fullyQualifiedChannelName,
         rowSizeMetric,
         channelRuntimeState,
-        insertRowsRecommendedMaxSizeInBytes,
-        insertRowsEnforcedMaxSizeInBytes);
+        maxChunkSizeInBytes);
     this.fieldIndex = new HashMap<>();
     this.metadata = new HashMap<>();
     this.data = new ArrayList<>();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -64,13 +64,17 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       ChannelRuntimeState channelRuntimeState,
       boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
-      long maxAllowedRowSizeInBytes) {
+      long maxAllowedRowSizeInBytes,
+      long insertRowsRecommendedMaxSizeInBytes,
+      long insertRowsEnforcedMaxSizeInBytes) {
     super(
         onErrorOption,
         defaultTimezone,
         fullyQualifiedChannelName,
         rowSizeMetric,
-        channelRuntimeState);
+        channelRuntimeState,
+        insertRowsRecommendedMaxSizeInBytes,
+        insertRowsEnforcedMaxSizeInBytes);
     this.fieldIndex = new HashMap<>();
     this.metadata = new HashMap<>();
     this.data = new ArrayList<>();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -130,7 +130,13 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
                 : ParameterProvider.MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT,
             owningClient != null
                 ? owningClient.getParameterProvider().getMaxAllowedRowSizeInBytes()
-                : ParameterProvider.MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT);
+                : ParameterProvider.MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT,
+            owningClient != null
+                ? owningClient.getParameterProvider().getInsertRowsRecommendedMaxSizeInBytes()
+                : ParameterProvider.INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES_DEFAULT,
+            owningClient != null
+                ? owningClient.getParameterProvider().getInsertRowsEnforcedMaxSizeInBytes()
+                : ParameterProvider.INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES_DEFAULT);
     logger.logInfo(
         "Channel={} created for table={}",
         this.channelFlushContext.getName(),

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -126,17 +126,11 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
                 ? owningClient.getParameterProvider().getEnableParquetInternalBuffering()
                 : ParameterProvider.ENABLE_PARQUET_INTERNAL_BUFFERING_DEFAULT,
             owningClient != null
-                ? owningClient.getParameterProvider().getMaxChannelSizeInBytes()
-                : ParameterProvider.MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT,
+                ? owningClient.getParameterProvider().getMaxChunkSizeInBytes()
+                : ParameterProvider.MAX_CHUNK_SIZE_IN_BYTES_DEFAULT,
             owningClient != null
                 ? owningClient.getParameterProvider().getMaxAllowedRowSizeInBytes()
-                : ParameterProvider.MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT,
-            owningClient != null
-                ? owningClient.getParameterProvider().getInsertRowsRecommendedMaxSizeInBytes()
-                : ParameterProvider.INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES_DEFAULT,
-            owningClient != null
-                ? owningClient.getParameterProvider().getInsertRowsEnforcedMaxSizeInBytes()
-                : ParameterProvider.INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES_DEFAULT);
+                : ParameterProvider.MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT);
     logger.logInfo(
         "Channel={} created for table={}",
         this.channelFlushContext.getName(),

--- a/src/main/java/net/snowflake/ingest/utils/ErrorCode.java
+++ b/src/main/java/net/snowflake/ingest/utils/ErrorCode.java
@@ -39,7 +39,8 @@ public enum ErrorCode {
   MAX_ROW_SIZE_EXCEEDED("0031"),
   MAKE_URI_FAILURE("0032"),
   OAUTH_REFRESH_TOKEN_ERROR("0033"),
-  INVALID_CONFIG_PARAMETER("0034");
+  INVALID_CONFIG_PARAMETER("0034"),
+  MAX_BATCH_SIZE_EXCEEDED("0035");
 
   public static final String errorMessageResource = "net.snowflake.ingest.ingest_error_messages";
 

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -163,7 +163,7 @@ public class ParameterProvider {
 
     this.updateValue(
         INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES,
-        INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES,
+        INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES_DEFAULT,
         parameterOverrides,
         props);
     this.updateValue(

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -31,6 +31,12 @@ public class ParameterProvider {
   public static final String MAX_ALLOWED_ROW_SIZE_IN_BYTES =
       "MAX_ALLOWED_ROW_SIZE_IN_BYTES".toLowerCase();
 
+  public static final String INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES =
+      "INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES".toLowerCase();
+
+  public static final String INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES =
+      "INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES".toLowerCase();
+
   // Default values
   public static final long BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT = 1000;
   public static final long BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT = 100;
@@ -46,6 +52,11 @@ public class ParameterProvider {
   public static final long MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT = 32000000L;
   public static final long MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 128000000L;
   public static final long MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT = 64 * 1024 * 1024; // 64 MB
+
+  public static final long INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES_DEFAULT =
+      16 * 1024 * 1024;
+  public static final long INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES_DEFAULT =
+      128 * 1024 * 1024;
 
   /* Parameter that enables using internal Parquet buffers for buffering of rows before serializing.
   It reduces memory consumption compared to using Java Objects for buffering.*/
@@ -149,6 +160,17 @@ public class ParameterProvider {
 
     this.updateValue(
         MAX_CHUNK_SIZE_IN_BYTES, MAX_CHUNK_SIZE_IN_BYTES_DEFAULT, parameterOverrides, props);
+
+    this.updateValue(
+        INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES,
+        INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES,
+        parameterOverrides,
+        props);
+    this.updateValue(
+        INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES,
+        INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES_DEFAULT,
+        parameterOverrides,
+        props);
   }
 
   /** @return Longest interval in milliseconds between buffer flushes */
@@ -293,6 +315,22 @@ public class ParameterProvider {
     Object val =
         this.parameterMap.getOrDefault(
             MAX_ALLOWED_ROW_SIZE_IN_BYTES, MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT);
+    return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
+  }
+
+  public long getInsertRowsRecommendedMaxSizeInBytes() {
+    Object val =
+        this.parameterMap.getOrDefault(
+            INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES,
+            INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES_DEFAULT);
+    return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
+  }
+
+  public long getInsertRowsEnforcedMaxSizeInBytes() {
+    Object val =
+        this.parameterMap.getOrDefault(
+            INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES,
+            INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES_DEFAULT);
     return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
   }
 

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -31,12 +31,6 @@ public class ParameterProvider {
   public static final String MAX_ALLOWED_ROW_SIZE_IN_BYTES =
       "MAX_ALLOWED_ROW_SIZE_IN_BYTES".toLowerCase();
 
-  public static final String INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES =
-      "INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES".toLowerCase();
-
-  public static final String INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES =
-      "INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES".toLowerCase();
-
   // Default values
   public static final long BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT = 1000;
   public static final long BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT = 100;
@@ -52,11 +46,6 @@ public class ParameterProvider {
   public static final long MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT = 32000000L;
   public static final long MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 128000000L;
   public static final long MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT = 64 * 1024 * 1024; // 64 MB
-
-  public static final long INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES_DEFAULT =
-      16 * 1024 * 1024;
-  public static final long INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES_DEFAULT =
-      128 * 1024 * 1024;
 
   /* Parameter that enables using internal Parquet buffers for buffering of rows before serializing.
   It reduces memory consumption compared to using Java Objects for buffering.*/
@@ -160,17 +149,6 @@ public class ParameterProvider {
 
     this.updateValue(
         MAX_CHUNK_SIZE_IN_BYTES, MAX_CHUNK_SIZE_IN_BYTES_DEFAULT, parameterOverrides, props);
-
-    this.updateValue(
-        INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES,
-        INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES_DEFAULT,
-        parameterOverrides,
-        props);
-    this.updateValue(
-        INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES,
-        INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES_DEFAULT,
-        parameterOverrides,
-        props);
   }
 
   /** @return Longest interval in milliseconds between buffer flushes */
@@ -315,22 +293,6 @@ public class ParameterProvider {
     Object val =
         this.parameterMap.getOrDefault(
             MAX_ALLOWED_ROW_SIZE_IN_BYTES, MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT);
-    return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
-  }
-
-  public long getInsertRowsRecommendedMaxSizeInBytes() {
-    Object val =
-        this.parameterMap.getOrDefault(
-            INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES,
-            INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES_DEFAULT);
-    return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
-  }
-
-  public long getInsertRowsEnforcedMaxSizeInBytes() {
-    Object val =
-        this.parameterMap.getOrDefault(
-            INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES,
-            INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES_DEFAULT);
     return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
   }
 

--- a/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
+++ b/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
@@ -37,3 +37,4 @@
 0032=URI builder fail to build url: {0}
 0033=OAuth token refresh failure: {0}
 0034=Invalid config parameter: {0}
+0035=The given batch of rows passed to insertRows() exceeded the maximum allowed batch size of {0} bytes. Consider splitting the batch into multiple smaller batches before passing them to insertRows(). We recommend batch size does not exceed {1} bytes.

--- a/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
+++ b/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
@@ -37,4 +37,4 @@
 0032=URI builder fail to build url: {0}
 0033=OAuth token refresh failure: {0}
 0034=Invalid config parameter: {0}
-0035=The given batch of rows passed to insertRows() exceeded the maximum allowed batch size of {0} bytes. Consider splitting the batch into multiple smaller batches before passing them to insertRows(). We recommend batch size does not exceed {1} bytes.
+0035=Too large batch of rows passed to insertRows, the batch size cannot exceed {0} bytes, recommended batch size for optimal performance and memory utilization is {1} bytes. We recommend splitting large batches into multiple smaller ones and call insertRows for each smaller batch separately.

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -1,6 +1,8 @@
 package net.snowflake.ingest.streaming.internal;
 
 import static java.time.ZoneOffset.UTC;
+import static net.snowflake.ingest.utils.ParameterProvider.INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES_DEFAULT;
+import static net.snowflake.ingest.utils.ParameterProvider.INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES_DEFAULT;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT;
 
@@ -117,7 +119,9 @@ public class RowBufferTest {
         initialState,
         enableParquetMemoryOptimization,
         MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT,
-        MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT);
+        MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT,
+        INSERT_ROWS_BATCH_SIZE_RECOMMENDED_MAX_SIZE_IN_BYTES_DEFAULT,
+        INSERT_ROWS_BATCH_SIZE_ENFORCED_MAX_SIZE_IN_BYTES_DEFAULT);
   }
 
   @Test
@@ -935,6 +939,36 @@ public class RowBufferTest {
         BigInteger.valueOf(11 * 60 * 60 * 1000L + 15 * 60 * 1000 + 456),
         result.getColumnEps().get("COLTIMESB8").getCurrentMaxIntValue());
     Assert.assertEquals(1, result.getColumnEps().get("COLTIMESB8").getCurrentNullCount());
+  }
+
+  @Test
+  public void testMaxInsertRowsBatchSize() {
+    testMaxInsertRowsBatchSizeHelper(OpenChannelRequest.OnErrorOption.CONTINUE);
+    testMaxInsertRowsBatchSizeHelper(OpenChannelRequest.OnErrorOption.ABORT);
+  }
+
+  private void testMaxInsertRowsBatchSizeHelper(OpenChannelRequest.OnErrorOption onErrorOption) {
+    AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
+    ColumnMetadata colBinary = new ColumnMetadata();
+    colBinary.setName("COLBINARY");
+    colBinary.setPhysicalType("LOB");
+    colBinary.setNullable(true);
+    colBinary.setLogicalType("BINARY");
+    colBinary.setLength(8 * 1024 * 1024);
+    colBinary.setByteLength(8 * 1024 * 1024);
+
+    byte[] arr = new byte[8 * 1024 * 1024];
+    innerBuffer.setupSchema(Collections.singletonList(colBinary));
+    List<Map<String, Object>> rows = new ArrayList<>();
+    for (int i = 0; i < 17; i++) { // 0 .. (128/8+1)
+      rows.add(Collections.singletonMap("COLBINARY", arr));
+    }
+    try {
+      innerBuffer.insertRows(rows, "");
+      Assert.fail("Inserting rows should have failed");
+    } catch (SFException e) {
+      Assert.assertEquals(ErrorCode.MAX_BATCH_SIZE_EXCEEDED.getMessageCode(), e.getVendorCode());
+    }
   }
 
   @Test


### PR DESCRIPTION
The SDK is currently unable to split the batch passed to insertRows if it is too large. This PR emits a warning if the batch is larger than 16MB and completely rejects the batch if its size is more than 128 MB. Both values are configurable.