### PR TITLE
SNOW-870386 Add default scheme parameters for test utils when profile is not specified

### DIFF
--- a/src/test/java/net/snowflake/ingest/TestUtils.java
+++ b/src/test/java/net/snowflake/ingest/TestUtils.java
@@ -96,6 +96,7 @@ public class TestUtils {
   private static String dummyUser = "user";
   private static int dummyPort = 443;
   private static String dummyHost = "snowflake.qa1.int.snowflakecomputing.com";
+  private static String dummyScheme = "http";
 
   /**
    * load all login info from profile
@@ -134,6 +135,7 @@ public class TestUtils {
       user = dummyUser;
       port = dummyPort;
       host = dummyHost;
+      scheme = dummyScheme;
       KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
       kpg.initialize(2048);
       keyPair = kpg.generateKeyPair();


### PR DESCRIPTION
OAuth Test fails when profile path is unspecified. Adding a default scheme parameter to resolve this issue.
See [JIRA ticket](https://snowflakecomputing.atlassian.net/browse/SNOW-870386) for more info.