### PR TITLE
Fix all vulnerabilities by updating packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <shadeBase>net.snowflake.ingest.internal</shadeBase>
     <slf4j.version>1.7.36</slf4j.version>
     <snappy.version>1.1.10.1</snappy.version>
-    <snowjdbc.version>3.13.30</snowjdbc.version>
+    <snowjdbc.version>3.13.33</snowjdbc.version>
     <yetus.version>0.13.0</yetus.version>
   </properties>
 
@@ -217,6 +217,14 @@
             <artifactId>hadoop-auth</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-guava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
           </exclusion>
@@ -268,6 +276,12 @@
         <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-hadoop</artifactId>
         <version>${parquet.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-jackson</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.yetus</groupId>
@@ -444,10 +458,6 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-hadoop</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <!-- Arifact name and version information -->
   <groupId>net.snowflake</groupId>
   <artifactId>snowflake-ingest-sdk</artifactId>
-  <version>2.0.3-REVI</version>
+  <version>2.0.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Snowflake Ingest SDK</name>
   <description>Snowflake Ingest SDK</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <!-- Arifact name and version information -->
   <groupId>net.snowflake</groupId>
   <artifactId>snowflake-ingest-sdk</artifactId>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>2.0.3-REVI</version>
   <packaging>jar</packaging>
   <name>Snowflake Ingest SDK</name>
   <description>Snowflake Ingest SDK</description>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <shadeBase>net.snowflake.ingest.internal</shadeBase>
     <slf4j.version>1.7.36</slf4j.version>
     <snappy.version>1.1.10.1</snappy.version>
-    <snowjdbc.version>3.13.33</snowjdbc.version>
+    <snowjdbc.version>3.13.31</snowjdbc.version>
     <yetus.version>0.13.0</yetus.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -218,10 +218,6 @@
           </exclusion>
           <exclusion>
             <groupId>org.apache.hadoop.thirdparty</groupId>
-            <artifactId>hadoop-shaded-guava</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.hadoop.thirdparty</groupId>
             <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
           </exclusion>
           <exclusion>
@@ -276,12 +272,6 @@
         <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-hadoop</artifactId>
         <version>${parquet.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-jackson</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.yetus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -460,6 +460,10 @@
       <artifactId>parquet-common</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-hadoop</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/src/test/java/net/snowflake/ingest/connection/UserAgentTest.java
+++ b/src/test/java/net/snowflake/ingest/connection/UserAgentTest.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.util.Properties;
 import net.snowflake.ingest.SimpleIngestManager;
 import org.junit.Assert;
-import org.junit.Test;
 
 public class UserAgentTest {
   // @Test

--- a/src/test/java/net/snowflake/ingest/connection/UserAgentTest.java
+++ b/src/test/java/net/snowflake/ingest/connection/UserAgentTest.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.util.Properties;
 import net.snowflake.ingest.SimpleIngestManager;
 import org.junit.Assert;
+import org.junit.Test;
 
 public class UserAgentTest {
   @Test

--- a/src/test/java/net/snowflake/ingest/connection/UserAgentTest.java
+++ b/src/test/java/net/snowflake/ingest/connection/UserAgentTest.java
@@ -8,7 +8,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class UserAgentTest {
-  @Test
+  // @Test
   public void testDefaultSdkVersionMatchesProjectVersion() throws IOException {
     Properties properties = new Properties();
     try (InputStream is =

--- a/src/test/java/net/snowflake/ingest/connection/UserAgentTest.java
+++ b/src/test/java/net/snowflake/ingest/connection/UserAgentTest.java
@@ -7,7 +7,7 @@ import net.snowflake.ingest.SimpleIngestManager;
 import org.junit.Assert;
 
 public class UserAgentTest {
-  // @Test
+  @Test
   public void testDefaultSdkVersionMatchesProjectVersion() throws IOException {
     Properties properties = new Properties();
     try (InputStream is =


### PR DESCRIPTION
Minimum JDBC version: 3.13.31, however needs to upgrade: 
- com.nimbusds:numbus-jose-jwt:9.2 (uses vulnerable net.minidev:json-smart:2.4.7) 
- Vulnerable com.google.guava:guava:30.0-jre -> 32.0.1-jre

Need to exclude org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1, but fails FlushServiceTest

### Changes
**❌ net.minidev:json-smart**
- Requires version update: 2.4.7 -> 2.4.9
- Search file: jsonaware
- Changes
	- net.snowflake:snowflake-jdbc:  3.13.30 -> 3.13.31
	 	- ✅ net.minidev:json-smart: 2.4.8 -> [2.4.9](https://github.com/snowflakedb/snowflake-jdbc/commit/aaf787e72adf73333caf8ce6aa2baae9fa1b0a1e)
	 	- ❌ NEEDS UPGRADE [v3.13.33](https://github.com/snowflakedb/snowflake-jdbc/blob/v3.13.33/pom.xml#L286) com.nimbusds:numbus-jose-jwt:9.21 (net.minidev:json-smart:2.4.7) 

**✅ com.google.protobuf:protobuf-java**
- Requires version update: 3.7.1 -> 3.16.3
- Search file: blockingrpcchannel
- Changes
	- 🆗 (no-op) com.google.protobuf:protobuf-java:3.19.6
	- ✅ exclude org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7

**❌ com.google.guava:guava**
- Requires version update: 30.1.1-jre -> 32.0.1
	- "Even though the security vulnerability is fixed in version 32.0.0, we recommend using version 32.0.1 as version 32.0.0 breaks some functionality under Windows." [CVE](https://nvd.nist.gov/vuln/detail/CVE-2023-2976)
- Search file: extraobjectmethodsforweb
- Changes
	- 🆗 (no-op) com.google.guava:guava:32.0.1-jre
	- ❌ exclude (but fails unit tests) org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1 (no upgrade)
		- com.google.guava:guava:[31.1-jre](https://github.com/apache/hadoop-thirdparty/blob/trunk/pom.xml#L98)
	- ❌ NEEDS UPGRADE net.snowflake:snowflake-jdbc: 3.13.30 -> 3.13.33
		- com.google.guava:guava:30.0-jre -> [31.1-jre](https://github.com/snowflakedb/snowflake-jdbc/commit/81eb493c10b0ae0ffbcea35828d0dda324dd044b)
		
		
**✅ com.fasterxml.jackson.core:jackson-databind**
- Requires version update: 2.13.2.2 -> 2.13.4
- Search file: propertynamingstrategies
- Changes
 	- 🆗 (no-op) com.fasterxml.jackson.core:jackson-databind:2.14.0
	- 🆗 (no-op) net.snowflake:snowflake-jdbc:3.13.30 on [2.13.4.2](https://github.com/snowflakedb/snowflake-jdbc/blob/v3.13.30/pom.xml#L45)
	- ✅ org.apache.parquet:parquet-jackson:1.12.3 -> 1.13.1 (in previous [pr](https://github.com/snowflakedb/snowflake-ingest-java/commit/2af18ec348c892f8d61899c4a5c2817b39d4ceed))
		- com.fasterxml.jackson.core:jackson-databind: 2.13.2.2 -> [2.13.4.2](https://github.com/apache/parquet-mr/blob/master/pom.xml#L70) 