### PR TITLE
reduce number of rows in BigFilesIT

### DIFF
--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestBigFilesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestBigFilesIT.java
@@ -69,7 +69,7 @@ public class StreamingIngestBigFilesIT {
 
     int numTables = 2;
     int numChannels = 4; // channels are assigned round-robin to tables.
-    int batchSize = 20000;
+    int batchSize = 10000;
     int numBatches = 10; // number of rows PER CHANNEL is batchSize * numBatches
     boolean isNullable = false;
 


### PR DESCRIPTION
This PR reduces the number of rows in `StreamingIngestBigFilesIT` from 20k to 10k per channel. This will stop server-side alerts on oversized chunks.