### PR TITLE
SNOW-672156 support specifying compression algorithm to be used for BDEC Parquet files

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
@@ -4,6 +4,7 @@
 
 package net.snowflake.ingest.streaming.internal;
 
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ParameterProvider;
 
 /** Channel's buffer relevant parameters that are set at the owning client level. */
@@ -14,6 +15,8 @@ public class ClientBufferParameters {
   private long maxChunkSizeInBytes;
 
   private long maxAllowedRowSizeInBytes;
+
+  private Constants.BdecParquetCompression bdecParquetCompression;
 
   /**
    * Private constructor used for test methods
@@ -26,10 +29,12 @@ public class ClientBufferParameters {
   private ClientBufferParameters(
       boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
-      long maxAllowedRowSizeInBytes) {
+      long maxAllowedRowSizeInBytes,
+      Constants.BdecParquetCompression bdecParquetCompression) {
     this.enableParquetInternalBuffering = enableParquetInternalBuffering;
     this.maxChunkSizeInBytes = maxChunkSizeInBytes;
     this.maxAllowedRowSizeInBytes = maxAllowedRowSizeInBytes;
+    this.bdecParquetCompression = bdecParquetCompression;
   }
 
   /** @param clientInternal reference to the client object where the relevant parameters are set */
@@ -46,6 +51,10 @@ public class ClientBufferParameters {
         clientInternal != null
             ? clientInternal.getParameterProvider().getMaxAllowedRowSizeInBytes()
             : ParameterProvider.MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT;
+    this.bdecParquetCompression =
+        clientInternal != null
+            ? clientInternal.getParameterProvider().getBdecParquetCompressionAlgorithm()
+            : ParameterProvider.BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT;
   }
 
   /**
@@ -58,9 +67,13 @@ public class ClientBufferParameters {
   public static ClientBufferParameters test_createClientBufferParameters(
       boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
-      long maxAllowedRowSizeInBytes) {
+      long maxAllowedRowSizeInBytes,
+      Constants.BdecParquetCompression bdecParquetCompression) {
     return new ClientBufferParameters(
-        enableParquetInternalBuffering, maxChunkSizeInBytes, maxAllowedRowSizeInBytes);
+        enableParquetInternalBuffering,
+        maxChunkSizeInBytes,
+        maxAllowedRowSizeInBytes,
+        bdecParquetCompression);
   }
 
   public boolean getEnableParquetInternalBuffering() {
@@ -73,5 +86,9 @@ public class ClientBufferParameters {
 
   public long getMaxAllowedRowSizeInBytes() {
     return maxAllowedRowSizeInBytes;
+  }
+
+  public Constants.BdecParquetCompression getBdecParquetCompression() {
+    return bdecParquetCompression;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.Pair;
@@ -27,15 +28,21 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
   private final boolean enableParquetInternalBuffering;
   private final long maxChunkSizeInBytes;
 
+  private final Constants.BdecParquetCompression bdecParquetCompression;
+
   /**
    * Construct parquet flusher from its schema and set flag that indicates whether Parquet memory
    * optimization is enabled, i.e. rows will be buffered in internal Parquet buffer.
    */
   public ParquetFlusher(
-      MessageType schema, boolean enableParquetInternalBuffering, long maxChunkSizeInBytes) {
+      MessageType schema,
+      boolean enableParquetInternalBuffering,
+      long maxChunkSizeInBytes,
+      Constants.BdecParquetCompression bdecParquetCompression) {
     this.schema = schema;
     this.enableParquetInternalBuffering = enableParquetInternalBuffering;
     this.maxChunkSizeInBytes = maxChunkSizeInBytes;
+    this.bdecParquetCompression = bdecParquetCompression;
   }
 
   @Override
@@ -198,7 +205,12 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
     Map<String, String> metadata = channelsDataPerTable.get(0).getVectors().metadata;
     parquetWriter =
         new BdecParquetWriter(
-            mergedData, schema, metadata, firstChannelFullyQualifiedTableName, maxChunkSizeInBytes);
+            mergedData,
+            schema,
+            metadata,
+            firstChannelFullyQualifiedTableName,
+            maxChunkSizeInBytes,
+            bdecParquetCompression);
     rows.forEach(parquetWriter::writeRow);
     parquetWriter.close();
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -122,7 +122,8 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
                 schema,
                 metadata,
                 channelName,
-                clientBufferParameters.getMaxChunkSizeInBytes());
+                clientBufferParameters.getMaxChunkSizeInBytes(),
+                clientBufferParameters.getBdecParquetCompression());
       } else {
         this.bdecParquetWriter = null;
       }
@@ -323,7 +324,8 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
     return new ParquetFlusher(
         schema,
         clientBufferParameters.getEnableParquetInternalBuffering(),
-        clientBufferParameters.getMaxChunkSizeInBytes());
+        clientBufferParameters.getMaxChunkSizeInBytes(),
+        clientBufferParameters.getBdecParquetCompression());
   }
 
   private static class ParquetColumn {

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -138,7 +138,7 @@ public class Constants {
       }
       throw new IllegalArgumentException(
           String.format(
-              "Unsupported BDEC_PARQUET_COMPRESSION_ALGORITHM = '%d', allowed values are %s",
+              "Unsupported BDEC_PARQUET_COMPRESSION_ALGORITHM = '%s', allowed values are %s",
               name, Arrays.asList(BdecParquetCompression.values())));
     }
   }

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -119,15 +119,10 @@ public class Constants {
    * CompressionCodecName, but we want to control and allow only specific values of that.
    */
   public enum BdecParquetCompression {
-    UNCOMPRESSED,
-    GZIP,
-    SNAPPY,
-    ZSTD;
+    GZIP;
 
     public CompressionCodecName getCompressionCodec() {
-      return (this == UNCOMPRESSED
-          ? CompressionCodecName.fromConf(null)
-          : CompressionCodecName.fromConf(this.name()));
+      return CompressionCodecName.fromConf(this.name());
     }
 
     public static BdecParquetCompression fromName(String name) {

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -5,6 +5,7 @@
 package net.snowflake.ingest.utils;
 
 import java.util.Arrays;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 /** Contains all the constants needed for Streaming Ingest */
 public class Constants {
@@ -113,6 +114,34 @@ public class Constants {
     }
   }
 
+  /**
+   * Compression algorithm supported by BDEC Parquet Writer. It is a wrapper around Parquet's lib
+   * CompressionCodecName, but we want to control and allow only specific values of that.
+   */
+  public enum BdecParquetCompression {
+    UNCOMPRESSED,
+    GZIP,
+    SNAPPY,
+    ZSTD;
+
+    public CompressionCodecName getCompressionCodec() {
+      return (this == UNCOMPRESSED
+          ? CompressionCodecName.fromConf(null)
+          : CompressionCodecName.fromConf(this.name()));
+    }
+
+    public static BdecParquetCompression fromName(String name) {
+      for (BdecParquetCompression e : BdecParquetCompression.values()) {
+        if (e.name().toLowerCase().equals(name.toLowerCase())) {
+          return e;
+        }
+      }
+      throw new IllegalArgumentException(
+          String.format(
+              "Unsupported BDEC_PARQUET_COMPRESSION_ALGORITHM = '%d', allowed values are %s",
+              name, Arrays.asList(BdecParquetCompression.values())));
+    }
+  }
   // Parameters
   public static final boolean DISABLE_BACKGROUND_FLUSH = false;
   public static final boolean COMPRESS_BLOB_TWICE = false;

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -38,6 +38,9 @@ public class ParameterProvider {
 
   public static final String MAX_CLIENT_LAG_ENABLED = "MAX_CLIENT_LAG_ENABLED".toLowerCase();
 
+  public static final String BDEC_PARQUET_COMPRESSION_ALGORITHM =
+          "BDEC_PARQUET_COMPRESSION_ALGORITHM".toLowerCase();
+
   // Default values
   public static final long BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT = 1000;
   public static final long BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT = 100;
@@ -62,6 +65,9 @@ public class ParameterProvider {
   static final long MAX_CLIENT_LAG_MS_MAX = TimeUnit.MINUTES.toMillis(10);
   public static final long MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT = 64 * 1024 * 1024; // 64 MB
   public static final int MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_DEFAULT = 100;
+
+  public static final Constants.BdecParquetCompression BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT =
+          Constants.BdecParquetCompression.GZIP;
 
   /* Parameter that enables using internal Parquet buffers for buffering of rows before serializing.
   It reduces memory consumption compared to using Java Objects for buffering.*/
@@ -178,6 +184,12 @@ public class ParameterProvider {
         MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_DEFAULT,
         parameterOverrides,
         props);
+
+    this.updateValue(
+            BDEC_PARQUET_COMPRESSION_ALGORITHM,
+            BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT,
+            parameterOverrides,
+            props);
   }
 
   /** @return Longest interval in milliseconds between buffer flushes */
@@ -377,7 +389,6 @@ public class ParameterProvider {
     return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
   }
 
-  /** @return The max allow row size (in bytes) */
   public long getMaxAllowedRowSizeInBytes() {
     Object val =
         this.parameterMap.getOrDefault(
@@ -395,6 +406,17 @@ public class ParameterProvider {
             MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST,
             MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_DEFAULT);
     return (val instanceof String) ? Integer.parseInt(val.toString()) : (int) val;
+  }
+
+  /** @return BDEC compression algorithm */
+  public Constants.BdecParquetCompression getBdecParquetCompressionAlgorithm() {
+    Object val =
+            this.parameterMap.getOrDefault(
+                    BDEC_PARQUET_COMPRESSION_ALGORITHM, BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT);
+    if (val instanceof Constants.BdecParquetCompression) {
+      return (Constants.BdecParquetCompression) val;
+    }
+    return Constants.BdecParquetCompression.fromName((String) val);
   }
 
   @Override

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -39,7 +39,7 @@ public class ParameterProvider {
   public static final String MAX_CLIENT_LAG_ENABLED = "MAX_CLIENT_LAG_ENABLED".toLowerCase();
 
   public static final String BDEC_PARQUET_COMPRESSION_ALGORITHM =
-          "BDEC_PARQUET_COMPRESSION_ALGORITHM".toLowerCase();
+      "BDEC_PARQUET_COMPRESSION_ALGORITHM".toLowerCase();
 
   // Default values
   public static final long BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT = 1000;
@@ -67,7 +67,7 @@ public class ParameterProvider {
   public static final int MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_DEFAULT = 100;
 
   public static final Constants.BdecParquetCompression BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT =
-          Constants.BdecParquetCompression.GZIP;
+      Constants.BdecParquetCompression.GZIP;
 
   /* Parameter that enables using internal Parquet buffers for buffering of rows before serializing.
   It reduces memory consumption compared to using Java Objects for buffering.*/
@@ -186,10 +186,10 @@ public class ParameterProvider {
         props);
 
     this.updateValue(
-            BDEC_PARQUET_COMPRESSION_ALGORITHM,
-            BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT,
-            parameterOverrides,
-            props);
+        BDEC_PARQUET_COMPRESSION_ALGORITHM,
+        BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT,
+        parameterOverrides,
+        props);
   }
 
   /** @return Longest interval in milliseconds between buffer flushes */

--- a/src/main/java/org/apache/parquet/hadoop/BdecParquetWriter.java
+++ b/src/main/java/org/apache/parquet/hadoop/BdecParquetWriter.java
@@ -17,7 +17,6 @@ import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.values.factory.DefaultV1ValuesWriterFactory;
 import org.apache.parquet.crypto.FileEncryptionProperties;
 import org.apache.parquet.hadoop.api.WriteSupport;
-import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.DelegatingPositionOutputStream;
 import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.io.ParquetEncodingException;
@@ -51,7 +50,8 @@ public class BdecParquetWriter implements AutoCloseable {
       MessageType schema,
       Map<String, String> extraMetaData,
       String channelName,
-      long maxChunkSizeInBytes)
+      long maxChunkSizeInBytes,
+      Constants.BdecParquetCompression bdecParquetCompression)
       throws IOException {
     OutputFile file = new ByteArrayOutputFile(stream, maxChunkSizeInBytes);
     ParquetProperties encodingProps = createParquetProperties();
@@ -86,7 +86,8 @@ public class BdecParquetWriter implements AutoCloseable {
     */
     codecFactory = new CodecFactory(conf, ParquetWriter.DEFAULT_PAGE_SIZE);
     @SuppressWarnings("deprecation") // Parquet does not support the new one now
-    CodecFactory.BytesCompressor compressor = codecFactory.getCompressor(CompressionCodecName.GZIP);
+    CodecFactory.BytesCompressor compressor =
+        codecFactory.getCompressor(bdecParquetCompression.getCompressionCodec());
     writer =
         new InternalParquetRecordWriter<>(
             fileWriter,

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -21,7 +21,7 @@ public class ParameterProviderTest {
     parameterMap.put(ParameterProvider.BLOB_UPLOAD_MAX_RETRY_COUNT, 100);
     parameterMap.put(ParameterProvider.MAX_MEMORY_LIMIT_IN_BYTES, 1000L);
     parameterMap.put(ParameterProvider.MAX_CHANNEL_SIZE_IN_BYTES, 1000000L);
-    parameterMap.put(ParameterProvider.BDEC_PARQUET_COMPRESSION_ALGORITHM, "zstd");
+    parameterMap.put(ParameterProvider.BDEC_PARQUET_COMPRESSION_ALGORITHM, "gzip");
     return parameterMap;
   }
 
@@ -42,7 +42,7 @@ public class ParameterProviderTest {
     Assert.assertEquals(1000L, parameterProvider.getMaxMemoryLimitInBytes());
     Assert.assertEquals(1000000L, parameterProvider.getMaxChannelSizeInBytes());
     Assert.assertEquals(
-        Constants.BdecParquetCompression.ZSTD,
+        Constants.BdecParquetCompression.GZIP,
         parameterProvider.getBdecParquetCompressionAlgorithm());
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -3,6 +3,7 @@ package net.snowflake.ingest.streaming.internal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ParameterProvider;
 import org.junit.Assert;
 import org.junit.Test;
@@ -20,6 +21,7 @@ public class ParameterProviderTest {
     parameterMap.put(ParameterProvider.BLOB_UPLOAD_MAX_RETRY_COUNT, 100);
     parameterMap.put(ParameterProvider.MAX_MEMORY_LIMIT_IN_BYTES, 1000L);
     parameterMap.put(ParameterProvider.MAX_CHANNEL_SIZE_IN_BYTES, 1000000L);
+    parameterMap.put(ParameterProvider.BDEC_PARQUET_COMPRESSION_ALGORITHM, "zstd");
     return parameterMap;
   }
 
@@ -39,6 +41,9 @@ public class ParameterProviderTest {
     Assert.assertEquals(100, parameterProvider.getBlobUploadMaxRetryCount());
     Assert.assertEquals(1000L, parameterProvider.getMaxMemoryLimitInBytes());
     Assert.assertEquals(1000000L, parameterProvider.getMaxChannelSizeInBytes());
+    Assert.assertEquals(
+        Constants.BdecParquetCompression.ZSTD,
+        parameterProvider.getBdecParquetCompressionAlgorithm());
   }
 
   @Test
@@ -130,6 +135,9 @@ public class ParameterProviderTest {
     Assert.assertEquals(
         ParameterProvider.MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT,
         parameterProvider.getMaxChannelSizeInBytes());
+    Assert.assertEquals(
+        ParameterProvider.BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT,
+        parameterProvider.getBdecParquetCompressionAlgorithm());
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -1,6 +1,8 @@
 package net.snowflake.ingest.streaming.internal;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import net.snowflake.ingest.utils.Constants;
@@ -288,5 +290,37 @@ public class ParameterProviderTest {
     parameterMap.put("max_chunks_in_blob_and_registration_request", 1);
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
     Assert.assertEquals(1, parameterProvider.getMaxChunksInBlobAndRegistrationRequest());
+  }
+
+  @Test
+  public void testValidCompressionAlgorithmsAndWithUppercaseLowerCase() {
+    List<String> gzipValues = Arrays.asList("GZIP", "gzip", "Gzip", "gZip");
+    gzipValues.forEach(
+        v -> {
+          Properties prop = new Properties();
+          Map<String, Object> parameterMap = getStartingParameterMap();
+          parameterMap.put(ParameterProvider.BDEC_PARQUET_COMPRESSION_ALGORITHM, v);
+          ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
+          Assert.assertEquals(
+              Constants.BdecParquetCompression.GZIP,
+              parameterProvider.getBdecParquetCompressionAlgorithm());
+        });
+  }
+
+  @Test
+  public void testInvalidCompressionAlgorithm() {
+    Properties prop = new Properties();
+    Map<String, Object> parameterMap = getStartingParameterMap();
+    parameterMap.put(ParameterProvider.BDEC_PARQUET_COMPRESSION_ALGORITHM, "invalid_comp");
+    ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
+    try {
+      parameterProvider.getBdecParquetCompressionAlgorithm();
+      Assert.fail("Should not have succeeded");
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals(
+          "Unsupported BDEC_PARQUET_COMPRESSION_ALGORITHM = 'invalid_comp', allowed values are"
+              + " [GZIP]",
+          e.getMessage());
+    }
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -120,7 +120,8 @@ public class RowBufferTest {
         ClientBufferParameters.test_createClientBufferParameters(
             enableParquetMemoryOptimization,
             MAX_CHUNK_SIZE_IN_BYTES_DEFAULT,
-            MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT));
+            MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT,
+            Constants.BdecParquetCompression.GZIP));
   }
 
   @Test


### PR DESCRIPTION
This PR adds support for specifying the compression algorithm to be used for BDEC Parquet files. The allowed value is just `GZIP` for now.