### PR TITLE
SNOW-902709 Limit the max allowed number of chunks in blob

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -350,6 +350,16 @@ class FlushService<T> {
         if (!leftoverChannelsDataPerTable.isEmpty()) {
           channelsDataPerTable.addAll(leftoverChannelsDataPerTable);
           leftoverChannelsDataPerTable.clear();
+        } else if (blobData.size()
+            >= this.owningClient.getParameterProvider().getMaxChunksInBlob()) {
+          // Create a new blob if the current one already contains max allowed number of chunks
+          logger.logInfo(
+              "Max allowed number of chunks in the current blob reached. chunkCount={}"
+                  + " maxChunkCount={} currentBlobPath={}",
+              blobData.size(),
+              this.owningClient.getParameterProvider().getMaxChunksInBlob(),
+              blobPath);
+          break;
         } else {
           ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<T>> table =
               itr.next().getValue();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -351,13 +351,15 @@ class FlushService<T> {
           channelsDataPerTable.addAll(leftoverChannelsDataPerTable);
           leftoverChannelsDataPerTable.clear();
         } else if (blobData.size()
-            >= this.owningClient.getParameterProvider().getMaxChunksInBlob()) {
+            >= this.owningClient
+                .getParameterProvider()
+                .getMaxChunksInBlobAndRegistrationRequest()) {
           // Create a new blob if the current one already contains max allowed number of chunks
           logger.logInfo(
               "Max allowed number of chunks in the current blob reached. chunkCount={}"
                   + " maxChunkCount={} currentBlobPath={}",
               blobData.size(),
-              this.owningClient.getParameterProvider().getMaxChunksInBlob(),
+              this.owningClient.getParameterProvider().getMaxChunksInBlobAndRegistrationRequest(),
               blobPath);
           break;
         } else {

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -31,6 +31,9 @@ public class ParameterProvider {
   public static final String MAX_CHUNK_SIZE_IN_BYTES = "MAX_CHUNK_SIZE_IN_BYTES".toLowerCase();
   public static final String MAX_ALLOWED_ROW_SIZE_IN_BYTES =
       "MAX_ALLOWED_ROW_SIZE_IN_BYTES".toLowerCase();
+  public static final String MAX_CHUNKS_IN_BLOB = "MAX_CHUNKS_IN_BLOB".toLowerCase();
+  public static final String MAX_CHUNKS_IN_REGISTRATION_REQUEST =
+      "MAX_CHUNKS_IN_REGISTRATION_REQUEST".toLowerCase();
 
   public static final String MAX_CLIENT_LAG = "MAX_CLIENT_LAG".toLowerCase();
 
@@ -59,6 +62,8 @@ public class ParameterProvider {
 
   static final long MAX_CLIENT_LAG_MS_MAX = TimeUnit.MINUTES.toMillis(10);
   public static final long MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT = 64 * 1024 * 1024; // 64 MB
+  public static final int MAX_CHUNKS_IN_BLOB_DEFAULT = 20;
+  public static final int MAX_CHUNKS_IN_REGISTRATION_REQUEST_DEFAULT = 100;
 
   /* Parameter that enables using internal Parquet buffers for buffering of rows before serializing.
   It reduces memory consumption compared to using Java Objects for buffering.*/
@@ -79,6 +84,7 @@ public class ParameterProvider {
    */
   public ParameterProvider(Map<String, Object> parameterOverrides, Properties props) {
     this.setParameterMap(parameterOverrides, props);
+    this.validateParameters();
   }
 
   /** Empty constructor for tests */
@@ -170,6 +176,12 @@ public class ParameterProvider {
     this.updateValue(MAX_CLIENT_LAG, MAX_CLIENT_LAG_DEFAULT, parameterOverrides, props);
     this.updateValue(
         MAX_CLIENT_LAG_ENABLED, MAX_CLIENT_LAG_ENABLED_DEFAULT, parameterOverrides, props);
+    this.updateValue(MAX_CHUNKS_IN_BLOB, MAX_CHUNKS_IN_BLOB_DEFAULT, parameterOverrides, props);
+    this.updateValue(
+        MAX_CHUNKS_IN_REGISTRATION_REQUEST,
+        MAX_CHUNKS_IN_REGISTRATION_REQUEST_DEFAULT,
+        parameterOverrides,
+        props);
   }
 
   /** @return Longest interval in milliseconds between buffer flushes */
@@ -369,11 +381,44 @@ public class ParameterProvider {
     return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
   }
 
+  /** @return The max allow row size (in bytes) */
   public long getMaxAllowedRowSizeInBytes() {
     Object val =
         this.parameterMap.getOrDefault(
             MAX_ALLOWED_ROW_SIZE_IN_BYTES, MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT);
     return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
+  }
+
+  /** @return The max number of chunks that can be put into a single BDEC file */
+  public int getMaxChunksInBlob() {
+    Object val = this.parameterMap.getOrDefault(MAX_CHUNKS_IN_BLOB, MAX_CHUNKS_IN_BLOB_DEFAULT);
+    return (val instanceof String) ? Integer.parseInt(val.toString()) : (int) val;
+  }
+
+  /**
+   * @return The max number of chunks that can be put into a single BDEC registration request. Must
+   *     be higher than MAX_CHUNKS_IN_BLOB.
+   */
+  public int getMaxChunksInRegistrationRequest() {
+    Object val =
+        this.parameterMap.getOrDefault(
+            MAX_CHUNKS_IN_REGISTRATION_REQUEST, MAX_CHUNKS_IN_REGISTRATION_REQUEST_DEFAULT);
+    return (val instanceof String) ? Integer.parseInt(val.toString()) : (int) val;
+  }
+
+  /** Validates parameters */
+  private void validateParameters() {
+    if (this.getMaxChunksInBlob() >= this.getMaxChunksInRegistrationRequest()) {
+      throw new SFException(
+          ErrorCode.INVALID_CONFIG_PARAMETER,
+          String.format(
+              "Value of configuration property %s (%d) must be smaller than the value of"
+                  + " configuration property %s (%d).",
+              MAX_CHUNKS_IN_BLOB,
+              getMaxChunksInBlob(),
+              MAX_CHUNKS_IN_REGISTRATION_REQUEST,
+              getMaxChunksInRegistrationRequest()));
+    }
   }
 
   @Override

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -31,9 +31,8 @@ public class ParameterProvider {
   public static final String MAX_CHUNK_SIZE_IN_BYTES = "MAX_CHUNK_SIZE_IN_BYTES".toLowerCase();
   public static final String MAX_ALLOWED_ROW_SIZE_IN_BYTES =
       "MAX_ALLOWED_ROW_SIZE_IN_BYTES".toLowerCase();
-  public static final String MAX_CHUNKS_IN_BLOB = "MAX_CHUNKS_IN_BLOB".toLowerCase();
-  public static final String MAX_CHUNKS_IN_REGISTRATION_REQUEST =
-      "MAX_CHUNKS_IN_REGISTRATION_REQUEST".toLowerCase();
+  public static final String MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST =
+      "MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST".toLowerCase();
 
   public static final String MAX_CLIENT_LAG = "MAX_CLIENT_LAG".toLowerCase();
 
@@ -62,8 +61,7 @@ public class ParameterProvider {
 
   static final long MAX_CLIENT_LAG_MS_MAX = TimeUnit.MINUTES.toMillis(10);
   public static final long MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT = 64 * 1024 * 1024; // 64 MB
-  public static final int MAX_CHUNKS_IN_BLOB_DEFAULT = 20;
-  public static final int MAX_CHUNKS_IN_REGISTRATION_REQUEST_DEFAULT = 100;
+  public static final int MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_DEFAULT = 100;
 
   /* Parameter that enables using internal Parquet buffers for buffering of rows before serializing.
   It reduces memory consumption compared to using Java Objects for buffering.*/
@@ -84,7 +82,6 @@ public class ParameterProvider {
    */
   public ParameterProvider(Map<String, Object> parameterOverrides, Properties props) {
     this.setParameterMap(parameterOverrides, props);
-    this.validateParameters();
   }
 
   /** Empty constructor for tests */
@@ -176,10 +173,9 @@ public class ParameterProvider {
     this.updateValue(MAX_CLIENT_LAG, MAX_CLIENT_LAG_DEFAULT, parameterOverrides, props);
     this.updateValue(
         MAX_CLIENT_LAG_ENABLED, MAX_CLIENT_LAG_ENABLED_DEFAULT, parameterOverrides, props);
-    this.updateValue(MAX_CHUNKS_IN_BLOB, MAX_CHUNKS_IN_BLOB_DEFAULT, parameterOverrides, props);
     this.updateValue(
-        MAX_CHUNKS_IN_REGISTRATION_REQUEST,
-        MAX_CHUNKS_IN_REGISTRATION_REQUEST_DEFAULT,
+        MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST,
+        MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_DEFAULT,
         parameterOverrides,
         props);
   }
@@ -389,36 +385,16 @@ public class ParameterProvider {
     return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
   }
 
-  /** @return The max number of chunks that can be put into a single BDEC file */
-  public int getMaxChunksInBlob() {
-    Object val = this.parameterMap.getOrDefault(MAX_CHUNKS_IN_BLOB, MAX_CHUNKS_IN_BLOB_DEFAULT);
-    return (val instanceof String) ? Integer.parseInt(val.toString()) : (int) val;
-  }
-
   /**
-   * @return The max number of chunks that can be put into a single BDEC registration request. Must
-   *     be higher than MAX_CHUNKS_IN_BLOB.
+   * @return The max number of chunks that can be put into a single BDEC or blob registration
+   *     request.
    */
-  public int getMaxChunksInRegistrationRequest() {
+  public int getMaxChunksInBlobAndRegistrationRequest() {
     Object val =
         this.parameterMap.getOrDefault(
-            MAX_CHUNKS_IN_REGISTRATION_REQUEST, MAX_CHUNKS_IN_REGISTRATION_REQUEST_DEFAULT);
+            MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST,
+            MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_DEFAULT);
     return (val instanceof String) ? Integer.parseInt(val.toString()) : (int) val;
-  }
-
-  /** Validates parameters */
-  private void validateParameters() {
-    if (this.getMaxChunksInBlob() >= this.getMaxChunksInRegistrationRequest()) {
-      throw new SFException(
-          ErrorCode.INVALID_CONFIG_PARAMETER,
-          String.format(
-              "Value of configuration property %s (%d) must be smaller than the value of"
-                  + " configuration property %s (%d).",
-              MAX_CHUNKS_IN_BLOB,
-              getMaxChunksInBlob(),
-              MAX_CHUNKS_IN_REGISTRATION_REQUEST,
-              getMaxChunksInRegistrationRequest()));
-    }
   }
 
   @Override

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -582,7 +582,7 @@ public class FlushServiceTest {
             Math.ceil(
                 (double) numberOfRows
                     / channelsPerTable
-                    / ParameterProvider.MAX_CHUNKS_IN_BLOB_DEFAULT);
+                    / ParameterProvider.MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_DEFAULT);
 
     final TestContext<List<List<Object>>> testContext = testContextFactory.create();
 
@@ -612,7 +612,7 @@ public class FlushServiceTest {
   public void testBlobSplitDueToNumberOfChunksWithLeftoverChannels() throws Exception {
     final TestContext<List<List<Object>>> testContext = testContextFactory.create();
 
-    for (int i = 0; i < 19; i++) { // 19 simple chunks
+    for (int i = 0; i < 99; i++) { // 19 simple chunks
       SnowflakeStreamingIngestChannelInternal<List<List<Object>>> channel =
           addChannel(testContext, i, 1);
       channel.setupSchema(Collections.singletonList(createLargeTestTextColumn("C1")));
@@ -622,19 +622,19 @@ public class FlushServiceTest {
     // 20th chunk would contain multiple channels, but there are some with different encryption key
     // ID, so they spill to a new blob
     SnowflakeStreamingIngestChannelInternal<List<List<Object>>> channel1 =
-        addChannel(testContext, 19, 1);
+        addChannel(testContext, 99, 1);
     channel1.setupSchema(Collections.singletonList(createLargeTestTextColumn("C1")));
-    channel1.insertRow(Collections.singletonMap("C1", 19), "");
+    channel1.insertRow(Collections.singletonMap("C1", 0), "");
 
     SnowflakeStreamingIngestChannelInternal<List<List<Object>>> channel2 =
-        addChannel(testContext, 19, 2);
+        addChannel(testContext, 99, 2);
     channel2.setupSchema(Collections.singletonList(createLargeTestTextColumn("C1")));
-    channel2.insertRow(Collections.singletonMap("C1", 19), "");
+    channel2.insertRow(Collections.singletonMap("C1", 0), "");
 
     SnowflakeStreamingIngestChannelInternal<List<List<Object>>> channel3 =
-        addChannel(testContext, 19, 2);
+        addChannel(testContext, 99, 2);
     channel3.setupSchema(Collections.singletonList(createLargeTestTextColumn("C1")));
-    channel3.insertRow(Collections.singletonMap("C1", 19), "");
+    channel3.insertRow(Collections.singletonMap("C1", 0), "");
 
     FlushService<List<List<Object>>> flushService = testContext.flushService;
     flushService.flush(true).get();
@@ -648,7 +648,7 @@ public class FlushServiceTest {
     List<List<List<ChannelData<List<List<Object>>>>>> allUploadedBlobs =
         blobDataCaptor.getAllValues();
 
-    Assert.assertEquals(22, getRows(allUploadedBlobs).size());
+    Assert.assertEquals(102, getRows(allUploadedBlobs).size());
   }
 
   private List<List<Object>> getRows(List<List<List<ChannelData<List<List<Object>>>>>> blobs) {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ManyTablesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ManyTablesIT.java
@@ -26,8 +26,8 @@ import org.junit.Test;
  */
 public class ManyTablesIT {
 
-  private static final int TABLES_COUNT = 100;
-  private static final int TOTAL_ROWS_COUNT = 20_000;
+  private static final int TABLES_COUNT = 20;
+  private static final int TOTAL_ROWS_COUNT = 200_000;
   private String dbName;
   private SnowflakeStreamingIngestClient client;
   private Connection connection;
@@ -37,8 +37,7 @@ public class ManyTablesIT {
   @Before
   public void setUp() throws Exception {
     Properties props = TestUtils.getProperties(Constants.BdecVersion.THREE, false);
-    props.put(ParameterProvider.MAX_CHUNKS_IN_BLOB, 2);
-    props.put(ParameterProvider.MAX_CHUNKS_IN_REGISTRATION_REQUEST, 3);
+    props.put(ParameterProvider.MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST, 2);
     if (props.getProperty(ROLE).equals("DEFAULT_ROLE")) {
       props.setProperty(ROLE, "ACCOUNTADMIN");
     }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ManyTablesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ManyTablesIT.java
@@ -1,0 +1,99 @@
+package net.snowflake.ingest.streaming.internal;
+
+import static net.snowflake.ingest.utils.Constants.ROLE;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import net.snowflake.ingest.TestUtils;
+import net.snowflake.ingest.streaming.OpenChannelRequest;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
+import net.snowflake.ingest.utils.Constants;
+import net.snowflake.ingest.utils.ParameterProvider;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verified that ingestion work when we ingest into large number of tables from the same client and
+ * blobs and registration requests have to be cut, so they don't contain large number of chunks
+ */
+public class ManyTablesIT {
+
+  private static final int TABLES_COUNT = 100;
+  private static final int TOTAL_ROWS_COUNT = 20_000;
+  private String dbName;
+  private SnowflakeStreamingIngestClient client;
+  private Connection connection;
+  private SnowflakeStreamingIngestChannel[] channels;
+  private String[] offsetTokensPerChannel;
+
+  @Before
+  public void setUp() throws Exception {
+    Properties props = TestUtils.getProperties(Constants.BdecVersion.THREE, false);
+    props.put(ParameterProvider.MAX_CHUNKS_IN_BLOB, 2);
+    props.put(ParameterProvider.MAX_CHUNKS_IN_REGISTRATION_REQUEST, 3);
+    if (props.getProperty(ROLE).equals("DEFAULT_ROLE")) {
+      props.setProperty(ROLE, "ACCOUNTADMIN");
+    }
+    client = SnowflakeStreamingIngestClientFactory.builder("client1").setProperties(props).build();
+    connection = TestUtils.getConnection(true);
+    dbName = String.format("sdk_it_many_tables_db_%d", System.nanoTime());
+
+    channels = new SnowflakeStreamingIngestChannel[TABLES_COUNT];
+    offsetTokensPerChannel = new String[TABLES_COUNT];
+    connection.createStatement().execute(String.format("create database %s;", dbName));
+
+    String[] tableNames = new String[TABLES_COUNT];
+    for (int i = 0; i < tableNames.length; i++) {
+      tableNames[i] = String.format("table_%d", i);
+      connection.createStatement().execute(String.format("create table table_%d(c int);", i));
+      channels[i] =
+          client.openChannel(
+              OpenChannelRequest.builder(String.format("channel-%d", i))
+                  .setDBName(dbName)
+                  .setSchemaName("public")
+                  .setTableName(tableNames[i])
+                  .setOnErrorOption(OpenChannelRequest.OnErrorOption.ABORT)
+                  .build());
+    }
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    connection.createStatement().execute(String.format("drop database %s;", dbName));
+    client.close();
+    connection.close();
+  }
+
+  @Test
+  public void testIngestionIntoManyTables() throws InterruptedException, SQLException {
+    for (int i = 0; i < TOTAL_ROWS_COUNT; i++) {
+      Map<String, Object> row = Collections.singletonMap("c", i);
+      String offset = String.valueOf(i);
+      int channelId = i % channels.length;
+      channels[channelId].insertRow(row, offset);
+      offsetTokensPerChannel[channelId] = offset;
+    }
+
+    for (int i = 0; i < channels.length; i++) {
+      TestUtils.waitForOffset(channels[i], offsetTokensPerChannel[i]);
+    }
+
+    int totalRowsCount = 0;
+    ResultSet rs =
+        connection
+            .createStatement()
+            .executeQuery(String.format("show tables in database %s;", dbName));
+    while (rs.next()) {
+      totalRowsCount += rs.getInt("rows");
+    }
+    Assert.assertEquals(TOTAL_ROWS_COUNT, totalRowsCount);
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -3,7 +3,9 @@ package net.snowflake.ingest.streaming.internal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.ParameterProvider;
+import net.snowflake.ingest.utils.SFException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -270,6 +272,31 @@ public class ParameterProviderTest {
       Assert.fail("Should not have succeeded");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().startsWith("Lag falls outside"));
+    }
+  }
+
+  @Test
+  public void testMaxChunksInBlobAndRegistrationRequest() {
+    Properties prop = new Properties();
+    Map<String, Object> parameterMap = getStartingParameterMap();
+    parameterMap.put("max_chunks_in_blob", 1);
+    parameterMap.put("max_chunks_in_registration_request", 2);
+    ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
+    Assert.assertEquals(1, parameterProvider.getMaxChunksInBlob());
+    Assert.assertEquals(2, parameterProvider.getMaxChunksInRegistrationRequest());
+  }
+
+  @Test
+  public void testValidationMaxChunksInBlobAndRegistrationRequest() {
+    Properties prop = new Properties();
+    Map<String, Object> parameterMap = getStartingParameterMap();
+    parameterMap.put("max_chunks_in_blob", 2);
+    parameterMap.put("max_chunks_in_registration_request", 1);
+    try {
+      new ParameterProvider(parameterMap, prop);
+      Assert.fail("Should not have succeeded");
+    } catch (SFException e) {
+      Assert.assertEquals(ErrorCode.INVALID_CONFIG_PARAMETER.getMessageCode(), e.getVendorCode());
     }
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -3,9 +3,7 @@ package net.snowflake.ingest.streaming.internal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.ParameterProvider;
-import net.snowflake.ingest.utils.SFException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -279,24 +277,8 @@ public class ParameterProviderTest {
   public void testMaxChunksInBlobAndRegistrationRequest() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put("max_chunks_in_blob", 1);
-    parameterMap.put("max_chunks_in_registration_request", 2);
+    parameterMap.put("max_chunks_in_blob_and_registration_request", 1);
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
-    Assert.assertEquals(1, parameterProvider.getMaxChunksInBlob());
-    Assert.assertEquals(2, parameterProvider.getMaxChunksInRegistrationRequest());
-  }
-
-  @Test
-  public void testValidationMaxChunksInBlobAndRegistrationRequest() {
-    Properties prop = new Properties();
-    Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put("max_chunks_in_blob", 2);
-    parameterMap.put("max_chunks_in_registration_request", 1);
-    try {
-      new ParameterProvider(parameterMap, prop);
-      Assert.fail("Should not have succeeded");
-    } catch (SFException e) {
-      Assert.assertEquals(ErrorCode.INVALID_CONFIG_PARAMETER.getMessageCode(), e.getVendorCode());
-    }
+    Assert.assertEquals(1, parameterProvider.getMaxChunksInBlobAndRegistrationRequest());
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -886,7 +886,11 @@ public class SnowflakeStreamingIngestClientTest {
     assertEquals(
         1, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(99)).size());
     assertEquals(
+        1, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(100)).size());
+    assertEquals(
         2, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(101)).size());
+    assertEquals(
+        2, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(200)).size());
     assertEquals(
         2, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(99, 2)).size());
     assertEquals(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -11,6 +11,8 @@ import static net.snowflake.ingest.utils.Constants.RESPONSE_SUCCESS;
 import static net.snowflake.ingest.utils.Constants.ROLE;
 import static net.snowflake.ingest.utils.Constants.USER;
 import static net.snowflake.ingest.utils.ParameterProvider.ENABLE_SNOWPIPE_STREAMING_METRICS;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
@@ -319,11 +321,11 @@ public class SnowflakeStreamingIngestClientTest {
     CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
     StatusLine statusLine = Mockito.mock(StatusLine.class);
     HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-    Mockito.when(statusLine.getStatusCode()).thenReturn(200);
-    Mockito.when(httpResponse.getStatusLine()).thenReturn(statusLine);
-    Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
-    Mockito.when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(responseString));
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(httpResponse.getEntity()).thenReturn(httpEntity);
+    when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(responseString));
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
 
     RequestBuilder requestBuilder =
         Mockito.spy(
@@ -378,11 +380,11 @@ public class SnowflakeStreamingIngestClientTest {
     CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
     StatusLine statusLine = Mockito.mock(StatusLine.class);
     HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-    Mockito.when(statusLine.getStatusCode()).thenReturn(500);
-    Mockito.when(httpResponse.getStatusLine()).thenReturn(statusLine);
-    Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
-    Mockito.when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(responseString));
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(statusLine.getStatusCode()).thenReturn(500);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(httpResponse.getEntity()).thenReturn(httpEntity);
+    when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(responseString));
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
 
     RequestBuilder requestBuilder =
         Mockito.spy(
@@ -645,12 +647,12 @@ public class SnowflakeStreamingIngestClientTest {
     CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
     StatusLine statusLine = Mockito.mock(StatusLine.class);
     HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-    Mockito.when(statusLine.getStatusCode()).thenReturn(500);
-    Mockito.when(httpResponse.getStatusLine()).thenReturn(statusLine);
-    Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
+    when(statusLine.getStatusCode()).thenReturn(500);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(httpResponse.getEntity()).thenReturn(httpEntity);
     String response = "testRegisterBlobErrorResponse";
-    Mockito.when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(response));
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(response));
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
 
     RequestBuilder requestBuilder =
         new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair());
@@ -693,11 +695,11 @@ public class SnowflakeStreamingIngestClientTest {
     CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
     StatusLine statusLine = Mockito.mock(StatusLine.class);
     HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-    Mockito.when(statusLine.getStatusCode()).thenReturn(200);
-    Mockito.when(httpResponse.getStatusLine()).thenReturn(statusLine);
-    Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
-    Mockito.when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(response));
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(httpResponse.getEntity()).thenReturn(httpEntity);
+    when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(response));
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
 
     RequestBuilder requestBuilder =
         new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair());
@@ -749,11 +751,11 @@ public class SnowflakeStreamingIngestClientTest {
     CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
     StatusLine statusLine = Mockito.mock(StatusLine.class);
     HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-    Mockito.when(statusLine.getStatusCode()).thenReturn(200);
-    Mockito.when(httpResponse.getStatusLine()).thenReturn(statusLine);
-    Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
-    Mockito.when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(response));
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(httpResponse.getEntity()).thenReturn(httpEntity);
+    when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(response));
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
 
     RequestBuilder requestBuilder =
         new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair());
@@ -827,16 +829,16 @@ public class SnowflakeStreamingIngestClientTest {
     CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
     StatusLine statusLine = Mockito.mock(StatusLine.class);
     HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-    Mockito.when(statusLine.getStatusCode()).thenReturn(200);
-    Mockito.when(httpResponse.getStatusLine()).thenReturn(statusLine);
-    Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
-    Mockito.when(httpEntity.getContent())
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(httpResponse.getEntity()).thenReturn(httpEntity);
+    when(httpEntity.getContent())
         .thenReturn(
             IOUtils.toInputStream(responseString),
             IOUtils.toInputStream(retryResponseString),
             IOUtils.toInputStream(retryResponseString),
             IOUtils.toInputStream(retryResponseString));
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
 
     RequestBuilder requestBuilder =
         Mockito.spy(
@@ -860,6 +862,79 @@ public class SnowflakeStreamingIngestClientTest {
         .generateStreamingIngestPostRequest(Mockito.anyString(), Mockito.any(), Mockito.any());
     Assert.assertFalse(channel1.isValid());
     Assert.assertFalse(channel2.isValid());
+  }
+
+  @Test
+  public void testRegisterBlobChunkLimit() throws Exception {
+    CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+    RequestBuilder requestBuilder =
+        Mockito.spy(
+            new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair()));
+
+    SnowflakeStreamingIngestClientInternal<Object> client =
+        Mockito.spy(
+            new SnowflakeStreamingIngestClientInternal<>(
+                "client",
+                new SnowflakeURL("snowflake.dev.local:8082"),
+                null,
+                httpClient,
+                true,
+                requestBuilder,
+                null));
+
+    assertEquals(0, client.partitionBlobListForRegistrationRequest(new ArrayList<>()).size());
+    assertEquals(
+        1, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(99)).size());
+    assertEquals(
+        2, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(101)).size());
+    assertEquals(
+        2, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(99, 2)).size());
+    assertEquals(
+        2,
+        client
+            .partitionBlobListForRegistrationRequest(createTestBlobMetadata(55, 44, 2, 98))
+            .size());
+    assertEquals(
+        3,
+        client
+            .partitionBlobListForRegistrationRequest(createTestBlobMetadata(55, 44, 2, 99))
+            .size());
+    assertEquals(
+        3,
+        client
+            .partitionBlobListForRegistrationRequest(createTestBlobMetadata(55, 44, 2, 99, 1))
+            .size());
+  }
+
+  /**
+   * Generate blob metadata with specified number of chunks per blob
+   *
+   * @param numbersOfChunks Array of chunk numbers per blob
+   * @return List of blob metadata
+   */
+  private List<BlobMetadata> createTestBlobMetadata(int... numbersOfChunks) {
+    List<BlobMetadata> result = new ArrayList<>();
+    for (int n : numbersOfChunks) {
+      List<ChunkMetadata> chunkMetadata = new ArrayList<>();
+      for (int i = 0; i < n; i++) {
+        ChunkMetadata chunk =
+            ChunkMetadata.builder()
+                .setOwningTableFromChannelContext(channel1.getChannelContext())
+                .setChunkStartOffset(0L)
+                .setChunkLength(1)
+                .setEncryptionKeyId(0L)
+                .setChunkMD5("")
+                .setEpInfo(new EpInfo())
+                .setChannelList(new ArrayList<>())
+                .setFirstInsertTimeInMs(0L)
+                .setLastInsertTimeInMs(0L)
+                .build();
+        chunkMetadata.add(chunk);
+      }
+
+      result.add(new BlobMetadata("", "", chunkMetadata, new BlobStats()));
+    }
+    return result;
   }
 
   @Test
@@ -945,13 +1020,13 @@ public class SnowflakeStreamingIngestClientTest {
     CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
     StatusLine statusLine = Mockito.mock(StatusLine.class);
     HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-    Mockito.when(statusLine.getStatusCode()).thenReturn(200);
-    Mockito.when(httpResponse.getStatusLine()).thenReturn(statusLine);
-    Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
-    Mockito.when(httpEntity.getContent())
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(httpResponse.getEntity()).thenReturn(httpEntity);
+    when(httpEntity.getContent())
         .thenReturn(
             IOUtils.toInputStream(responseString), IOUtils.toInputStream(retryResponseString));
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
 
     RequestBuilder requestBuilder =
         Mockito.spy(
@@ -1022,11 +1097,11 @@ public class SnowflakeStreamingIngestClientTest {
     CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
     StatusLine statusLine = Mockito.mock(StatusLine.class);
     HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-    Mockito.when(statusLine.getStatusCode()).thenReturn(200);
-    Mockito.when(httpResponse.getStatusLine()).thenReturn(statusLine);
-    Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
-    Mockito.when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(response));
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(httpResponse.getEntity()).thenReturn(httpEntity);
+    when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(response));
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
 
     RequestBuilder requestBuilder =
         new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair());
@@ -1146,7 +1221,7 @@ public class SnowflakeStreamingIngestClientTest {
 
     CompletableFuture<Void> future = new CompletableFuture<>();
     future.completeExceptionally(new Exception("Simulating Error"));
-    Mockito.when(client.flush(true)).thenReturn(future);
+    when(client.flush(true)).thenReturn(future);
 
     Assert.assertFalse(client.isClosed());
     try {
@@ -1249,11 +1324,11 @@ public class SnowflakeStreamingIngestClientTest {
     CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
     StatusLine statusLine = Mockito.mock(StatusLine.class);
     HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-    Mockito.when(statusLine.getStatusCode()).thenReturn(200);
-    Mockito.when(httpResponse.getStatusLine()).thenReturn(statusLine);
-    Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
-    Mockito.when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(responseString));
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(httpResponse.getEntity()).thenReturn(httpEntity);
+    when(httpEntity.getContent()).thenReturn(IOUtils.toInputStream(responseString));
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
 
     RequestBuilder requestBuilder =
         Mockito.spy(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -884,13 +884,22 @@ public class SnowflakeStreamingIngestClientTest {
 
     assertEquals(0, client.partitionBlobListForRegistrationRequest(new ArrayList<>()).size());
     assertEquals(
+        1, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(1)).size());
+    assertEquals(
         1, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(99)).size());
     assertEquals(
         1, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(100)).size());
+
     assertEquals(
-        2, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(101)).size());
+        1, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(3, 95, 2)).size());
     assertEquals(
-        2, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(200)).size());
+        2,
+        client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(3, 95, 2, 1)).size());
+    assertEquals(
+        3,
+        client
+            .partitionBlobListForRegistrationRequest(createTestBlobMetadata(3, 95, 2, 1, 100))
+            .size());
     assertEquals(
         2, client.partitionBlobListForRegistrationRequest(createTestBlobMetadata(99, 2)).size());
     assertEquals(


### PR DESCRIPTION
When one client is ingesting into many tables, we are seeing occasional timeouts from blob registrations calls. This PR introduces the limit of 20 chunks in one blob and in blob registration request.

Fixes #570
Fixes #567