### PR TITLE
@no-snow refactor a few variables into ClientBufferParameters

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -170,6 +170,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
 
   final ZoneId defaultTimezone;
 
+  // Buffer parameters that are set at the owning client level
   final ClientBufferParameters clientBufferParameters;
 
   AbstractRowBuffer(

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
@@ -16,14 +16,14 @@ public class ClientBufferParameters {
   private long maxAllowedRowSizeInBytes;
 
   /**
-   * This is TEST-ONLY constructor
+   * Private constructor used for test methods
    *
    * @param enableParquetInternalBuffering flag whether buffering in internal Parquet buffers is
    *     enabled
    * @param maxChunkSizeInBytes maximum chunk size in bytes
    * @param maxAllowedRowSizeInBytes maximum row size in bytes
    */
-  public ClientBufferParameters(
+  private ClientBufferParameters(
       boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
       long maxAllowedRowSizeInBytes) {
@@ -46,6 +46,21 @@ public class ClientBufferParameters {
         clientInternal != null
             ? clientInternal.getParameterProvider().getMaxAllowedRowSizeInBytes()
             : ParameterProvider.MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT;
+  }
+
+  /**
+   * @param enableParquetInternalBuffering flag whether buffering in internal Parquet buffers is
+   *     enabled
+   * @param maxChunkSizeInBytes maximum chunk size in bytes
+   * @param maxAllowedRowSizeInBytes maximum row size in bytes
+   * @return ClientBufferParameters object
+   */
+  public static ClientBufferParameters test_createClientBufferParameters(
+      boolean enableParquetInternalBuffering,
+      long maxChunkSizeInBytes,
+      long maxAllowedRowSizeInBytes) {
+    return new ClientBufferParameters(
+        enableParquetInternalBuffering, maxChunkSizeInBytes, maxAllowedRowSizeInBytes);
   }
 
   public boolean getEnableParquetInternalBuffering() {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
@@ -1,0 +1,51 @@
+package net.snowflake.ingest.streaming.internal;
+
+import net.snowflake.ingest.utils.ParameterProvider;
+
+/** Channel's buffer relevant parameters that are set at the owning client level. */
+public class ClientBufferParameters {
+  private SnowflakeStreamingIngestClientInternal clientInternal;
+
+  private boolean enableParquetInternalBuffering;
+
+  private long maxChunkSizeInBytes;
+
+  private long maxAllowedRowSizeInBytes;
+
+  public ClientBufferParameters(
+      boolean enableParquetInternalBuffering,
+      long maxChunkSizeInBytes,
+      long maxAllowedRowSizeInBytes) {
+    this.enableParquetInternalBuffering = enableParquetInternalBuffering;
+    this.maxChunkSizeInBytes = maxChunkSizeInBytes;
+    this.maxAllowedRowSizeInBytes = maxAllowedRowSizeInBytes;
+  }
+
+  public ClientBufferParameters(SnowflakeStreamingIngestClientInternal clientInternal) {
+    this.clientInternal = clientInternal;
+    this.enableParquetInternalBuffering =
+        clientInternal != null
+            ? clientInternal.getParameterProvider().getEnableParquetInternalBuffering()
+            : ParameterProvider.ENABLE_PARQUET_INTERNAL_BUFFERING_DEFAULT;
+    this.maxChunkSizeInBytes =
+        clientInternal != null
+            ? clientInternal.getParameterProvider().getMaxChunkSizeInBytes()
+            : ParameterProvider.MAX_CHUNK_SIZE_IN_BYTES_DEFAULT;
+    this.maxAllowedRowSizeInBytes =
+        clientInternal != null
+            ? clientInternal.getParameterProvider().getMaxAllowedRowSizeInBytes()
+            : ParameterProvider.MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT;
+  }
+
+  public boolean getEnableParquetInternalBuffering() {
+    return enableParquetInternalBuffering;
+  }
+
+  public long getMaxChunkSizeInBytes() {
+    return maxChunkSizeInBytes;
+  }
+
+  public long getMaxAllowedRowSizeInBytes() {
+    return maxAllowedRowSizeInBytes;
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
@@ -1,10 +1,13 @@
+/*
+ * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal;
 
 import net.snowflake.ingest.utils.ParameterProvider;
 
 /** Channel's buffer relevant parameters that are set at the owning client level. */
 public class ClientBufferParameters {
-  private SnowflakeStreamingIngestClientInternal clientInternal;
 
   private boolean enableParquetInternalBuffering;
 
@@ -12,6 +15,14 @@ public class ClientBufferParameters {
 
   private long maxAllowedRowSizeInBytes;
 
+  /**
+   * This is TEST-ONLY constructor
+   *
+   * @param enableParquetInternalBuffering flag whether buffering in internal Parquet buffers is
+   *     enabled
+   * @param maxChunkSizeInBytes maximum chunk size in bytes
+   * @param maxAllowedRowSizeInBytes maximum row size in bytes
+   */
   public ClientBufferParameters(
       boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
@@ -21,8 +32,11 @@ public class ClientBufferParameters {
     this.maxAllowedRowSizeInBytes = maxAllowedRowSizeInBytes;
   }
 
+  /**
+   * @param clientInternal reference to the clientInternal object, where the relevant parameters are
+   *     set
+   */
   public ClientBufferParameters(SnowflakeStreamingIngestClientInternal clientInternal) {
-    this.clientInternal = clientInternal;
     this.enableParquetInternalBuffering =
         clientInternal != null
             ? clientInternal.getParameterProvider().getEnableParquetInternalBuffering()

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
@@ -32,10 +32,7 @@ public class ClientBufferParameters {
     this.maxAllowedRowSizeInBytes = maxAllowedRowSizeInBytes;
   }
 
-  /**
-   * @param clientInternal reference to the clientInternal object, where the relevant parameters are
-   *     set
-   */
+  /** @param clientInternal reference to the client object where the relevant parameters are set */
   public ClientBufferParameters(SnowflakeStreamingIngestClientInternal clientInternal) {
     this.enableParquetInternalBuffering =
         clientInternal != null

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -24,7 +24,6 @@ import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Logging;
-import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.Utils;
 
@@ -122,15 +121,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
             getFullyQualifiedName(),
             this::collectRowSize,
             channelState,
-            owningClient != null
-                ? owningClient.getParameterProvider().getEnableParquetInternalBuffering()
-                : ParameterProvider.ENABLE_PARQUET_INTERNAL_BUFFERING_DEFAULT,
-            owningClient != null
-                ? owningClient.getParameterProvider().getMaxChunkSizeInBytes()
-                : ParameterProvider.MAX_CHUNK_SIZE_IN_BYTES_DEFAULT,
-            owningClient != null
-                ? owningClient.getParameterProvider().getMaxAllowedRowSizeInBytes()
-                : ParameterProvider.MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT);
+            new ClientBufferParameters(owningClient));
     logger.logInfo(
         "Channel={} created for table={}",
         this.channelFlushContext.getName(),

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -115,9 +115,10 @@ public class RowBufferTest {
         "test.buffer",
         rs -> {},
         initialState,
-        enableParquetMemoryOptimization,
-        MAX_CHUNK_SIZE_IN_BYTES_DEFAULT,
-        MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT);
+        new ClientBufferParameters(
+            enableParquetMemoryOptimization,
+            MAX_CHUNK_SIZE_IN_BYTES_DEFAULT,
+            MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT));
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -115,7 +115,7 @@ public class RowBufferTest {
         "test.buffer",
         rs -> {},
         initialState,
-        new ClientBufferParameters(
+        ClientBufferParameters.test_createClientBufferParameters(
             enableParquetMemoryOptimization,
             MAX_CHUNK_SIZE_IN_BYTES_DEFAULT,
             MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT));


### PR DESCRIPTION
This PR extracts `enableParquetMemoryOptimization, maxChunkSizeInBytes, maxRowSizeInBytes` into `ClientBufferParameters`, which represents relevant buffer parameters that are set at client level. This is done for more readibility and to make adding new parameters easier.