### PR TITLE
SNOW-928802 Use concurrent hashmap to prevent ConcurrentModificationE…

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -174,7 +174,7 @@ class FlushService<T> {
     this.isNeedFlush = false;
     this.lastFlushTime = System.currentTimeMillis();
     this.isTestMode = isTestMode;
-    this.latencyTimerContextMap = new HashMap<>();
+    this.latencyTimerContextMap = new ConcurrentHashMap<>();
     this.bdecVersion = this.owningClient.getParameterProvider().getBlobFormatVersion();
     createWorkers();
   }


### PR DESCRIPTION
…xception

- We did make a change to use ConcurrentHashMap but that was in test code, we still used HashMap! This change should not result into `ConcurrentModificationException`
- This constructor is being used in `StreamingClientInternal` code path
- Long time back change https://github.com/snowflakedb/snowflake-ingest-java/pull/303

Here is the stack trace which points to this map implementation
```
  java.base/java.util.HashMap.computeIfPresent(HashMap.java:1177)
  net.snowflake.ingest.streaming.internal.RegisterService.lambda$registerBlobs$2(RegisterService.java:205)
  java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
  net.snowflake.ingest.streaming.internal.RegisterService.registerBlobs(RegisterService.java:203)
  net.snowflake.ingest.streaming.internal.FlushService.lambda$registerFuture$2(FlushService.java:244)
  java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1736)
  java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
  java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
  java.base/java.lang.Thread.run(Thread.java:829). (net.snowflake.ingest.streaming.internal.FlushService:51)
```