### PR TITLE
SNOW-926149 Fix issues while using snowflake-jdbc-fips

### DIFF
--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -67,3 +67,26 @@ jobs:
       - name: Unit & Integration Test (Windows)
         continue-on-error: false
         run: mvn -DghActionsIT verify --batch-mode
+  build-e2e-jar-test:
+    name: E2E JAR Test - ${{ matrix.java }}, Cloud ${{ matrix.snowflake_cloud }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 8 ]
+        snowflake_cloud: [ 'AWS' ]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Install Java ${{ matrix.java }}
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: maven
+      - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
+        env:
+          DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}
+        run: ./scripts/decrypt_secret.sh ${{ matrix.snowflake_cloud }}
+      - name: Run E2E JAR Test
+        run: ./e2e-jar-test/run_e2e_jar_test.sh

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The Snowflake Ingest SDK provides shaded and unshaded versions of its jar. The s
 whereas the unshaded version declares its dependencies in `pom.xml`, which are fetched as standard transitive dependencies by the build system like Maven or Gradle.
 The shaded JAR can help avoid potential dependency conflicts, but the unshaded version provides finer graned control over transitive dependencies.
 
-## Using with snowflake-jdbc-fics
+## Using with snowflake-jdbc-fips
 
 For use cases, which need to use `snowflake-jdbc-fips` instead of the default `snowflake-jdbc`, we recommend to take the following steps:
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ dependencies {
 }
 ```
 
+## Jar Versions
+
+The Snowflake Ingest SDK provides shaded and unshaded versions of its jar. The shaded version bundles the dependencies into its own jar,
+whereas the unshaded version declares its dependencies in `pom.xml`, which are fetched as standard transitive dependencies by the build system like Maven or Gradle.
+The shaded JAR can help avoid potential dependency conflicts, but the unshaded version provides finer graned control over transitive dependencies.
+
+## Using with snowflake-jdbc-fics
+
+For use cases, which need to use `snowflake-jdbc-fips` instead of the default `snowflake-jdbc`, we recommend to take the following steps:
+
+- Use the unshaded version of the Ingest SDK.
+- Exclude these transitive dependencies:
+    - `net.snowflake:snowflake-jdbc`
+    - `org.bouncycastle:bcpkix-jdk18on`
+    - `org.bouncycastle:bcprov-jdk18on`
+- Add a dependency on `snowflake-jdbc-fips`.
+
+See [this test](https://github.com/snowflakedb/snowflake-ingest-java/tree/master/e2e-jar-test/fips) for an example how to use Snowflake Ingest SDK together with Snowflake FIPS JDBC Driver.
+
 # Example
 
 ## Snowpipe

--- a/e2e-jar-test/core/pom.xml
+++ b/e2e-jar-test/core/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>net.snowflake.snowflake-ingest-java-e2e-jar-test</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>core</artifactId>
+    <name>core</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- Provided because we let submodules define which way they pull in the SDK (e.g. with/without snowflake-jdbc-fips, etc) -->
+        <dependency>
+            <groupId>net.snowflake</groupId>
+            <artifactId>snowflake-ingest-sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/e2e-jar-test/core/src/main/java/net/snowflake/IngestTestUtils.java
+++ b/e2e-jar-test/core/src/main/java/net/snowflake/IngestTestUtils.java
@@ -1,0 +1,169 @@
+package net.snowflake;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.UUID;
+
+import net.snowflake.ingest.streaming.OpenChannelRequest;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
+
+public class IngestTestUtils {
+  private static final String PROFILE_PATH = "profile.json";
+
+  private final Connection connection;
+
+  private final String database;
+  private final String schema;
+  private final String table;
+
+  private final String testId;
+
+  private final SnowflakeStreamingIngestClient client;
+
+  private final SnowflakeStreamingIngestChannel channel;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private final Random random = new Random();
+
+  private final Base64.Decoder base64Decoder = Base64.getDecoder();
+
+  public IngestTestUtils(String testName)
+      throws SQLException,
+          IOException,
+          ClassNotFoundException,
+          NoSuchAlgorithmException,
+          InvalidKeySpecException {
+    testId = String.format("%s_%s", testName, UUID.randomUUID().toString().replace("-", "_"));
+    connection = getConnection();
+    database = String.format("database_%s", testId);
+    schema = String.format("schema_%s", testId);
+    table = String.format("table_%s", testId);
+
+    connection.createStatement().execute(String.format("create database %s", database));
+    connection.createStatement().execute(String.format("create schema %s", schema));
+    connection.createStatement().execute(String.format("create table %s (c1 int, c2 varchar, c3 binary)", table));
+
+    client =
+        SnowflakeStreamingIngestClientFactory.builder("TestClient01")
+            .setProperties(loadProperties())
+            .build();
+
+    channel = client.openChannel(
+            OpenChannelRequest.builder(String.format("channel_%s", this.testId))
+                    .setDBName(database)
+                    .setSchemaName(schema)
+                    .setTableName(table)
+                    .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
+                    .build());
+  }
+
+  private Properties loadProperties() throws IOException {
+    Properties props = new Properties();
+    Iterator<Map.Entry<String, JsonNode>> propIt =
+        objectMapper.readTree(new String(Files.readAllBytes(Paths.get(PROFILE_PATH)))).fields();
+    while (propIt.hasNext()) {
+      Map.Entry<String, JsonNode> prop = propIt.next();
+      props.put(prop.getKey(), prop.getValue().asText());
+    }
+    return props;
+  }
+
+  private Connection getConnection()
+      throws IOException, ClassNotFoundException, SQLException, NoSuchAlgorithmException, InvalidKeySpecException {
+    Class.forName("net.snowflake.client.jdbc.SnowflakeDriver");
+
+    Properties loadedProps = loadProperties();
+
+    byte[] decoded = base64Decoder.decode(loadedProps.getProperty("private_key"));
+    KeyFactory kf = KeyFactory.getInstance("RSA");
+
+    PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
+    PrivateKey privateKey = kf.generatePrivate(keySpec);
+
+    Properties props = new Properties();
+    props.putAll(loadedProps);
+    props.put("client_session_keep_alive", "true");
+    props.put("privateKey", privateKey);
+
+    return DriverManager.getConnection(loadedProps.getProperty("connect_string"), props);
+  }
+
+  private Map<String, Object> createRow() {
+    Map<String, Object> row = new HashMap<>();
+
+    byte[] bytes = new byte[1024];
+    random.nextBytes(bytes);
+
+    row.put("c1", random.nextInt());
+    row.put("c2", String.valueOf(random.nextInt()));
+    row.put("c3", bytes);
+
+    return row;
+  }
+
+  /**
+   * Given a channel and expected offset, this method waits up to 60 seconds until the last
+   * committed offset is equal to the passed offset
+   */
+  private void waitForOffset(SnowflakeStreamingIngestChannel channel, String expectedOffset)
+          throws InterruptedException {
+    int counter = 0;
+    String lastCommittedOffset = null;
+    while (counter < 600) {
+      String currentOffset = channel.getLatestCommittedOffsetToken();
+      if (expectedOffset.equals(currentOffset)) {
+        return;
+      }
+      System.out.printf("Waiting for offset expected=%s actual=%s%n", expectedOffset, currentOffset);
+      lastCommittedOffset = currentOffset;
+      counter++;
+      Thread.sleep(100);
+    }
+    throw new RuntimeException(
+            String.format(
+                    "Timeout exceeded while waiting for offset %s. Last committed offset: %s",
+                    expectedOffset, lastCommittedOffset));
+  }
+
+  public void test() throws InterruptedException {
+    // Insert few rows one by one
+    for (int offset = 2; offset < 1000; offset++) {
+      offset++;
+      channel.insertRow(createRow(), String.valueOf(offset));
+    }
+
+    // Insert a batch of rows
+    String offset = "final-offset";
+    channel.insertRows(
+            Arrays.asList(createRow(), createRow(), createRow(), createRow(), createRow()), offset);
+
+    waitForOffset(channel, offset);
+  }
+
+  public void close() throws Exception {
+    connection.close();
+    channel.close().get();
+    client.close();
+  }
+}

--- a/e2e-jar-test/fips/pom.xml
+++ b/e2e-jar-test/fips/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>net.snowflake.snowflake-ingest-java-e2e-jar-test</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>fips</artifactId>
+    <packaging>jar</packaging>
+    <name>fips</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.snowflake.snowflake-ingest-java-e2e-jar-test</groupId>
+            <artifactId>core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.snowflake</groupId>
+            <artifactId>snowflake-ingest-sdk</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.snowflake</groupId>
+                    <artifactId>snowflake-jdbc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk18on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk18on</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.snowflake</groupId>
+            <artifactId>snowflake-jdbc-fips</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/e2e-jar-test/fips/src/test/java/net/snowflake/FipsIngestE2ETest.java
+++ b/e2e-jar-test/fips/src/test/java/net/snowflake/FipsIngestE2ETest.java
@@ -1,0 +1,31 @@
+package net.snowflake;
+
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.security.Security;
+
+public class FipsIngestE2ETest {
+
+  private IngestTestUtils ingestTestUtils;
+
+  @Before
+  public void setUp() throws Exception {
+    // Add FIPS provider, the SDK does not do this by default
+    Security.addProvider(new BouncyCastleFipsProvider("C:HYBRID;ENABLE{All};"));
+
+    ingestTestUtils = new IngestTestUtils("fips_ingest");
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    ingestTestUtils.close();
+  }
+
+  @Test
+  public void name() throws InterruptedException {
+    ingestTestUtils.test();
+  }
+}

--- a/e2e-jar-test/pom.xml
+++ b/e2e-jar-test/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>net.snowflake.snowflake-ingest-java-e2e-jar-test</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>snowflake-ingest-sdk-e2e-test</name>
+
+  <modules>
+    <module>standard</module>
+    <module>fips</module>
+    <module>core</module>
+  </modules>
+
+  <dependencyManagement>
+
+    <dependencies>
+      <dependency>
+        <groupId>net.snowflake.snowflake-ingest-java-e2e-jar-test</groupId>
+        <artifactId>core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>net.snowflake</groupId>
+        <artifactId>snowflake-ingest-sdk</artifactId>
+        <version>2.0.4-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>net.snowflake</groupId>
+        <artifactId>snowflake-jdbc-fips</artifactId>
+        <version>3.13.30</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>1.7.36</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.14.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/e2e-jar-test/run_e2e_jar_test.sh
+++ b/e2e-jar-test/run_e2e_jar_test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+## This script tests the SDK JARs end-to-end, i.e. not using integration tests from within the project, but from an
+## external Maven project, which depends on the SDK deployed into the local maven repository. The following SDK variants are tested:
+## 1. Shaded jar
+## 2. Unshaded jar
+## 3. FIPS-compliant jar, i.e. unshaded jar without snowflake-jdbc and bouncy castle dependencies, but with snowflake-jdbc-fips depedency
+
+maven_repo_dir=$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
+sdk_repo_dir="${maven_repo_dir}/net/snowflake/snowflake-ingest-sdk"
+
+cp profile.json e2e-jar-test/standard
+cp profile.json e2e-jar-test/fips
+
+###################
+# TEST SHADED JAR #
+###################
+
+# Remove the SDK from local maven repository
+rm -fr $sdk_repo_dir
+
+# Prepare pom.xml for shaded JAR
+project_version=$(./scripts/get_project_info_from_pom.py pom.xml version)
+./scripts/update_project_version.py public_pom.xml $project_version > generated_public_pom.xml
+
+# Build shaded SDK
+mvn clean package -DskipTests=true --batch-mode --show-version
+
+# Install shaded SDK JARs into local maven repository
+mvn install:install-file -Dfile=target/snowflake-ingest-sdk.jar -DpomFile=generated_public_pom.xml
+
+# Run e2e tests
+(cd e2e-jar-test && mvn clean verify -pl standard -am)
+
+#####################
+# TEST UNSHADED JAR #
+#####################
+
+# Remove the SDK from local maven repository
+rm -r $sdk_repo_dir
+
+# Install unshaded SDK into local maven repository
+mvn clean install -Dnot-shadeDep -DskipTests=true --batch-mode --show-version
+
+# Run e2e tests
+(cd e2e-jar-test && mvn clean verify -pl standard -am)
+
+#############
+# TEST FIPS #
+#############
+
+# Remove the SDK from local maven repository
+rm -r $sdk_repo_dir
+
+# Install unshaded SDK into local maven repository
+mvn clean install -Dnot-shadeDep -DskipTests=true --batch-mode --show-version
+
+# Run e2e tests on the FIPS module
+(cd e2e-jar-test && mvn clean verify -pl fips -am)

--- a/e2e-jar-test/standard/pom.xml
+++ b/e2e-jar-test/standard/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>net.snowflake.snowflake-ingest-java-e2e-jar-test</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>standard</artifactId>
+    <packaging>jar</packaging>
+    <name>unshaded</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.snowflake.snowflake-ingest-java-e2e-jar-test</groupId>
+            <artifactId>core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.snowflake</groupId>
+            <artifactId>snowflake-ingest-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/e2e-jar-test/standard/src/test/java/net/snowflake/StandardIngestE2ETest.java
+++ b/e2e-jar-test/standard/src/test/java/net/snowflake/StandardIngestE2ETest.java
@@ -1,0 +1,25 @@
+package net.snowflake;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StandardIngestE2ETest {
+
+  private IngestTestUtils ingestTestUtils;
+
+  @Before
+  public void setUp() throws Exception {
+    ingestTestUtils = new IngestTestUtils("standard_ingest");
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    ingestTestUtils.close();
+  }
+
+  @Test
+  public void name() throws InterruptedException {
+    ingestTestUtils.test();
+  }
+}

--- a/linkage-checker-exclusion-rules.xml
+++ b/linkage-checker-exclusion-rules.xml
@@ -19,6 +19,18 @@
         <Reason>Google Crypto Tink is an optional dependency of nimbus-jose-jwt</Reason>
     </LinkageError>
 
+    <LinkageError>
+        <Target>
+            <Class name="org.bouncycastle.asn1.x509.qualified.QCStatement" />
+        </Target>
+        <Reason>Seems like a false positive, this class does exist on classpath.</Reason>
+    </LinkageError>
+    <LinkageError>
+        <Target>
+            <Class name="org.bouncycastle.asn1.x9.X9FieldID" />
+        </Target>
+        <Reason>Seems like a false positive, this class does exist on classpath.</Reason>
+    </LinkageError>
     <!-- Hadoop-related linkage errors-->
     <LinkageError>
         <Source>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
   <!-- Set our Language Level to Java 8 -->
   <properties>
+    <bouncycastle.version>1.74</bouncycastle.version>
     <codehaus.version>1.9.13</codehaus.version>
     <commonscodec.version>1.15</commonscodec.version>
     <commonscollections.version>3.2.2</commonscollections.version>
@@ -275,6 +276,16 @@
         <version>${yetus.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-core-asl</artifactId>
         <version>${codehaus.version}</version>
@@ -449,6 +460,15 @@
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-hadoop</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -531,7 +551,7 @@
             <dependency>
               <groupId>com.google.cloud.tools</groupId>
               <artifactId>linkage-checker-enforcer-rules</artifactId>
-              <version>1.5.12</version>
+              <version>1.5.13</version>
             </dependency>
             <dependency>
               <groupId>org.codehaus.mojo</groupId>
@@ -758,6 +778,7 @@
             <includedLicense>The MIT License</includedLicense>
             <includedLicense>EDL 1.0</includedLicense>
             <includedLicense>The Go license</includedLicense>
+            <includedLicense>Bouncy Castle Licence</includedLicense>
           </includedLicenses>
           <excludedScopes>test,provided,system</excludedScopes>
           <failOnBlacklist>true</failOnBlacklist>
@@ -928,6 +949,10 @@
                 <relocation>
                   <pattern>com.nimbusds</pattern>
                   <shadedPattern>${shadeBase}.com.nimbusds</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.bouncycastle</pattern>
+                  <shadedPattern>${shadeBase}.org.bouncycastle</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>net.jcip</pattern>

--- a/scripts/process_licenses.py
+++ b/scripts/process_licenses.py
@@ -30,6 +30,7 @@ BSD_3_CLAUSE_LICENSE = "3-Clause BSD License"
 EDL_10_LICENSE = "EDL 1.0"
 MIT_LICENSE = "The MIT License"
 GO_LICENSE = "The Go license"
+BOUNCY_CASTLE_LICENSE = "Bouncy Castle Licence <https://www.bouncycastle.org/licence.html>"
 
 # The SDK does not need to include licenses of dependencies, which aren't shaded
 IGNORED_DEPENDENCIES = {"net.snowflake:snowflake-jdbc", "org.slf4j:slf4j-api"}
@@ -57,6 +58,9 @@ ADDITIONAL_LICENSES_MAP = {
     "org.apache.parquet:parquet-format-structures": APACHE_LICENSE,
     "com.github.luben:zstd-jni": BSD_2_CLAUSE_LICENSE,
     "io.airlift:aircompressor": APACHE_LICENSE,
+    "org.bouncycastle:bcpkix-jdk18on": BOUNCY_CASTLE_LICENSE,
+    "org.bouncycastle:bcutil-jdk18on": BOUNCY_CASTLE_LICENSE,
+    "org.bouncycastle:bcprov-jdk18on": BOUNCY_CASTLE_LICENSE,
 }
 
 

--- a/scripts/update_project_version.py
+++ b/scripts/update_project_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 # Update project version

--- a/src/main/java/net/snowflake/ingest/utils/ErrorCode.java
+++ b/src/main/java/net/snowflake/ingest/utils/ErrorCode.java
@@ -40,7 +40,8 @@ public enum ErrorCode {
   MAKE_URI_FAILURE("0032"),
   OAUTH_REFRESH_TOKEN_ERROR("0033"),
   INVALID_CONFIG_PARAMETER("0034"),
-  MAX_BATCH_SIZE_EXCEEDED("0035");
+  MAX_BATCH_SIZE_EXCEEDED("0035"),
+  CRYPTO_PROVIDER_ERROR("0036");
 
   public static final String errorMessageResource = "net.snowflake.ingest.ingest_error_messages";
 

--- a/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
+++ b/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
@@ -38,3 +38,4 @@
 0033=OAuth token refresh failure: {0}
 0034=Invalid config parameter: {0}
 0035=Too large batch of rows passed to insertRows, the batch size cannot exceed {0} bytes, recommended batch size for optimal performance and memory utilization is {1} bytes. We recommend splitting large batches into multiple smaller ones and call insertRows for each smaller batch separately.
+0036=Failed to load {0}. If you use FIPS, import BouncyCastleFipsProvider in the application: {1}

--- a/src/test/java/net/snowflake/ingest/TestUtils.java
+++ b/src/test/java/net/snowflake/ingest/TestUtils.java
@@ -41,7 +41,6 @@ import java.util.function.Supplier;
 import net.snowflake.client.jdbc.internal.apache.http.client.utils.URIBuilder;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
-import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.utils.Constants;
@@ -122,8 +121,6 @@ public class TestUtils {
       scheme = profile.get(SCHEME).asText();
       role = Optional.ofNullable(profile.get(ROLE)).map(r -> r.asText()).orElse("DEFAULT_ROLE");
       privateKeyPem = profile.get(PRIVATE_KEY).asText();
-
-      java.security.Security.addProvider(new BouncyCastleProvider());
 
       byte[] encoded = Base64.decodeBase64(privateKeyPem);
       KeyFactory kf = KeyFactory.getInstance("RSA");

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -39,7 +39,6 @@ import java.util.concurrent.TimeUnit;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
-import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.Cryptor;
@@ -47,7 +46,6 @@ import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
@@ -276,11 +274,6 @@ public class FlushServiceTest {
   }
 
   TestContextFactory<?> testContextFactory;
-
-  @Before
-  public void setup() {
-    java.security.Security.addProvider(new BouncyCastleProvider());
-  }
 
   private SnowflakeStreamingIngestChannelInternal<?> addChannel1(TestContext<?> testContext) {
     return testContext

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.security.KeyPair;
 import java.security.PrivateKey;
-import java.security.Security;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,13 +39,6 @@ import net.snowflake.client.jdbc.internal.apache.http.client.methods.CloseableHt
 import net.snowflake.client.jdbc.internal.apache.http.client.methods.HttpPost;
 import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
 import net.snowflake.client.jdbc.internal.google.common.collect.Sets;
-import net.snowflake.client.jdbc.internal.org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
-import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
-import net.snowflake.client.jdbc.internal.org.bouncycastle.openssl.jcajce.JcaPEMWriter;
-import net.snowflake.client.jdbc.internal.org.bouncycastle.operator.OperatorCreationException;
-import net.snowflake.client.jdbc.internal.org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfoBuilder;
-import net.snowflake.client.jdbc.internal.org.bouncycastle.pkcs.jcajce.JcaPKCS8EncryptedPrivateKeyInfoBuilder;
-import net.snowflake.client.jdbc.internal.org.bouncycastle.pkcs.jcajce.JcePKCSPBEOutputEncryptorBuilder;
 import net.snowflake.ingest.TestUtils;
 import net.snowflake.ingest.connection.RequestBuilder;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
@@ -59,6 +51,12 @@ import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;
+import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfoBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS8EncryptedPrivateKeyInfoBuilder;
+import org.bouncycastle.pkcs.jcajce.JcePKCSPBEOutputEncryptorBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -293,7 +291,6 @@ public class SnowflakeStreamingIngestClientTest {
 
   private String generateAESKey(PrivateKey key, char[] passwd)
       throws IOException, OperatorCreationException {
-    Security.addProvider(new BouncyCastleProvider());
     StringWriter writer = new StringWriter();
     JcaPEMWriter pemWriter = new JcaPEMWriter(writer);
     PKCS8EncryptedPrivateKeyInfoBuilder pkcs8EncryptedPrivateKeyInfoBuilder =
@@ -301,7 +298,7 @@ public class SnowflakeStreamingIngestClientTest {
     pemWriter.writeObject(
         pkcs8EncryptedPrivateKeyInfoBuilder.build(
             new JcePKCSPBEOutputEncryptorBuilder(NISTObjectIdentifiers.id_aes256_CBC)
-                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .setProvider(Utils.getProvider().getName())
                 .build(passwd)));
     pemWriter.close();
     return writer.toString();

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/BinaryIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/BinaryIT.java
@@ -1,6 +1,6 @@
 package net.snowflake.ingest.streaming.internal.datatypes;
 
-import net.snowflake.client.jdbc.internal.org.bouncycastle.util.encoders.Hex;
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 
 public class BinaryIT extends AbstractDataTypeTest {


### PR DESCRIPTION
This PR implements support for FIPS-compliant JDBC driver `snowflake-jdbc-fips`, which some users are using instead of the default `snowflake-jdbc`. The difference is that the `snowflake-jdbc` shades bouncy castle, but `snowflake-jdbc-fips` declares FIPS compliant bouncy castle JARs in its `pom.xml`.

The existing SDK versions are not working with `snowflake-jdbc-fips` because they assume that bouncy castle is bundled in the JDBC driver and that `BouncyCastleProvider` exists on classpath, but in case of the FIPS version, the provider class name is `BouncyCastleFipsProvider`.

Documentation has been updated with instructions how to use the SDK in a FIPS-compliant way.

This PR also introduces a new external testing suite - a dedicated maven project, which does not test the SDK from "within" the SDK maven project, like our existing unit and integrations tests do, but runs a simple integration test with the SDK declared as a standard Maven dependency, installed into the local Maven repository. This suite can detect issues with JAR builds, for example. There is a wrapper script, which builds the SDK and orchestrates the end-to-end JAR tests. The following JAR variants are tested: shaded, unshaded and FIPS-compliant setups.