### PR TITLE
SNOW-936900 Use upgraded version of snappy-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -473,6 +473,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- JUnit so that we can make some basic unit tests -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
The SDK is exporting an old version of its transitive dependency snappy-java. This is visible in the new `e2e-jar-test` project, which is pulling in `snappy-java` version defined in `hadoop-common` and not the version we define in `dependencyManagement`. This PR makes `snappy-java` a direct runtime dependency, so we can control the version.