### PR TITLE
SNOW-945927 SNOW-945928 Fix Snyk vulnerabilities

### DIFF
--- a/e2e-jar-test/pom.xml
+++ b/e2e-jar-test/pom.xml
@@ -37,6 +37,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bc-fips</artifactId>
+        <version>1.0.2.4</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
         <version>1.7.36</version>

--- a/pom.xml
+++ b/pom.xml
@@ -474,6 +474,11 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
       <scope>runtime</scope>


### PR DESCRIPTION
This PR resolves the following Snyk findings:

* `bc-fips` - In our e2e-jar-test project we depend on `snowflake-jdbc-fips`, which transitively depends on a vulnerable version of `bc-fips`. We explicitly pull in a newer version. 
* `protobuf-java` - SDK contains vulnerable transitive dependency pull in by `hadoop-common`. This PR marks `protobuf-java` as a direct dependency, so version specified by the SDK will be pulled in. 

Closes #610
Closes #611
Closes #612
Closes #613
Closes #614
Closes #615
Closes #616
Closes #617
Closes #618
Closes #622
Closes #623
Closes #624
Closes #625
