### PR TITLE
NO-SNOW: Deprecate BUFFER_FLUSH_INTERVAL_IN_MILLIS parameter

### DIFF
--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -295,7 +295,8 @@ public class RequestBuilder {
       SecurityManager securityManager,
       CloseableHttpClient httpClient,
       String clientName) {
-    this(accountName,
+    this(
+        accountName,
         userName,
         credential,
         schemeName,
@@ -648,7 +649,7 @@ public class RequestBuilder {
   public void addToken(HttpUriRequest request) {
     request.setHeader(HttpHeaders.AUTHORIZATION, BEARER_PARAMETER + securityManager.getToken());
     request.setHeader(SF_HEADER_AUTHORIZATION_TOKEN_TYPE, this.securityManager.getTokenType());
-    if(addAccountNameInRequest) {
+    if (addAccountNameInRequest) {
       request.setHeader(SF_HEADER_ACCOUNT_NAME, accountName);
     }
   }

--- a/src/main/java/net/snowflake/ingest/streaming/OpenChannelRequest.java
+++ b/src/main/java/net/snowflake/ingest/streaming/OpenChannelRequest.java
@@ -89,10 +89,10 @@ public class OpenChannelRequest {
       return this;
     }
 
-    public OpenChannelRequestBuilder setOffsetToken(String offsetToken){
+    public OpenChannelRequestBuilder setOffsetToken(String offsetToken) {
       this.offsetToken = offsetToken;
       this.isOffsetTokenProvided = true;
-      return  this;
+      return this;
     }
 
     public OpenChannelRequest build() {

--- a/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestClientFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestClientFactory.java
@@ -6,7 +6,6 @@ package net.snowflake.ingest.streaming;
 
 import java.util.Map;
 import java.util.Properties;
-
 import net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientInternal;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.SnowflakeURL;
@@ -71,10 +70,10 @@ public class SnowflakeStreamingIngestClientFactory {
 
       if (addAccountNameInRequest) {
         return new SnowflakeStreamingIngestClientInternal<>(
-          this.name, accountURL, prop, this.parameterOverrides, addAccountNameInRequest);
+            this.name, accountURL, prop, this.parameterOverrides, addAccountNameInRequest);
       }
       return new SnowflakeStreamingIngestClientInternal<>(
-        this.name, accountURL, prop, this.parameterOverrides);
+          this.name, accountURL, prop, this.parameterOverrides);
     }
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -261,7 +261,7 @@ class FlushService<T> {
             && !isTestMode()
             && (this.isNeedFlush
                 || timeDiffMillis
-                    >= this.owningClient.getParameterProvider().getBufferFlushIntervalInMs()))) {
+                    >= this.owningClient.getParameterProvider().getCachedMaxClientLagInMs()))) {
 
       return this.statsFuture()
           .thenCompose((v) -> this.distributeFlush(isForce, timeDiffMillis))

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -214,7 +214,8 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
                 prop.getProperty(Constants.OAUTH_CLIENT_SECRET),
                 prop.getProperty(Constants.OAUTH_REFRESH_TOKEN));
       }
-      this.requestBuilder = new RequestBuilder(
+      this.requestBuilder =
+          new RequestBuilder(
               accountURL,
               prop.get(USER).toString(),
               credential,
@@ -275,14 +276,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
       Properties prop,
       Map<String, Object> parameterOverrides,
       boolean addAccountNameInRequest) {
-    this(name,
-        accountURL,
-        prop,
-        null,
-        false,
-        null,
-        parameterOverrides,
-        addAccountNameInRequest);
+    this(name, accountURL, prop, null, false, null, parameterOverrides, addAccountNameInRequest);
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -304,7 +304,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
       payload.put("schema", request.getSchemaName());
       payload.put("write_mode", Constants.WriteMode.CLOUD_STORAGE.name());
       payload.put("role", this.role);
-      if (request.isOffsetTokenProvided()){
+      if (request.isOffsetTokenProvided()) {
         payload.put("offset_token", request.getOffsetToken());
       }
 

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -109,6 +109,16 @@ public class ParameterProvider {
    * @param props Properties file provided to client constructor
    */
   private void setParameterMap(Map<String, Object> parameterOverrides, Properties props) {
+    // BUFFER_FLUSH_INTERVAL_IN_MILLIS is deprecated and disallowed
+    if ((parameterOverrides != null
+            && parameterOverrides.containsKey(BUFFER_FLUSH_INTERVAL_IN_MILLIS))
+        || (props != null && props.containsKey(BUFFER_FLUSH_INTERVAL_IN_MILLIS))) {
+      throw new IllegalArgumentException(
+          String.format(
+              "%s is deprecated, please use %s instead",
+              BUFFER_FLUSH_INTERVAL_IN_MILLIS, MAX_CLIENT_LAG));
+    }
+
     this.updateValue(
         BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS,
         BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT,
@@ -182,14 +192,6 @@ public class ParameterProvider {
 
   /** @return Longest interval in milliseconds between buffer flushes */
   public long getCachedMaxClientLagInMs() {
-    // BUFFER_FLUSH_INTERVAL_IN_MILLIS is deprecated and disallowed
-    if (this.parameterMap.containsKey(BUFFER_FLUSH_INTERVAL_IN_MILLIS)) {
-      throw new IllegalArgumentException(
-          String.format(
-              "%s is deprecated, please use %s instead",
-              BUFFER_FLUSH_INTERVAL_IN_MILLIS, MAX_CLIENT_LAG));
-    }
-
     if (cachedBufferFlushIntervalMs != -1L) {
       return cachedBufferFlushIntervalMs;
     }

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -192,7 +192,9 @@ public class ParameterProvider {
         props);
   }
 
-  /** @return Longest interval in milliseconds between buffer flushes */
+  /**
+   * @return Longest interval in milliseconds between buffer flushes
+   */
   public long getBufferFlushIntervalInMs() {
     if (getMaxClientLagEnabled()) {
       if (cachedBufferFlushIntervalMs != -1L) {
@@ -203,18 +205,18 @@ public class ParameterProvider {
         cachedBufferFlushIntervalMs = lag;
       }
       return cachedBufferFlushIntervalMs;
-    } else {
-      Object val =
-          this.parameterMap.getOrDefault(
-              BUFFER_FLUSH_INTERVAL_IN_MILLIS, BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT);
-      return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
     }
+
+    Object val =
+        this.parameterMap.getOrDefault(
+            BUFFER_FLUSH_INTERVAL_IN_MILLIS, BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT);
+    return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
   }
 
   private long getMaxClientLagMs() {
     Object val = this.parameterMap.getOrDefault(MAX_CLIENT_LAG, MAX_CLIENT_LAG_DEFAULT);
     if (!(val instanceof String)) {
-      return BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT;
+      return getBufferFlushIntervalInMs();
     }
     String maxLag = (String) val;
     String[] lagParts = maxLag.split(" ");
@@ -249,9 +251,9 @@ public class ParameterProvider {
     if (!(computedLag >= MAX_CLIENT_LAG_MS_MIN && computedLag <= MAX_CLIENT_LAG_MS_MAX)) {
       throw new IllegalArgumentException(
           String.format(
-              "Lag falls outside of allowed time range. Minimum (milliseconds) = %s, Maximum"
-                  + " (milliseconds) = %s",
-              MAX_CLIENT_LAG_MS_MIN, MAX_CLIENT_LAG_MS_MAX));
+              "Lag falls outside of allowed time range. Minimum (seconds) = %s, Maximum"
+                  + " (seconds) = %s",
+              MAX_CLIENT_LAG_MS_MIN / 1000, MAX_CLIENT_LAG_MS_MAX / 1000));
     }
     return computedLag;
   }
@@ -262,7 +264,9 @@ public class ParameterProvider {
     return (val instanceof String) ? Boolean.parseBoolean(val.toString()) : (boolean) val;
   }
 
-  /** @return Time in milliseconds between checks to see if the buffer should be flushed */
+  /**
+   * @return Time in milliseconds between checks to see if the buffer should be flushed
+   */
   public long getBufferFlushCheckIntervalInMs() {
     Object val =
         this.parameterMap.getOrDefault(
@@ -273,7 +277,9 @@ public class ParameterProvider {
     return (long) val;
   }
 
-  /** @return Duration in milliseconds to delay data insertion to the buffer when throttled */
+  /**
+   * @return Duration in milliseconds to delay data insertion to the buffer when throttled
+   */
   public long getInsertThrottleIntervalInMs() {
     Object val =
         this.parameterMap.getOrDefault(
@@ -284,7 +290,9 @@ public class ParameterProvider {
     return (long) val;
   }
 
-  /** @return Percent of free total memory at which we throttle row inserts */
+  /**
+   * @return Percent of free total memory at which we throttle row inserts
+   */
   public int getInsertThrottleThresholdInPercentage() {
     Object val =
         this.parameterMap.getOrDefault(
@@ -296,7 +304,9 @@ public class ParameterProvider {
     return (int) val;
   }
 
-  /** @return Absolute size in bytes of free total memory at which we throttle row inserts */
+  /**
+   * @return Absolute size in bytes of free total memory at which we throttle row inserts
+   */
   public int getInsertThrottleThresholdInBytes() {
     Object val =
         this.parameterMap.getOrDefault(
@@ -307,7 +317,9 @@ public class ParameterProvider {
     return (int) val;
   }
 
-  /** @return true if jmx metrics are enabled for a client */
+  /**
+   * @return true if jmx metrics are enabled for a client
+   */
   public boolean hasEnabledSnowpipeStreamingMetrics() {
     Object val =
         this.parameterMap.getOrDefault(
@@ -318,7 +330,9 @@ public class ParameterProvider {
     return (boolean) val;
   }
 
-  /** @return Blob format version */
+  /**
+   * @return Blob format version
+   */
   public Constants.BdecVersion getBlobFormatVersion() {
     Object val = this.parameterMap.getOrDefault(BLOB_FORMAT_VERSION, BLOB_FORMAT_VERSION_DEFAULT);
     if (val instanceof Constants.BdecVersion) {
@@ -347,7 +361,9 @@ public class ParameterProvider {
     return (int) val;
   }
 
-  /** @return the max retry count when waiting for a blob upload task to finish */
+  /**
+   * @return the max retry count when waiting for a blob upload task to finish
+   */
   public int getBlobUploadMaxRetryCount() {
     Object val =
         this.parameterMap.getOrDefault(
@@ -358,7 +374,9 @@ public class ParameterProvider {
     return (int) val;
   }
 
-  /** @return The max memory limit in bytes */
+  /**
+   * @return The max memory limit in bytes
+   */
   public long getMaxMemoryLimitInBytes() {
     Object val =
         this.parameterMap.getOrDefault(
@@ -366,7 +384,9 @@ public class ParameterProvider {
     return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
   }
 
-  /** @return Return whether memory optimization for Parquet is enabled. */
+  /**
+   * @return Return whether memory optimization for Parquet is enabled.
+   */
   public boolean getEnableParquetInternalBuffering() {
     Object val =
         this.parameterMap.getOrDefault(
@@ -374,7 +394,9 @@ public class ParameterProvider {
     return (val instanceof String) ? Boolean.parseBoolean(val.toString()) : (boolean) val;
   }
 
-  /** @return The max channel size in bytes */
+  /**
+   * @return The max channel size in bytes
+   */
   public long getMaxChannelSizeInBytes() {
     Object val =
         this.parameterMap.getOrDefault(
@@ -382,7 +404,9 @@ public class ParameterProvider {
     return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
   }
 
-  /** @return The max chunk size in bytes that could avoid OOM at server side */
+  /**
+   * @return The max chunk size in bytes that could avoid OOM at server side
+   */
   public long getMaxChunkSizeInBytes() {
     Object val =
         this.parameterMap.getOrDefault(MAX_CHUNK_SIZE_IN_BYTES, MAX_CHUNK_SIZE_IN_BYTES_DEFAULT);
@@ -408,11 +432,13 @@ public class ParameterProvider {
     return (val instanceof String) ? Integer.parseInt(val.toString()) : (int) val;
   }
 
-  /** @return BDEC compression algorithm */
+  /**
+   * @return BDEC compression algorithm
+   */
   public Constants.BdecParquetCompression getBdecParquetCompressionAlgorithm() {
     Object val =
-            this.parameterMap.getOrDefault(
-                    BDEC_PARQUET_COMPRESSION_ALGORITHM, BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT);
+        this.parameterMap.getOrDefault(
+            BDEC_PARQUET_COMPRESSION_ALGORITHM, BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT);
     if (val instanceof Constants.BdecParquetCompression) {
       return (Constants.BdecParquetCompression) val;
     }

--- a/src/test/java/net/snowflake/ingest/SimpleIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/SimpleIngestIT.java
@@ -178,8 +178,7 @@ public class SimpleIngestIT {
   }
 
   private void getHistoryAndAssertLoad(SimpleIngestManager manager, String test_file_name_2)
-      throws InterruptedException,
-          java.util.concurrent.ExecutionException,
+      throws InterruptedException, java.util.concurrent.ExecutionException,
           java.util.concurrent.TimeoutException {
     // keeps track of whether we've loaded the file
     boolean loaded = false;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -14,7 +14,7 @@ public class ParameterProviderTest {
 
   private Map<String, Object> getStartingParameterMap() {
     Map<String, Object> parameterMap = new HashMap<>();
-    parameterMap.put(ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS, 3L);
+    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, 1000L);
     parameterMap.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS, 4L);
     parameterMap.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE, 6);
     parameterMap.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_BYTES, 1024);
@@ -31,10 +31,9 @@ public class ParameterProviderTest {
   public void withValuesSet() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, false);
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
 
-    Assert.assertEquals(3L, parameterProvider.getBufferFlushIntervalInMs());
+    Assert.assertEquals(1000L, parameterProvider.getCachedMaxClientLagInMs());
     Assert.assertEquals(4L, parameterProvider.getBufferFlushCheckIntervalInMs());
     Assert.assertEquals(6, parameterProvider.getInsertThrottleThresholdInPercentage());
     Assert.assertEquals(1024, parameterProvider.getInsertThrottleThresholdInBytes());
@@ -51,14 +50,13 @@ public class ParameterProviderTest {
   @Test
   public void withNullProps() {
     Map<String, Object> parameterMap = new HashMap<>();
-    parameterMap.put(ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS, 3L);
+    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, 3000L);
     parameterMap.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS, 4L);
     parameterMap.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE, 6);
     parameterMap.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_BYTES, 1024);
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, false);
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, null);
 
-    Assert.assertEquals(3, parameterProvider.getBufferFlushIntervalInMs());
+    Assert.assertEquals(3000, parameterProvider.getCachedMaxClientLagInMs());
     Assert.assertEquals(4, parameterProvider.getBufferFlushCheckIntervalInMs());
     Assert.assertEquals(6, parameterProvider.getInsertThrottleThresholdInPercentage());
     Assert.assertEquals(1024, parameterProvider.getInsertThrottleThresholdInBytes());
@@ -70,14 +68,13 @@ public class ParameterProviderTest {
   @Test
   public void withNullParameterMap() {
     Properties props = new Properties();
-    props.put(ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS, 3L);
+    props.put(ParameterProvider.MAX_CLIENT_LAG, 3000L);
     props.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS, 4L);
     props.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE, 6);
     props.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_BYTES, 1024);
-    props.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, false);
     ParameterProvider parameterProvider = new ParameterProvider(null, props);
 
-    Assert.assertEquals(3, parameterProvider.getBufferFlushIntervalInMs());
+    Assert.assertEquals(3000, parameterProvider.getCachedMaxClientLagInMs());
     Assert.assertEquals(4, parameterProvider.getBufferFlushCheckIntervalInMs());
     Assert.assertEquals(6, parameterProvider.getInsertThrottleThresholdInPercentage());
     Assert.assertEquals(1024, parameterProvider.getInsertThrottleThresholdInBytes());
@@ -91,8 +88,7 @@ public class ParameterProviderTest {
     ParameterProvider parameterProvider = new ParameterProvider(null, null);
 
     Assert.assertEquals(
-        ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT,
-        parameterProvider.getBufferFlushIntervalInMs());
+        ParameterProvider.MAX_CLIENT_LAG_DEFAULT, parameterProvider.getCachedMaxClientLagInMs());
     Assert.assertEquals(
         ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT,
         parameterProvider.getBufferFlushCheckIntervalInMs());
@@ -112,8 +108,7 @@ public class ParameterProviderTest {
     ParameterProvider parameterProvider = new ParameterProvider();
 
     Assert.assertEquals(
-        ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS_DEFAULT,
-        parameterProvider.getBufferFlushIntervalInMs());
+        ParameterProvider.MAX_CLIENT_LAG_DEFAULT, parameterProvider.getCachedMaxClientLagInMs());
     Assert.assertEquals(
         ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT,
         parameterProvider.getBufferFlushCheckIntervalInMs());
@@ -146,77 +141,75 @@ public class ParameterProviderTest {
   public void testMaxClientLagEnabled() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, true);
     parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, "2 second");
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
-    Assert.assertEquals(2000, parameterProvider.getBufferFlushIntervalInMs());
+    Assert.assertEquals(2000, parameterProvider.getCachedMaxClientLagInMs());
     // call again to trigger caching logic
-    Assert.assertEquals(2000, parameterProvider.getBufferFlushIntervalInMs());
+    Assert.assertEquals(2000, parameterProvider.getCachedMaxClientLagInMs());
   }
 
   @Test
   public void testMaxClientLagEnabledPluralTimeUnit() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, true);
     parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, "2 seconds");
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
-    Assert.assertEquals(2000, parameterProvider.getBufferFlushIntervalInMs());
+    Assert.assertEquals(2000, parameterProvider.getCachedMaxClientLagInMs());
   }
 
   @Test
   public void testMaxClientLagEnabledMinuteTimeUnit() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, true);
     parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, "1 minute");
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
-    Assert.assertEquals(60000, parameterProvider.getBufferFlushIntervalInMs());
+    Assert.assertEquals(60000, parameterProvider.getCachedMaxClientLagInMs());
   }
 
   @Test
   public void testMaxClientLagEnabledMinuteTimeUnitPluralTimeUnit() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, true);
     parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, "2 minutes");
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
-    Assert.assertEquals(120000, parameterProvider.getBufferFlushIntervalInMs());
+    Assert.assertEquals(120000, parameterProvider.getCachedMaxClientLagInMs());
   }
 
   @Test
   public void testMaxClientLagEnabledDefaultValue() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, true);
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
-    Assert.assertEquals(1000, parameterProvider.getBufferFlushIntervalInMs());
+    Assert.assertEquals(
+        ParameterProvider.MAX_CLIENT_LAG_DEFAULT, parameterProvider.getCachedMaxClientLagInMs());
   }
 
   @Test
-  public void testMaxClientLagEnabledMissingUnit() {
+  public void testMaxClientLagEnabledDefaultUnit() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, true);
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, "1");
+    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, "3000");
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
-    try {
-      parameterProvider.getBufferFlushIntervalInMs();
-      Assert.fail("Should not have succeeded");
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Failed to parse"));
-    }
+    Assert.assertEquals(3000, parameterProvider.getCachedMaxClientLagInMs());
+  }
+
+  @Test
+  public void testMaxClientLagEnabledLongInput() {
+    Properties prop = new Properties();
+    Map<String, Object> parameterMap = getStartingParameterMap();
+    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, 3000L);
+    ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
+    Assert.assertEquals(3000, parameterProvider.getCachedMaxClientLagInMs());
   }
 
   @Test
   public void testMaxClientLagEnabledMissingUnitTimeUnitSupplied() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, true);
     parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, " year");
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
     try {
-      parameterProvider.getBufferFlushIntervalInMs();
+      parameterProvider.getCachedMaxClientLagInMs();
       Assert.fail("Should not have succeeded");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().startsWith("Failed to parse"));
@@ -227,11 +220,10 @@ public class ParameterProviderTest {
   public void testMaxClientLagEnabledInvalidTimeUnit() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, true);
     parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, "1 year");
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
     try {
-      parameterProvider.getBufferFlushIntervalInMs();
+      parameterProvider.getCachedMaxClientLagInMs();
       Assert.fail("Should not have succeeded");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().startsWith("Invalid time unit"));
@@ -242,11 +234,10 @@ public class ParameterProviderTest {
   public void testMaxClientLagEnabledInvalidUnit() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, true);
     parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, "banana minute");
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
     try {
-      parameterProvider.getBufferFlushIntervalInMs();
+      parameterProvider.getCachedMaxClientLagInMs();
       Assert.fail("Should not have succeeded");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().startsWith("Failed to parse"));
@@ -257,11 +248,10 @@ public class ParameterProviderTest {
   public void testMaxClientLagEnabledThresholdBelow() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, true);
     parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, "0 second");
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
     try {
-      parameterProvider.getBufferFlushIntervalInMs();
+      parameterProvider.getCachedMaxClientLagInMs();
       Assert.fail("Should not have succeeded");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().startsWith("Lag falls outside"));
@@ -272,11 +262,10 @@ public class ParameterProviderTest {
   public void testMaxClientLagEnabledThresholdAbove() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();
-    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG_ENABLED, true);
     parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, "11 minutes");
     ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
     try {
-      parameterProvider.getBufferFlushIntervalInMs();
+      parameterProvider.getCachedMaxClientLagInMs();
       Assert.fail("Should not have succeeded");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().startsWith("Lag falls outside"));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -273,6 +273,20 @@ public class ParameterProviderTest {
   }
 
   @Test
+  public void testMaxClientLagEnableEmptyInput() {
+    Properties prop = new Properties();
+    Map<String, Object> parameterMap = getStartingParameterMap();
+    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, "");
+    ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop);
+    try {
+      parameterProvider.getCachedMaxClientLagInMs();
+      Assert.fail("Should not have succeeded");
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals(e.getCause().getClass(), NumberFormatException.class);
+    }
+  }
+
+  @Test
   public void testMaxChunksInBlobAndRegistrationRequest() {
     Properties prop = new Properties();
     Map<String, Object> parameterMap = getStartingParameterMap();

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -266,20 +266,19 @@ public class SnowflakeStreamingIngestChannelTest {
     Assert.assertFalse(request.isOffsetTokenProvided());
   }
 
-
   @Test
   public void testOpenChannelRequesCreationtWithOffsetToken() {
     OpenChannelRequest request =
-            OpenChannelRequest.builder("CHANNEL")
-                    .setDBName("STREAMINGINGEST_TEST")
-                    .setSchemaName("PUBLIC")
-                    .setTableName("T_STREAMINGINGEST")
-                    .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
-                    .setOffsetToken("TEST_TOKEN")
-                    .build();
+        OpenChannelRequest.builder("CHANNEL")
+            .setDBName("STREAMINGINGEST_TEST")
+            .setSchemaName("PUBLIC")
+            .setTableName("T_STREAMINGINGEST")
+            .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
+            .setOffsetToken("TEST_TOKEN")
+            .build();
 
     Assert.assertEquals(
-            "STREAMINGINGEST_TEST.PUBLIC.T_STREAMINGINGEST", request.getFullyQualifiedTableName());
+        "STREAMINGINGEST_TEST.PUBLIC.T_STREAMINGINGEST", request.getFullyQualifiedTableName());
     Assert.assertEquals("TEST_TOKEN", request.getOffsetToken());
     Assert.assertTrue(request.isOffsetTokenProvided());
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -142,17 +142,16 @@ public class SnowflakeStreamingIngestClientTest {
   }
 
   @Test
-  @Ignore // Until able to test in PROD
   public void testConstructorParameters() throws Exception {
     Properties prop = new Properties();
     prop.put(USER, TestUtils.getUser());
     prop.put(ACCOUNT_URL, TestUtils.getHost());
     prop.put(PRIVATE_KEY, TestUtils.getPrivateKey());
-    prop.put(ROLE, "role");
-    prop.put(ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS, 123);
+    prop.put(ROLE, TestUtils.getRole());
+    prop.put(ParameterProvider.MAX_CLIENT_LAG, 1234);
 
     Map<String, Object> parameterMap = new HashMap<>();
-    parameterMap.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS, 321);
+    parameterMap.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS, 321L);
 
     SnowflakeStreamingIngestClientInternal<?> client =
         (SnowflakeStreamingIngestClientInternal<?>)
@@ -162,7 +161,7 @@ public class SnowflakeStreamingIngestClientTest {
                 .build();
 
     Assert.assertEquals("client", client.getName());
-    Assert.assertEquals(123, client.getParameterProvider().getBufferFlushIntervalInMs());
+    Assert.assertEquals(1234, client.getParameterProvider().getCachedMaxClientLagInMs());
     Assert.assertEquals(321, client.getParameterProvider().getBufferFlushCheckIntervalInMs());
     Assert.assertEquals(
         ParameterProvider.INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT,
@@ -256,15 +255,12 @@ public class SnowflakeStreamingIngestClientTest {
   }
 
   @Test
-  @Ignore // Wait for the client/configure endpoint to be available in PROD, can't mock the
-  // HttpUtil.executeGeneralRequest call because it's also used when setting up the
-  // connection
   public void testClientFactorySuccess() throws Exception {
     Properties prop = new Properties();
     prop.put(USER, TestUtils.getUser());
     prop.put(ACCOUNT_URL, TestUtils.getHost());
     prop.put(PRIVATE_KEY, TestUtils.getPrivateKey());
-    prop.put(ROLE, "role");
+    prop.put(ROLE, TestUtils.getRole());
 
     SnowflakeStreamingIngestClient client =
         SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -192,7 +192,7 @@ public class StreamingIngestIT {
   @Test
   public void testParameterOverrides() throws Exception {
     Map<String, Object> parameterMap = new HashMap<>();
-    parameterMap.put(ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS, 30L);
+    parameterMap.put(ParameterProvider.MAX_CLIENT_LAG, "3 sec");
     parameterMap.put(ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS, 50L);
     parameterMap.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE, 1);
     parameterMap.put(ParameterProvider.INSERT_THROTTLE_THRESHOLD_IN_BYTES, 1024);
@@ -536,19 +536,16 @@ public class StreamingIngestIT {
   public void testOpenChannelOffsetToken() throws Exception {
     String tableName = "offsetTokenTest";
     jdbcConnection
-            .createStatement()
-            .execute(
-                    String.format(
-                            "create or replace table %s (s text);",
-                            tableName));
+        .createStatement()
+        .execute(String.format("create or replace table %s (s text);", tableName));
     OpenChannelRequest request1 =
-            OpenChannelRequest.builder("TEST_CHANNEL")
-                    .setDBName(testDb)
-                    .setSchemaName(TEST_SCHEMA)
-                    .setTableName(tableName)
-                    .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
-                    .setOffsetToken("TEST_OFFSET")
-                    .build();
+        OpenChannelRequest.builder("TEST_CHANNEL")
+            .setDBName(testDb)
+            .setSchemaName(TEST_SCHEMA)
+            .setTableName(tableName)
+            .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
+            .setOffsetToken("TEST_OFFSET")
+            .build();
 
     // Open a streaming ingest channel from the given client
     SnowflakeStreamingIngestChannel channel1 = client.openChannel(request1);
@@ -558,7 +555,7 @@ public class StreamingIngestIT {
 
     for (int i = 1; i < 15; i++) {
       if (channel1.getLatestCommittedOffsetToken() != null
-              && channel1.getLatestCommittedOffsetToken().equals("TEST_OFFSET")) {
+          && channel1.getLatestCommittedOffsetToken().equals("TEST_OFFSET")) {
         return;
       } else {
         Thread.sleep(2000);


### PR DESCRIPTION
- After `MAX_CLIENT_LAG` was introduced, it's not backward compatible with the current logic since `MAX_CLIENT_LAG_ENABLED` is true by default and we won't even check for `BUFFER_FLUSH_INTERVAL_IN_MILLIS`. Instead of supporting backward compatible, I decide to remove `BUFFER_FLUSH_INTERVAL_IN_MILLIS` completely since that is an undocumented parameter. We only support `MAX_CLIENT_LAG` going forward and using `BUFFER_FLUSH_INTERVAL_IN_MILLIS` will result in an exception. 
- To match the behavior of `BUFFER_FLUSH_INTERVAL_IN_MILLIS` so the transition is smooth, `MAX_CLIENT_LAG` now also supports LONG input and input without a time unit (default will be milliseconds)
- Some code format changes done automatically by the Google Java Format
- Reenable some tests disabled long time ago