### PR TITLE
NO-SNOW: fix test failures during releasing

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestClientFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestClientFactory.java
@@ -28,6 +28,9 @@ public class SnowflakeStreamingIngestClientFactory {
     // Allows client to override some default parameter values
     private Map<String, Object> parameterOverrides;
 
+    // Indicates whether it's under test mode
+    private boolean isTestMode;
+
     private Builder(String name) {
       this.name = name;
     }
@@ -42,6 +45,11 @@ public class SnowflakeStreamingIngestClientFactory {
       return this;
     }
 
+    public Builder setIsTestMode(boolean isTestMode) {
+      this.isTestMode = isTestMode;
+      return this;
+    }
+
     public SnowflakeStreamingIngestClient build() {
       Utils.assertStringNotNullOrEmpty("client name", this.name);
       Utils.assertNotNull("connection properties", this.prop);
@@ -50,7 +58,7 @@ public class SnowflakeStreamingIngestClientFactory {
       SnowflakeURL accountURL = new SnowflakeURL(prop.getProperty(Constants.ACCOUNT_URL));
 
       return new SnowflakeStreamingIngestClientInternal<>(
-          this.name, accountURL, prop, this.parameterOverrides);
+          this.name, accountURL, prop, this.parameterOverrides, this.isTestMode);
     }
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -227,13 +227,15 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
    * @param accountURL Snowflake account url
    * @param prop connection properties
    * @param parameterOverrides map of parameters to override for this client
+   * @param isTestMode indicates whether it's under test mode
    */
   public SnowflakeStreamingIngestClientInternal(
       String name,
       SnowflakeURL accountURL,
       Properties prop,
-      Map<String, Object> parameterOverrides) {
-    this(name, accountURL, prop, null, false, null, parameterOverrides);
+      Map<String, Object> parameterOverrides,
+      boolean isTestMode) {
+    this(name, accountURL, prop, null, isTestMode, null, parameterOverrides);
   }
 
   /*** Constructor for TEST ONLY
@@ -269,7 +271,9 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
     return this.role;
   }
 
-  /** @return a boolean to indicate whether the client is closed or not */
+  /**
+   * @return a boolean to indicate whether the client is closed or not
+   */
   @Override
   public boolean isClosed() {
     return isClosed;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -271,9 +271,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
     return this.role;
   }
 
-  /**
-   * @return a boolean to indicate whether the client is closed or not
-   */
+  /** @return a boolean to indicate whether the client is closed or not */
   @Override
   public boolean isClosed() {
     return isClosed;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -158,6 +158,7 @@ public class SnowflakeStreamingIngestClientTest {
             SnowflakeStreamingIngestClientFactory.builder("client")
                 .setProperties(prop)
                 .setParameterOverrides(parameterMap)
+                .setIsTestMode(true)
                 .build();
 
     Assert.assertEquals("client", client.getName());
@@ -263,7 +264,10 @@ public class SnowflakeStreamingIngestClientTest {
     prop.put(ROLE, TestUtils.getRole());
 
     SnowflakeStreamingIngestClient client =
-        SnowflakeStreamingIngestClientFactory.builder("client").setProperties(prop).build();
+        SnowflakeStreamingIngestClientFactory.builder("client")
+            .setProperties(prop)
+            .setIsTestMode(true)
+            .build();
 
     Assert.assertEquals("client", client.getName());
     Assert.assertFalse(client.isClosed());


### PR DESCRIPTION
We're hitting test failures during snapshot release and the reason is because there's no profile.json file, this PR adds a test mode in SnowflakeStreamingIngestClientFactory so that we can continue use dummyHost name for unit testing.

2024-01-09 23:17:26 testClientFactorySuccess(net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientTest)  Time elapsed: 180.565 sec  <<< ERROR!
2024-01-09 23:17:26 net.snowflake.ingest.utils.SFException: Unable to connect to streaming ingest internal stage.
2024-01-09 23:17:26 	at net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientTest.testClientFactorySuccess(SnowflakeStreamingIngestClientTest.java:266)
2024-01-09 23:17:26 Caused by: net.snowflake.client.jdbc.internal.apache.http.conn.ConnectTimeoutException: Connect to snowflake.qa1.int.snowflakecomputing.com:443 [snowflake.qa1.int.snowflakecomputing.com/10.180.20.15, snowflake.qa1.int.snowflakecomputing.com/10.180.20.17, snowflake.qa1.int.snowflakecomputing.com/10.180.20.16] failed: connect timed out
2024-01-09 23:17:26 	at net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientTest.testClientFactorySuccess(SnowflakeStreamingIngestClientTest.java:266)
2024-01-09 23:17:26 Caused by: java.net.SocketTimeoutException: connect timed out
2024-01-09 23:17:26 	at net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientTest.testClientFactorySuccess(SnowflakeStreamingIngestClientTest.java:266)
2024-01-09 23:17:26 
2024-01-09 23:17:26 testConstructorParameters(net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientTest)  Time elapsed: 180.392 sec  <<< ERROR!