### PR TITLE
SNOW-995369 GCS token refresh

### DIFF
--- a/e2e-jar-test/fips/src/test/java/net/snowflake/FipsIngestE2ETest.java
+++ b/e2e-jar-test/fips/src/test/java/net/snowflake/FipsIngestE2ETest.java
@@ -3,9 +3,12 @@ package net.snowflake;
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.security.Security;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 public class FipsIngestE2ETest {
 
@@ -25,7 +28,13 @@ public class FipsIngestE2ETest {
   }
 
   @Test
-  public void name() throws InterruptedException {
-    ingestTestUtils.test();
+  public void basicTest() throws InterruptedException {
+    ingestTestUtils.runBasicTest();
+  }
+
+  @Test
+  @Ignore("Takes too long to run")
+  public void longRunningTest() throws InterruptedException {
+    ingestTestUtils.runLongRunningTest(Duration.of(80, ChronoUnit.MINUTES));
   }
 }

--- a/e2e-jar-test/pom.xml
+++ b/e2e-jar-test/pom.xml
@@ -27,7 +27,8 @@
             <dependency>
                 <groupId>net.snowflake</groupId>
                 <artifactId>snowflake-ingest-sdk</artifactId>
-                <version>2.0.4</version>
+                <!-- This value should be the same as the version in the pom.xml of the SDK -->
+                <version>2.0.5-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/e2e-jar-test/standard/src/test/java/net/snowflake/StandardIngestE2ETest.java
+++ b/e2e-jar-test/standard/src/test/java/net/snowflake/StandardIngestE2ETest.java
@@ -2,7 +2,11 @@ package net.snowflake;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 public class StandardIngestE2ETest {
 
@@ -19,7 +23,13 @@ public class StandardIngestE2ETest {
   }
 
   @Test
-  public void name() throws InterruptedException {
-    ingestTestUtils.test();
+  public void basicTest() throws InterruptedException {
+    ingestTestUtils.runBasicTest();
+  }
+
+  @Test
+  @Ignore("Takes too long to run")
+  public void longRunningTest() throws InterruptedException {
+    ingestTestUtils.runLongRunningTest(Duration.of(80, ChronoUnit.MINUTES));
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -59,6 +59,9 @@ import net.snowflake.ingest.utils.Utils;
  */
 class FlushService<T> {
 
+  // The max number of upload retry attempts to the stage
+  private static final int DEFAULT_MAX_UPLOAD_RETRIES = 5;
+
   // Static class to save the list of channels that are used to build a blob, which is mainly used
   // to invalidate all the channels when there is a failure
   static class BlobData<T> {
@@ -163,7 +166,8 @@ class FlushService<T> {
               client.getRole(),
               client.getHttpClient(),
               client.getRequestBuilder(),
-              client.getName());
+              client.getName(),
+              DEFAULT_MAX_UPLOAD_RETRIES);
     } catch (SnowflakeSQLException | IOException err) {
       throw new SFException(err, ErrorCode.UNABLE_TO_CONNECT_TO_STAGE);
     }


### PR DESCRIPTION
This PR implements refresh of downscoped GCS tokens. Additionally, it increases the number of retries up to 10 for cloud storage upload errors with exponential backoff. 

Testing: There is a new test in the e2e JAR test project, which runs 80-minute test with both `snowflake-jdbc` and `snowflake-jdbc-fips` during which the token should be refreshed. This test passed successfully ([AWS](https://github.com/snowflakedb/snowflake-ingest-java/actions/runs/7530921751/job/20498349542?pr=665), [Azure](https://github.com/snowflakedb/snowflake-ingest-java/actions/runs/7530921751/job/20498350641?pr=665), [GCP](https://github.com/snowflakedb/snowflake-ingest-java/actions/runs/7530921751/job/20498351333?pr=665)), but it is disabled by default due to its long runtime. Due to SNOW-1009045, `-SNAPSHOTS` SDK versions do not use downscoped GCP tokens, which is why the SDK version has been temporarily changed for testing purposes. 

Azure token refresh:
```
2024-01-15T17:46:50.8514661Z SEVERE: Exception encountered during file upload: 
2024-01-15T17:46:50.8517117Z [ingest-build-upload-thread-1] INFO net.snowflake.ingest.streaming.internal.StreamingIngestStage - [SF_INGEST] Stage metadata need to be refreshed due to upload error: !240001!
2024-01-15T17:46:50.8519355Z [ingest-build-upload-thread-1] INFO net.snowflake.ingest.streaming.internal.StreamingIngestStage - [SF_INGEST] Refresh Snowflake metadata, client=TestClient01
2024-01-15T17:46:50.9843109Z [ingest-build-upload-thread-1] INFO net.snowflake.ingest.streaming.internal.StreamingIngestStage - [SF_INGEST] Retrying upload, attempt 1/10 !240001!
2024-01-15T17:46:51.1153295Z [ingest-build-upload-thread-1] INFO net.snowflake.ingest.streaming.internal.FlushService - [SF_INGEST] Finish uploading blob=2024/1/15/17/46/s7bde2_R8HFY6Nzxdw1SyFE9qzdctP8jQlrqGNxBB11eWtOaQ5sCC_2001_15_61.bdec, size=6160, timeInMillis=541
2024-01-15T17:46:51.1157308Z [ingest-register-thread] INFO net.snowflake.ingest.streaming.internal.RegisterService - [SF_INGEST] Start registering blobs in client=TestClient01, totalBlobListSize=1, currentBlobListSize=1, idx=1
2024-01-15T17:46:51.1160625Z [ingest-register-thread] INFO net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientInternal - [SF_INGEST] Register blob request preparing for blob=[2024/1/15/17/46/s7bde2_R8HFY6Nzxdw1SyFE9qzdctP8jQlrqGNxBB11eWtOaQ5sCC_2001_15_61.bdec], client=TestClient01, executionCount=0
2024-01-15T17:46:51.3214224Z [ingest-register-thread] INFO net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientInternal - [SF_INGEST] Register blob request returned for blob=[2024/1/15/17/46/s7bde2_R8HFY6Nzxdw1SyFE9qzdctP8jQlrqGNxBB11eWtOaQ5sCC_2001_15_61.bdec], client=TestClient01, executionCount=0
```

GCS token refresh:
```
2024-01-15T16:25:19.3197706Z [ingest-build-upload-thread-1] INFO net.snowflake.ingest.streaming.internal.FlushService - [SF_INGEST] Start uploading blob=2024/1/15/16/25/s7b9m7_WuVa2QZo53FRL2CFBBK2S1iiPramoBBNsisDTh58uD1OMCC_3001_15_61.bdec, size=6176
2024-01-15T16:25:19.4334528Z Jan 15, 2024 4:25:19 PM net.snowflake.client.jdbc.SnowflakeFileTransferAgent uploadWithoutConnection
2024-01-15T16:25:19.4335318Z SEVERE: Exception encountered during file upload: 
2024-01-15T16:25:19.4336835Z [ingest-build-upload-thread-1] INFO net.snowflake.ingest.streaming.internal.StreamingIngestStage - [SF_INGEST] Stage metadata need to be refreshed due to upload error: 401 Unauthorized
2024-01-15T16:25:19.4339761Z POST https://storage.googleapis.com/upload/storage/v1/b/gcpuscentral1_8n9qngc_stage/o?projection=full&uploadType=multipart
2024-01-15T16:25:19.4342141Z [ingest-build-upload-thread-1] INFO net.snowflake.ingest.streaming.internal.StreamingIngestStage - [SF_INGEST] Refresh Snowflake metadata, client=TestClient01
2024-01-15T16:25:19.6470067Z [ingest-build-upload-thread-1] INFO net.snowflake.ingest.streaming.internal.StreamingIngestStage - [SF_INGEST] Retrying upload, attempt 1/10 401 Unauthorized
2024-01-15T16:25:19.6471929Z POST https://storage.googleapis.com/upload/storage/v1/b/gcpuscentral1_8n9qngc_stage/o?projection=full&uploadType=multipart
2024-01-15T16:25:19.7588300Z [ingest-build-upload-thread-1] INFO net.snowflake.ingest.streaming.internal.FlushService - [SF_INGEST] Finish uploading blob=2024/1/15/16/25/s7b9m7_WuVa2QZo53FRL2CFBBK2S1iiPramoBBNsisDTh58uD1OMCC_3001_15_61.bdec, size=6176, timeInMillis=439
2024-01-15T16:25:19.7590519Z [ingest-register-thread] INFO net.snowflake.ingest.streaming.internal.RegisterService - [SF_INGEST] Start registering blobs in client=TestClient01, totalBlobListSize=1, currentBlobListSize=1, idx=1
2024-01-15T16:25:19.7592911Z [ingest-register-thread] INFO net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientInternal - [SF_INGEST] Register blob request preparing for blob=[2024/1/15/16/25/s7b9m7_WuVa2QZo53FRL2CFBBK2S1iiPramoBBNsisDTh58uD1OMCC_3001_15_61.bdec], client=TestClient01, executionCount=0
2024-01-15T16:25:19.9282642Z [ingest-register-thread] INFO net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientInternal - [SF_INGEST] Register blob request returned for blob=[2024/1/15/16/25/s7b9m7_WuVa2QZo53FRL2CFBBK2S1iiPramoBBNsisDTh58uD1OMCC_3001_15_61.bdec], client=TestClient01, executionCount=0
```