### PR TITLE
NO-SNOW Run e2e jar tests on all clouds

### DIFF
--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 8 ]
-        snowflake_cloud: [ 'AWS' ]
+        snowflake_cloud: [ 'AWS', 'AZURE', 'GCP' ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/e2e-jar-test/pom.xml
+++ b/e2e-jar-test/pom.xml
@@ -33,7 +33,7 @@
             <dependency>
                 <groupId>net.snowflake</groupId>
                 <artifactId>snowflake-jdbc-fips</artifactId>
-                <version>3.13.30</version>
+                <version>3.13.34</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR changes the end to end JAR test to run on all clouds. The `snowflake-jdbc-fips` is updated to `3.13.34`, which fixed upload to GCS that was previously failing.  