### PR TITLE
Snowpipe Streaming: send column ordinal back to GS with blob EPs to register

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 
 /** Audit register endpoint/FileColumnPropertyDTO property list. */
 class FileColumnProperties {
-
+  private int columnOrdinal;
   private String minStrValue;
 
   private String maxStrValue;
@@ -45,6 +45,7 @@ class FileColumnProperties {
   public static final Double DEFAULT_MIN_MAX_REAL_VAL_FOR_EP = 0d;
 
   FileColumnProperties(RowBufferStats stats) {
+    this.setColumnOrdinal(stats.getOrdinal());
     this.setCollation(stats.getCollationDefinitionString());
     this.setMaxIntValue(
         stats.getCurrentMaxIntValue() == null
@@ -81,6 +82,15 @@ class FileColumnProperties {
 
     this.setNullCount(stats.getCurrentNullCount());
     this.setDistinctValues(stats.getDistinctValues());
+  }
+
+  @JsonProperty("columnId")
+  public int getColumnOrdinal() {
+    return columnOrdinal;
+  }
+
+  public void setColumnOrdinal(int columnOrdinal) {
+    this.columnOrdinal = columnOrdinal;
   }
 
   // Annotation required in order to have package private fields serialized
@@ -195,6 +205,7 @@ class FileColumnProperties {
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder("{");
+    sb.append("\"columnOrdinal\": ").append(columnOrdinal);
     if (minIntValue != null) {
       sb.append(", \"minIntValue\": ").append(minIntValue);
       sb.append(", \"maxIntValue\": ").append(maxIntValue);
@@ -220,7 +231,8 @@ class FileColumnProperties {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     FileColumnProperties that = (FileColumnProperties) o;
-    return distinctValues == that.distinctValues
+    return Objects.equals(columnOrdinal,that.columnOrdinal)
+        && distinctValues == that.distinctValues
         && nullCount == that.nullCount
         && maxLength == that.maxLength
         && Objects.equals(minStrValue, that.minStrValue)
@@ -237,6 +249,7 @@ class FileColumnProperties {
   @Override
   public int hashCode() {
     return Objects.hash(
+        columnOrdinal,
         minStrValue,
         maxStrValue,
         collation,

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -95,12 +95,12 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
         addNonNullableFieldName(column.getInternalName());
       }
       this.statsMap.put(
-          column.getInternalName(), new RowBufferStats(column.getName(), column.getCollation()));
+          column.getInternalName(), new RowBufferStats(column.getName(), column.getCollation(), column.getOrdinal()));
 
       if (onErrorOption == OpenChannelRequest.OnErrorOption.ABORT
           || onErrorOption == OpenChannelRequest.OnErrorOption.SKIP_BATCH) {
         this.tempStatsMap.put(
-            column.getInternalName(), new RowBufferStats(column.getName(), column.getCollation()));
+            column.getInternalName(), new RowBufferStats(column.getName(), column.getCollation(), column.getOrdinal()));
       }
 
       id++;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -15,6 +15,7 @@ import net.snowflake.ingest.utils.SFException;
 /** Keeps track of the active EP stats, used to generate a file EP info */
 class RowBufferStats {
 
+  private final int ordinal;
   private byte[] currentMinStrValue;
   private byte[] currentMaxStrValue;
   private BigInteger currentMinIntValue;
@@ -29,14 +30,15 @@ class RowBufferStats {
   private final String columnDisplayName;
 
   /** Creates empty stats */
-  RowBufferStats(String columnDisplayName, String collationDefinitionString) {
+  RowBufferStats(String columnDisplayName, String collationDefinitionString, int ordinal) {
     this.columnDisplayName = columnDisplayName;
     this.collationDefinitionString = collationDefinitionString;
+    this.ordinal= ordinal;
     reset();
   }
 
   RowBufferStats(String columnDisplayName) {
-    this(columnDisplayName, null);
+    this(columnDisplayName, null, -1);
   }
 
   void reset() {
@@ -52,7 +54,7 @@ class RowBufferStats {
 
   /** Create new statistics for the same column, with all calculated values set to empty */
   RowBufferStats forkEmpty() {
-    return new RowBufferStats(this.getColumnDisplayName(), this.getCollationDefinitionString());
+    return new RowBufferStats(this.getColumnDisplayName(), this.getCollationDefinitionString(), this.getOrdinal());
   }
 
   // TODO performance test this vs in place update
@@ -66,7 +68,7 @@ class RowBufferStats {
               left.getCollationDefinitionString(), right.getCollationDefinitionString()));
     }
     RowBufferStats combined =
-        new RowBufferStats(left.columnDisplayName, left.getCollationDefinitionString());
+        new RowBufferStats(left.columnDisplayName, left.getCollationDefinitionString(), left.getOrdinal());
 
     if (left.currentMinIntValue != null) {
       combined.addIntValue(left.currentMinIntValue);
@@ -207,6 +209,10 @@ class RowBufferStats {
 
   String getColumnDisplayName() {
     return columnDisplayName;
+  }
+
+  public int getOrdinal() {
+    return ordinal;
   }
 
   /**

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FileColumnPropertiesTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FileColumnPropertiesTest.java
@@ -8,20 +8,22 @@ public class FileColumnPropertiesTest {
   @Test
   public void testFileColumnPropertiesConstructor() {
     // Test simple construction
-    RowBufferStats stats = new RowBufferStats("COL");
+    RowBufferStats stats = new RowBufferStats("COL", null, 1);
     stats.addStrValue("bcd");
     stats.addStrValue("abcde");
     FileColumnProperties props = new FileColumnProperties(stats);
+    Assert.assertEquals(1, props.getColumnOrdinal());
     Assert.assertEquals("6162636465", props.getMinStrValue());
     Assert.assertNull(props.getMinStrNonCollated());
     Assert.assertEquals("626364", props.getMaxStrValue());
     Assert.assertNull(props.getMaxStrNonCollated());
 
     // Test that truncation is performed
-    stats = new RowBufferStats("COL");
+    stats = new RowBufferStats("COL", null, 1);
     stats.addStrValue("aßßßßßßßßßßßßßßßß");
     Assert.assertEquals(33, stats.getCurrentMinStrValue().length);
     props = new FileColumnProperties(stats);
+    Assert.assertEquals(1, props.getColumnOrdinal());
     Assert.assertNull(props.getMinStrNonCollated());
     Assert.assertNull(props.getMaxStrNonCollated());
     Assert.assertEquals(32 * 2, props.getMinStrValue().length());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -349,6 +349,7 @@ public class FlushServiceTest {
 
   private static ColumnMetadata createTestIntegerColumn(String name) {
     ColumnMetadata colInt = new ColumnMetadata();
+    colInt.setOrdinal(1);
     colInt.setName(name);
     colInt.setPhysicalType("SB4");
     colInt.setNullable(true);
@@ -360,6 +361,7 @@ public class FlushServiceTest {
 
   private static ColumnMetadata createTestTextColumn(String name) {
     ColumnMetadata colChar = new ColumnMetadata();
+    colChar.setOrdinal(1);
     colChar.setName(name);
     colChar.setPhysicalType("LOB");
     colChar.setNullable(true);
@@ -372,6 +374,7 @@ public class FlushServiceTest {
 
   private static ColumnMetadata createLargeTestTextColumn(String name) {
     ColumnMetadata colChar = new ColumnMetadata();
+    colChar.setOrdinal(1);
     colChar.setName(name);
     colChar.setPhysicalType("LOB");
     colChar.setNullable(true);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -20,6 +20,7 @@ import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.commons.codec.binary.Hex;
+import org.checkerframework.common.value.qual.IntRange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -104,8 +105,12 @@ public class RowBufferTest {
     colChar.setLength(11);
     colChar.setScale(0);
 
-    return Arrays.asList(
-        colTinyIntCase, colTinyInt, colSmallInt, colInt, colBigInt, colDecimal, colChar);
+    List<ColumnMetadata> columns = Arrays.asList(
+            colTinyIntCase, colTinyInt, colSmallInt, colInt, colBigInt, colDecimal, colChar);
+    for (int i = 0; i < columns.size(); i++) {
+      columns.get(i).setOrdinal(i + 1);
+    }
+    return columns;
   }
 
   private AbstractRowBuffer<?> createTestBuffer(OpenChannelRequest.OnErrorOption onErrorOption) {
@@ -506,6 +511,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colDoubleQuotes = new ColumnMetadata();
+    colDoubleQuotes.setOrdinal(1);
     colDoubleQuotes.setName("\"colDoubleQuotes\"");
     colDoubleQuotes.setPhysicalType("SB16");
     colDoubleQuotes.setNullable(true);
@@ -662,6 +668,7 @@ public class RowBufferTest {
   private void testE2ETimestampErrorsHelper(AbstractRowBuffer<?> innerBuffer) {
 
     ColumnMetadata colTimestampLtzSB16 = new ColumnMetadata();
+    colTimestampLtzSB16.setOrdinal(1);
     colTimestampLtzSB16.setName("COLTIMESTAMPLTZ_SB16");
     colTimestampLtzSB16.setPhysicalType("SB16");
     colTimestampLtzSB16.setNullable(false);
@@ -782,6 +789,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colTimestampLtzSB8 = new ColumnMetadata();
+    colTimestampLtzSB8.setOrdinal(1);
     colTimestampLtzSB8.setName("COLTIMESTAMPLTZ_SB8");
     colTimestampLtzSB8.setPhysicalType("SB8");
     colTimestampLtzSB8.setNullable(true);
@@ -789,6 +797,7 @@ public class RowBufferTest {
     colTimestampLtzSB8.setScale(0);
 
     ColumnMetadata colTimestampLtzSB16 = new ColumnMetadata();
+    colTimestampLtzSB16.setOrdinal(2);
     colTimestampLtzSB16.setName("COLTIMESTAMPLTZ_SB16");
     colTimestampLtzSB16.setPhysicalType("SB16");
     colTimestampLtzSB16.setNullable(true);
@@ -796,6 +805,7 @@ public class RowBufferTest {
     colTimestampLtzSB16.setScale(9);
 
     ColumnMetadata colTimestampLtzSB16Scale6 = new ColumnMetadata();
+    colTimestampLtzSB16Scale6.setOrdinal(2);
     colTimestampLtzSB16Scale6.setName("COLTIMESTAMPLTZ_SB16_SCALE6");
     colTimestampLtzSB16Scale6.setPhysicalType("SB16");
     colTimestampLtzSB16Scale6.setNullable(true);
@@ -864,6 +874,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colDate = new ColumnMetadata();
+    colDate.setOrdinal(1);
     colDate.setName("COLDATE");
     colDate.setPhysicalType("SB8");
     colDate.setNullable(true);
@@ -913,6 +924,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colTimeSB4 = new ColumnMetadata();
+    colTimeSB4.setOrdinal(1);
     colTimeSB4.setName("COLTIMESB4");
     colTimeSB4.setPhysicalType("SB4");
     colTimeSB4.setNullable(true);
@@ -920,6 +932,7 @@ public class RowBufferTest {
     colTimeSB4.setScale(0);
 
     ColumnMetadata colTimeSB8 = new ColumnMetadata();
+    colTimeSB8.setOrdinal(2);
     colTimeSB8.setName("COLTIMESB8");
     colTimeSB8.setPhysicalType("SB8");
     colTimeSB8.setNullable(true);
@@ -984,6 +997,7 @@ public class RowBufferTest {
   private void testMaxInsertRowsBatchSizeHelper(OpenChannelRequest.OnErrorOption onErrorOption) {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
     ColumnMetadata colBinary = new ColumnMetadata();
+    colBinary.setOrdinal(1);
     colBinary.setName("COLBINARY");
     colBinary.setPhysicalType("LOB");
     colBinary.setNullable(true);
@@ -1023,6 +1037,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colBoolean = new ColumnMetadata();
+    colBoolean.setOrdinal(1);
     colBoolean.setName("COLBOOLEAN");
     colBoolean.setPhysicalType("SB1");
     colBoolean.setNullable(false);
@@ -1063,6 +1078,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colBoolean = new ColumnMetadata();
+    colBoolean.setOrdinal(1);
     colBoolean.setName("COLBOOLEAN");
     colBoolean.setPhysicalType("SB1");
     colBoolean.setNullable(false);
@@ -1070,6 +1086,7 @@ public class RowBufferTest {
     colBoolean.setScale(0);
 
     ColumnMetadata colBoolean2 = new ColumnMetadata();
+    colBoolean2.setOrdinal(2);
     colBoolean2.setName("COLBOOLEAN2");
     colBoolean2.setPhysicalType("SB1");
     colBoolean2.setNullable(true);
@@ -1107,6 +1124,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(OpenChannelRequest.OnErrorOption.CONTINUE);
 
     ColumnMetadata colBoolean = new ColumnMetadata();
+    colBoolean.setOrdinal(1);
     colBoolean.setName("COLBOOLEAN1");
     colBoolean.setPhysicalType("SB1");
     colBoolean.setNullable(false);
@@ -1139,6 +1157,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colVarchar1 = new ColumnMetadata();
+    colVarchar1.setOrdinal(1);
     colVarchar1.setName("COLVARCHAR1");
     colVarchar1.setPhysicalType("LOB");
     colVarchar1.setNullable(true);
@@ -1146,6 +1165,7 @@ public class RowBufferTest {
     colVarchar1.setLength(1000);
 
     ColumnMetadata colVarchar2 = new ColumnMetadata();
+    colVarchar2.setOrdinal(2);
     colVarchar2.setName("COLVARCHAR2");
     colVarchar2.setPhysicalType("LOB");
     colVarchar2.setNullable(true);
@@ -1153,6 +1173,7 @@ public class RowBufferTest {
     colVarchar2.setLength(1000);
 
     ColumnMetadata colBoolean = new ColumnMetadata();
+    colBoolean.setOrdinal(3);
     colBoolean.setName("COLBOOLEAN1");
     colBoolean.setPhysicalType("SB1");
     colBoolean.setNullable(true);
@@ -1215,6 +1236,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colBoolean = new ColumnMetadata();
+    colBoolean.setOrdinal(1);
     colBoolean.setName("COLBOOLEAN");
     colBoolean.setPhysicalType("SB1");
     colBoolean.setNullable(true);
@@ -1264,6 +1286,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colBinary = new ColumnMetadata();
+    colBinary.setOrdinal(1);
     colBinary.setName("COLBINARY");
     colBinary.setPhysicalType("LOB");
     colBinary.setNullable(true);
@@ -1321,6 +1344,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colReal = new ColumnMetadata();
+    colReal.setOrdinal(1);
     colReal.setName("COLREAL");
     colReal.setPhysicalType("SB16");
     colReal.setNullable(true);
@@ -1363,6 +1387,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(OpenChannelRequest.OnErrorOption.ABORT);
 
     ColumnMetadata colDecimal = new ColumnMetadata();
+    colDecimal.setOrdinal(1);
     colDecimal.setName("COLDECIMAL");
     colDecimal.setPhysicalType("SB16");
     colDecimal.setNullable(true);
@@ -1440,6 +1465,7 @@ public class RowBufferTest {
         createTestBuffer(OpenChannelRequest.OnErrorOption.SKIP_BATCH);
 
     ColumnMetadata colDecimal = new ColumnMetadata();
+    colDecimal.setOrdinal(1);
     colDecimal.setName("COLDECIMAL");
     colDecimal.setPhysicalType("SB16");
     colDecimal.setNullable(true);
@@ -1517,6 +1543,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colVariant = new ColumnMetadata();
+    colVariant.setOrdinal(1);
     colVariant.setName("COLVARIANT");
     colVariant.setPhysicalType("LOB");
     colVariant.setNullable(true);
@@ -1567,6 +1594,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colObject = new ColumnMetadata();
+    colObject.setOrdinal(1);
     colObject.setName("COLOBJECT");
     colObject.setPhysicalType("LOB");
     colObject.setNullable(true);
@@ -1599,6 +1627,7 @@ public class RowBufferTest {
     AbstractRowBuffer<?> innerBuffer = createTestBuffer(onErrorOption);
 
     ColumnMetadata colObject = new ColumnMetadata();
+    colObject.setOrdinal(1);
     colObject.setName("COLARRAY");
     colObject.setPhysicalType("LOB");
     colObject.setNullable(true);
@@ -1647,6 +1676,7 @@ public class RowBufferTest {
         createTestBuffer(OpenChannelRequest.OnErrorOption.SKIP_BATCH);
 
     ColumnMetadata colChar = new ColumnMetadata();
+    colChar.setOrdinal(1);
     colChar.setName("COLCHAR");
     colChar.setPhysicalType("LOB");
     colChar.setNullable(true);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -455,6 +455,7 @@ public class SnowflakeStreamingIngestChannelTest {
             + "  \"offset_token\" : \"\",\n"
             + "  \"encryption_key_id\" : 17229585102,\n"
             + "  \"table_columns\" : [ {\n"
+            + "    \"ordinal\" : 1,\n"
             + "    \"name\" : \"C1\",\n"
             + "    \"type\" : \"NUMBER(38,0)\",\n"
             + "    \"logical_type\" : \"fixed\",\n"
@@ -465,6 +466,7 @@ public class SnowflakeStreamingIngestChannelTest {
             + "    \"length\" : null,\n"
             + "    \"nullable\" : true\n"
             + "  }, {\n"
+            + "    \"ordinal\" : 2,\n"
             + "    \"name\" : \"C2\",\n"
             + "    \"type\" : \"NUMBER(38,0)\",\n"
             + "    \"logical_type\" : \"fixed\",\n"
@@ -551,6 +553,7 @@ public class SnowflakeStreamingIngestChannelTest {
             UTC);
 
     ColumnMetadata col = new ColumnMetadata();
+    col.setOrdinal(1);
     col.setName("COL");
     col.setPhysicalType("SB16");
     col.setNullable(false);
@@ -593,9 +596,10 @@ public class SnowflakeStreamingIngestChannelTest {
     List<ColumnMetadata> schema =
         IntStream.range(0, 64)
             .mapToObj(
-                rowId -> {
+                colId -> {
                   ColumnMetadata col = new ColumnMetadata();
-                  col.setName("COL" + rowId);
+                  col.setOrdinal(colId + 1);
+                  col.setName("COL" + colId);
                   col.setPhysicalType("LOB");
                   col.setNullable(false);
                   col.setLogicalType("BINARY");


### PR DESCRIPTION
This PR sends column ordinals additionally to column names to server side for cross-check of columns in case of table schema changes where columns are recreated with the same name but different data type.