### PR TITLE
SNOW-967235 Sends start and end offsets from the Client SDK

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -470,6 +470,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       float oldBufferSize = 0F;
       long oldRowSequencer = 0;
       String oldOffsetToken = null;
+      String oldStartOffsetToken = null;
       Map<String, RowBufferStats> oldColumnEps = null;
       Pair<Long, Long> oldMinMaxInsertTimeInMs = null;
 
@@ -484,6 +485,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
           oldBufferSize = this.bufferSize;
           oldRowSequencer = this.channelState.incrementAndGetRowSequencer();
           oldOffsetToken = this.channelState.getEndOffsetToken();
+          oldStartOffsetToken = this.channelState.getStartOffsetToken();
           oldColumnEps = new HashMap<>(this.statsMap);
           oldMinMaxInsertTimeInMs =
               new Pair<>(
@@ -508,6 +510,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
         data.setBufferSize(oldBufferSize);
         data.setRowSequencer(oldRowSequencer);
         data.setOffsetToken(oldOffsetToken);
+        data.setStartOffsetToken(oldStartOffsetToken);
         data.setColumnEps(oldColumnEps);
         data.setMinMaxInsertTimeInMs(oldMinMaxInsertTimeInMs);
         data.setFlusherFactory(this::createFlusher);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelData.java
@@ -20,6 +20,7 @@ import net.snowflake.ingest.utils.SFException;
 class ChannelData<T> {
   private Long rowSequencer;
   private String offsetToken;
+  private String startOffsetToken;
   private T vectors;
   private float bufferSize;
   private int rowCount;
@@ -98,8 +99,16 @@ class ChannelData<T> {
     return this.offsetToken;
   }
 
+  String getStartOffsetToken() {
+    return this.startOffsetToken;
+  }
+
   void setOffsetToken(String offsetToken) {
     this.offsetToken = offsetToken;
+  }
+
+  void setStartOffsetToken(String startOffsetToken) {
+    this.startOffsetToken = startOffsetToken;
   }
 
   T getVectors() {
@@ -157,6 +166,8 @@ class ChannelData<T> {
         + rowSequencer
         + ", offsetToken='"
         + offsetToken
+        + ", startOffsetToken='"
+        + startOffsetToken
         + '\''
         + ", bufferSize="
         + bufferSize

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelMetadata.java
@@ -17,6 +17,7 @@ class ChannelMetadata {
   private final Long clientSequencer;
   private final Long rowSequencer;
   @Nullable private final String offsetToken;
+  @Nullable private final String startOffsetToken;
 
   static Builder builder() {
     return new Builder();
@@ -28,6 +29,7 @@ class ChannelMetadata {
     private Long clientSequencer;
     private Long rowSequencer;
     @Nullable private String offsetToken; // offset token could be null
+    @Nullable private String startOffsetToken; // start offset token could be null
 
     Builder setOwningChannelFromContext(ChannelFlushContext channelFlushContext) {
       this.channelName = channelFlushContext.getName();
@@ -45,6 +47,12 @@ class ChannelMetadata {
       return this;
     }
 
+
+    Builder setStartOffsetToken(String startOffsetToken) {
+      this.startOffsetToken = startOffsetToken;
+      return this;
+    }
+
     ChannelMetadata build() {
       return new ChannelMetadata(this);
     }
@@ -59,6 +67,7 @@ class ChannelMetadata {
     this.clientSequencer = builder.clientSequencer;
     this.rowSequencer = builder.rowSequencer;
     this.offsetToken = builder.offsetToken;
+    this.startOffsetToken = builder.startOffsetToken;
   }
 
   @JsonProperty("channel_name")
@@ -79,6 +88,18 @@ class ChannelMetadata {
   @Nullable
   @JsonProperty("offset_token")
   String getOffsetToken() {
+    return this.offsetToken;
+  }
+
+  @Nullable
+  @JsonProperty("start_offset_token")
+  String getStartOffsetToken() {
+    return this.startOffsetToken;
+  }
+
+  @Nullable
+  @JsonProperty("end_offset_token")
+  String getEndOffsetToken() {
     return this.offsetToken;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -74,6 +74,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
               .setOwningChannelFromContext(data.getChannelContext())
               .setRowSequencer(data.getRowSequencer())
               .setOffsetToken(data.getOffsetToken())
+              .setStartOffsetToken(data.getStartOffsetToken())
               .build();
       // Add channel metadata to the metadata list
       channelsMetadataList.add(channelMetadata);
@@ -153,6 +154,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
               .setOwningChannelFromContext(data.getChannelContext())
               .setRowSequencer(data.getRowSequencer())
               .setOffsetToken(data.getOffsetToken())
+              .setStartOffsetToken(data.getStartOffsetToken())
               .build();
       // Add channel metadata to the metadata list
       channelsMetadataList.add(channelMetadata);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -495,6 +495,7 @@ public class RowBufferTest {
     Assert.assertEquals(2, data.getRowCount());
     Assert.assertEquals((Long) 1L, data.getRowSequencer());
     Assert.assertEquals(offsetToken, data.getOffsetToken());
+    Assert.assertEquals(offsetToken, data.getStartOffsetToken());
     Assert.assertEquals(bufferSize, data.getBufferSize(), 0);
 
     final ParquetChunkData chunkData = (ParquetChunkData) data.getVectors();

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -586,6 +586,7 @@ public class SnowflakeStreamingIngestChannelTest {
     Assert.assertEquals((Long) 1L, data.getRowSequencer());
     Assert.assertEquals(1, ((ChannelData<ParquetChunkData>) data).getVectors().rows.get(0).size());
     Assert.assertEquals("3", data.getOffsetToken());
+    Assert.assertEquals("1", data.getStartOffsetToken());
     Assert.assertTrue(data.getBufferSize() > 0);
     Assert.assertTrue(insertStartTimeInMs <= data.getMinMaxInsertTimeInMs().getFirst());
     Assert.assertTrue(insertEndTimeInMs >= data.getMinMaxInsertTimeInMs().getSecond());


### PR DESCRIPTION
This sends the start and end offset tokens for a channel when sending a blob to Snowflake. Right now only the end offset is sent which makes reasoning about ranges difficult.

@test verified via existing tests in `RowBufferTest` and `SnowflakeStreamingIngestChannelTest`