### PR TITLE
SNOW-1230527 Disable linkage checker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -561,7 +561,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.4.1</version>
           <dependencies>
             <dependency>
               <groupId>com.google.cloud.tools</groupId>
@@ -846,7 +846,9 @@
                 <goals>
                   <goal>enforce</goal>
                 </goals>
-                <phase>verify</phase>
+                <!-- Disabled in SNOW-1230527 -->
+                <phase>none</phase>
+                <!-- <phase>verify</phase> -->
                 <configuration>
                   <rules>
                     <LinkageCheckerRule implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">


### PR DESCRIPTION
The linkage checker is failing with Maven 3.9.5.