### PR TITLE
SNOW-1196967 SNOW-1196966 Update vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
   <!-- Set our Language Level to Java 8 -->
   <properties>
-    <bouncycastle.version>1.74</bouncycastle.version>
+    <bouncycastle.version>1.77</bouncycastle.version>
     <codehaus.version>1.9.13</codehaus.version>
     <commonscodec.version>1.15</commonscodec.version>
     <commonscollections.version>3.2.2</commonscollections.version>
@@ -442,6 +442,10 @@
       <artifactId>snowflake-jdbc</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>
@@ -695,6 +699,12 @@
             <configuration>
               <failOnWarning>true</failOnWarning>
               <ignoreNonCompile>true</ignoreNonCompile>
+              <ignoredDependencies>
+                <!-- We defined common-compress as a direct dependency (as opposed to just declaring it in dependencyManagement)
+                to workaround https://issues.apache.org/jira/browse/MNG-7982. Now the dependency analyzer complains that
+                the dependency is unused, so we ignore it here-->
+                <ignoredDependency>org.apache.commons:commons-compress</ignoredDependency>
+              </ignoredDependencies>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This PR updates dependencies identified by Snyk as vulnerable.

- `common-compress` - The SDK already using the fixed version, but due to Maven bug [MNG-7982](https://issues.apache.org/jira/browse/MNG-7982), the version is not propagated to the e2e test project. This PR declares `common-compress` as a direct dependency to work around the issue.
- `bouncycastle` - the [Snyk-identified vulnerability](https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6277381) doesn't seem to resolved even in the latest BC version, so we just upgrade BC to the latest version, and we will see if the warning disappears.

---

- Fixes #706
- Fixes #707
- Fixes #708
- Fixes #709
- Fixes #710 
- Fixes #711