### PR TITLE
SNOW-1000828 Expose specific error messages as part of the channel invalidation exception

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
@@ -37,9 +37,9 @@ class ChannelCache<T> {
         channels.put(channel.getName(), channel);
     // Invalidate old channel if it exits to block new inserts and return error to users earlier
     if (oldChannel != null) {
-      String errorMessage =
+      String invalidationCause =
           String.format("Old channel removed from cache, channelName=%s", channel.getName());
-      oldChannel.invalidate("removed from cache", errorMessage);
+      oldChannel.invalidate("removed from cache", invalidationCause);
     }
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
@@ -37,7 +37,9 @@ class ChannelCache<T> {
         channels.put(channel.getName(), channel);
     // Invalidate old channel if it exits to block new inserts and return error to users earlier
     if (oldChannel != null) {
-      oldChannel.invalidate("removed from cache");
+      String errorMessage =
+          String.format("Old channel removed from cache, channelName=%s", channel.getName());
+      oldChannel.invalidate("removed from cache", errorMessage);
     }
   }
 
@@ -82,14 +84,15 @@ class ChannelCache<T> {
       String schemaName,
       String tableName,
       String channelName,
-      Long channelSequencer) {
+      Long channelSequencer,
+      String invalidateCause) {
     String fullyQualifiedTableName = String.format("%s.%s.%s", dbName, schemaName, tableName);
     ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<T>> channelsMapPerTable =
         cache.get(fullyQualifiedTableName);
     if (channelsMapPerTable != null) {
       SnowflakeStreamingIngestChannelInternal<T> channel = channelsMapPerTable.get(channelName);
       if (channel != null && channel.getChannelSequencer().equals(channelSequencer)) {
-        channel.invalidate("invalidate with matched sequencer");
+        channel.invalidate("invalidate with matched sequencer", invalidateCause);
       }
     }
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
@@ -85,14 +85,14 @@ class ChannelCache<T> {
       String tableName,
       String channelName,
       Long channelSequencer,
-      String invalidateCause) {
+      String invalidationCause) {
     String fullyQualifiedTableName = String.format("%s.%s.%s", dbName, schemaName, tableName);
     ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<T>> channelsMapPerTable =
         cache.get(fullyQualifiedTableName);
     if (channelsMapPerTable != null) {
       SnowflakeStreamingIngestChannelInternal<T> channel = channelsMapPerTable.get(channelName);
       if (channel != null && channel.getChannelSequencer().equals(channelSequencer)) {
-        channel.invalidate("invalidate with matched sequencer", invalidateCause);
+        channel.invalidate("invalidate with matched sequencer", invalidationCause);
       }
     }
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -464,7 +464,7 @@ class FlushService<T> {
                         }
 
                         if (e instanceof IOException) {
-                          invalidateAllChannelsInBlob(blobData);
+                          invalidateAllChannelsInBlob(blobData, errorMessage);
                           return null;
                         } else if (e instanceof NoSuchAlgorithmException) {
                           throw new SFException(e, ErrorCode.MD5_HASHING_NOT_AVAILABLE);
@@ -657,7 +657,7 @@ class FlushService<T> {
    *
    * @param blobData list of channels that belongs to the blob
    */
-  <CD> void invalidateAllChannelsInBlob(List<List<ChannelData<CD>>> blobData) {
+  <CD> void invalidateAllChannelsInBlob(List<List<ChannelData<CD>>> blobData, String errorMessage) {
     blobData.forEach(
         chunkData ->
             chunkData.forEach(
@@ -669,7 +669,8 @@ class FlushService<T> {
                           channelData.getChannelContext().getSchemaName(),
                           channelData.getChannelContext().getTableName(),
                           channelData.getChannelContext().getName(),
-                          channelData.getChannelContext().getChannelSequencer());
+                          channelData.getChannelContext().getChannelSequencer(),
+                          errorMessage);
                 }));
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -657,7 +657,8 @@ class FlushService<T> {
    *
    * @param blobData list of channels that belongs to the blob
    */
-  <CD> void invalidateAllChannelsInBlob(List<List<ChannelData<CD>>> blobData, String errorMessage) {
+  <CD> void invalidateAllChannelsInBlob(
+      List<List<ChannelData<CD>>> blobData, String invalidationCause) {
     blobData.forEach(
         chunkData ->
             chunkData.forEach(
@@ -670,7 +671,7 @@ class FlushService<T> {
                           channelData.getChannelContext().getTableName(),
                           channelData.getChannelContext().getName(),
                           channelData.getChannelContext().getChannelSequencer(),
-                          errorMessage);
+                          invalidationCause);
                 }));
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
@@ -175,7 +175,7 @@ class RegisterService<T> {
               }
               this.owningClient
                   .getFlushService()
-                  .invalidateAllChannelsInBlob(futureBlob.getKey().getData());
+                  .invalidateAllChannelsInBlob(futureBlob.getKey().getData(), errorMessage);
               errorBlobs.add(futureBlob.getKey());
               retry = 0;
               idx++;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -59,7 +59,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   private final Map<String, ColumnProperties> tableColumns;
 
   // The cause of channel invalidation
-  private String invalidateCause;
+  private String invalidationCause;
 
   /**
    * Constructor for TESTING ONLY which allows us to set the test mode
@@ -220,9 +220,9 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   }
 
   /** Mark the channel as invalid, and release resources */
-  void invalidate(String message, String invalidateCause) {
+  void invalidate(String message, String invalidationCause) {
     this.channelState.invalidate();
-    this.invalidateCause = invalidateCause;
+    this.invalidationCause = invalidationCause;
     this.rowBuffer.close("invalidate");
     logger.logWarn(
         "Channel is invalidated, name={}, channel sequencer={}, row sequencer={}, message={}",
@@ -505,7 +505,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
       this.owningClient.removeChannelIfSequencersMatch(this);
       this.rowBuffer.close("checkValidation");
       throw new SFException(
-          ErrorCode.INVALID_CHANNEL, getFullyQualifiedName(), this.invalidateCause);
+          ErrorCode.INVALID_CHANNEL, getFullyQualifiedName(), this.invalidationCause);
     }
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -58,7 +58,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   // Internal map of column name -> column properties
   private final Map<String, ColumnProperties> tableColumns;
 
-  // The cause of channel invalidation
+  // The latest cause of channel invalidation
   private String invalidationCause;
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -58,6 +58,9 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   // Internal map of column name -> column properties
   private final Map<String, ColumnProperties> tableColumns;
 
+  // The cause of channel invalidation
+  private String invalidateCause;
+
   /**
    * Constructor for TESTING ONLY which allows us to set the test mode
    *
@@ -217,8 +220,9 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   }
 
   /** Mark the channel as invalid, and release resources */
-  void invalidate(String message) {
+  void invalidate(String message, String invalidateCause) {
     this.channelState.invalidate();
+    this.invalidateCause = invalidateCause;
     this.rowBuffer.close("invalidate");
     logger.logWarn(
         "Channel is invalidated, name={}, channel sequencer={}, row sequencer={}, message={}",
@@ -500,7 +504,8 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
     if (!isValid()) {
       this.owningClient.removeChannelIfSequencersMatch(this);
       this.rowBuffer.close("checkValidation");
-      throw new SFException(ErrorCode.INVALID_CHANNEL, getFullyQualifiedName());
+      throw new SFException(
+          ErrorCode.INVALID_CHANNEL, getFullyQualifiedName(), this.invalidateCause);
     }
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -650,7 +650,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
                                               String.format(
                                                   "Channel has been invalidated because of failure"
                                                       + " response, name=%s, channel_sequencer=%d,"
-                                                      + " status_code=%d,  message=%s,"
+                                                      + " status_code=%d, message=%s,"
                                                       + " executionCount=%d",
                                                   channelStatus.getChannelName(),
                                                   channelStatus.getChannelSequencer(),
@@ -668,7 +668,8 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
                                               chunkStatus.getSchemaName(),
                                               chunkStatus.getTableName(),
                                               channelStatus.getChannelName(),
-                                              channelStatus.getChannelSequencer());
+                                              channelStatus.getChannelSequencer(),
+                                              errorMessage);
                                         }
                                       }
                                     })));

--- a/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
+++ b/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
@@ -15,7 +15,7 @@
 0010=Missing {0} in config file.
 0011=Failed to upload blob.
 0012=Failed to cleanup resources during {0}.
-0013=Channel {0} is invalid and might contain uncommitted rows, please consider reopening the channel to restart.
+0013=Channel {0} is invalid and might contain uncommitted rows, please consider reopening the channel to restart. Channel invalidated cause: "{1}".
 0014=Channel {0} is closed, please reopen the channel to restart.
 0015=Invalid Snowflake URL, URL format: 'https://<account_name>.<region_name>.snowflakecomputing.com:443', 'https://' and ':443' are optional.
 0016=Client is closed, please recreate to restart.

--- a/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
+++ b/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
@@ -15,7 +15,7 @@
 0010=Missing {0} in config file.
 0011=Failed to upload blob.
 0012=Failed to cleanup resources during {0}.
-0013=Channel {0} is invalid and might contain uncommitted rows, please consider reopening the channel to restart. Channel invalidated cause: "{1}".
+0013=Channel {0} is invalid and might contain uncommitted rows, please consider reopening the channel to restart. Channel invalidation cause: "{1}".
 0014=Channel {0} is closed, please reopen the channel to restart.
 0015=Invalid Snowflake URL, URL format: 'https://<account_name>.<region_name>.snowflakecomputing.com:443', 'https://' and ':443' are optional.
 0016=Client is closed, please recreate to restart.

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
@@ -213,7 +213,8 @@ public class ChannelCacheTest {
         channel1.getSchemaName(),
         channel1.getTableName(),
         channel1.getName(),
-        channel1.getChannelSequencer());
+        channel1.getChannelSequencer(),
+        "Invalidated by test");
     Assert.assertFalse(channel1.isValid());
 
     cache.invalidateChannelIfSequencersMatch(
@@ -221,7 +222,8 @@ public class ChannelCacheTest {
         channel2.getSchemaName(),
         channel2.getTableName(),
         channel2.getName(),
-        channel2.getChannelSequencer());
+        channel2.getChannelSequencer(),
+        "Invalidated by test");
     Assert.assertFalse(channel2.isValid());
 
     cache.invalidateChannelIfSequencersMatch(
@@ -229,7 +231,8 @@ public class ChannelCacheTest {
         channel3.getSchemaName(),
         channel3.getTableName(),
         channel3.getName(),
-        channel3.getChannelSequencer());
+        channel3.getChannelSequencer(),
+        "Invalidated by test");
     Assert.assertFalse(channel3.isValid());
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -916,7 +916,7 @@ public class FlushServiceTest {
     Mockito.when(stage.getClientPrefix()).thenReturn("client_prefix");
     FlushService<StubChunkData> flushService =
         new FlushService<>(client, channelCache, stage, false);
-    flushService.invalidateAllChannelsInBlob(blobData);
+    flushService.invalidateAllChannelsInBlob(blobData, "Invalidated by test");
 
     Assert.assertFalse(channel1.isValid());
     Assert.assertTrue(channel2.isValid());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -175,7 +175,7 @@ public class SnowflakeStreamingIngestChannelTest {
             UTC);
 
     Assert.assertTrue(channel.isValid());
-    channel.invalidate("from testChannelValid");
+    channel.invalidate("from testChannelValid", "Invalidated by test");
     Assert.assertFalse(channel.isValid());
 
     // Can't insert rows to invalid channel
@@ -881,7 +881,7 @@ public class SnowflakeStreamingIngestChannelTest {
     Mockito.doReturn(response).when(client).getChannelsStatus(Mockito.any());
 
     Assert.assertFalse(channel.isClosed());
-    channel.invalidate("test");
+    channel.invalidate("test", "Invalidated by test");
     Mockito.doNothing().when(client).dropChannel(Mockito.any());
     Assert.assertThrows(SFException.class, () -> channel.close(true).get());
     Mockito.verify(client, Mockito.never()).dropChannel(Mockito.any());


### PR DESCRIPTION
When a channel is invalidated, the original SDK does not throw a visible enough error. This PR makes SDK show more specific details for user when `INVALID_CHANNEL` is thrown.

[JIRA](https://snowflakecomputing.atlassian.net/browse/SNOW-1000828)