### PR TITLE
SNOW-1258064 Remove/Relax the limitations in order to generate bigger files

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -202,7 +202,6 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
         tempRowsSizeInBytes +=
             addTempRow(row, tempRowCount, rowBuffer.tempStatsMap, inputColumnNames, tempRowCount);
         tempRowCount++;
-        checkBatchSizeEnforcedMaximum(tempRowsSizeInBytes);
         if ((long) rowBuffer.bufferedRowCount + tempRowCount >= Integer.MAX_VALUE) {
           throw new SFException(ErrorCode.INTERNAL_ERROR, "Row count reaches MAX value");
         }
@@ -261,7 +260,6 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
           response.addError(error);
         }
         rowIndex++;
-        checkBatchSizeEnforcedMaximum(tempRowsSizeInBytes);
         if ((long) rowBuffer.bufferedRowCount + rowIndex >= Integer.MAX_VALUE) {
           throw new SFException(ErrorCode.INTERNAL_ERROR, "Row count reaches MAX value");
         }
@@ -670,15 +668,6 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       default:
         throw new SFException(
             ErrorCode.INTERNAL_ERROR, "Unsupported BDEC format version: " + bdecVersion);
-    }
-  }
-
-  private void checkBatchSizeEnforcedMaximum(float batchSizeInBytes) {
-    if (batchSizeInBytes > clientBufferParameters.getMaxChunkSizeInBytes()) {
-      throw new SFException(
-          ErrorCode.MAX_BATCH_SIZE_EXCEEDED,
-          clientBufferParameters.getMaxChunkSizeInBytes(),
-          INSERT_ROWS_RECOMMENDED_MAX_BATCH_SIZE_IN_BYTES);
     }
   }
 

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -42,7 +42,7 @@ public class Constants {
       7L; // Don't change, should match server side
   public static final int BLOB_UPLOAD_TIMEOUT_IN_SEC = 5;
   public static final int INSERT_THROTTLE_MAX_RETRY_COUNT = 60;
-  public static final long MAX_BLOB_SIZE_IN_BYTES = 256000000L;
+  public static final long MAX_BLOB_SIZE_IN_BYTES = 512000000L;
   public static final int BLOB_TAG_SIZE_IN_BYTES = 4;
   public static final int BLOB_VERSION_SIZE_IN_BYTES = 1;
   public static final int BLOB_FILE_SIZE_SIZE_IN_BYTES = 8;

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -50,16 +50,16 @@ public class ParameterProvider {
   public static final int IO_TIME_CPU_RATIO_DEFAULT = 2;
   public static final int BLOB_UPLOAD_MAX_RETRY_COUNT_DEFAULT = 24;
   public static final long MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT = -1L;
-  public static final long MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT = 32000000L;
-  public static final long MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 128000000L;
+  public static final long MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT = 64000000L;
+  public static final long MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 256000000L;
 
   // Lag related parameters
   public static final long MAX_CLIENT_LAG_DEFAULT = 1000; // 1 second
   static final long MAX_CLIENT_LAG_MS_MIN = TimeUnit.SECONDS.toMillis(1);
   static final long MAX_CLIENT_LAG_MS_MAX = TimeUnit.MINUTES.toMillis(10);
 
-  public static final long MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT = 64 * 1024 * 1024; // 64 MB
-  public static final int MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_DEFAULT = 100;
+  public static final long MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT = 128 * 1024 * 1024; // 128 MB
+  public static final int MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_DEFAULT = 200;
 
   public static final Constants.BdecParquetCompression BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT =
       Constants.BdecParquetCompression.GZIP;


### PR DESCRIPTION
Relax file size limitation to deal with longer client flush lag which might produce larger file.

[JIRA](snowflakecomputing.atlassian.net/browse/SNOW-1258064)