### PR TITLE
Reduce OAuth test time

### DIFF
--- a/src/main/java/net/snowflake/ingest/connection/OAuthClient.java
+++ b/src/main/java/net/snowflake/ingest/connection/OAuthClient.java
@@ -71,28 +71,24 @@ public class OAuthClient {
   }
 
   /** Refresh access token using a valid refresh token */
-  public void refreshToken() {
-    String respBodyString = null;
-    try (CloseableHttpResponse httpResponse = httpClient.execute(makeRefreshTokenRequest())) {
-      respBodyString = EntityUtils.toString(httpResponse.getEntity());
+  public void refreshToken() throws IOException {
+    CloseableHttpResponse httpResponse = httpClient.execute(makeRefreshTokenRequest());
+    String respBodyString = EntityUtils.toString(httpResponse.getEntity());
 
-      if (httpResponse.getStatusLine().getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
-        JsonObject respBody = JsonParser.parseString(respBodyString).getAsJsonObject();
+    if (httpResponse.getStatusLine().getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
+      JsonObject respBody = JsonParser.parseString(respBodyString).getAsJsonObject();
 
-        if (respBody.has(ACCESS_TOKEN) && respBody.has(EXPIRES_IN)) {
-          // Trim surrounding quotation marks
-          String newAccessToken = respBody.get(ACCESS_TOKEN).toString().replaceAll("^\"|\"$", "");
-          oAuthCredential.get().setAccessToken(newAccessToken);
-          oAuthCredential.get().setExpiresIn(respBody.get(EXPIRES_IN).getAsInt());
-          return;
-        }
+      if (respBody.has(ACCESS_TOKEN) && respBody.has(EXPIRES_IN)) {
+        // Trim surrounding quotation marks
+        String newAccessToken = respBody.get(ACCESS_TOKEN).toString().replaceAll("^\"|\"$", "");
+        oAuthCredential.get().setAccessToken(newAccessToken);
+        oAuthCredential.get().setExpiresIn(respBody.get(EXPIRES_IN).getAsInt());
+        return;
       }
-      throw new SFException(
-          ErrorCode.OAUTH_REFRESH_TOKEN_ERROR,
-          "Refresh access token fail with response: " + respBodyString);
-    } catch (IOException e) {
-      throw new SFException(ErrorCode.OAUTH_REFRESH_TOKEN_ERROR, e.getMessage());
     }
+    throw new SFException(
+        ErrorCode.OAUTH_REFRESH_TOKEN_ERROR,
+        "Refresh access token fail with response: " + respBodyString);
   }
 
   /** Helper method for making refresh request */

--- a/src/main/java/net/snowflake/ingest/connection/OAuthManager.java
+++ b/src/main/java/net/snowflake/ingest/connection/OAuthManager.java
@@ -4,6 +4,7 @@
 
 package net.snowflake.ingest.connection;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import net.snowflake.client.jdbc.internal.apache.http.client.utils.URIBuilder;
 import net.snowflake.ingest.utils.Constants;
@@ -154,6 +155,9 @@ public final class OAuthManager extends SecurityManager {
             "Refresh access token, next refresh is scheduled after {} seconds", nextRefreshDelay);
 
         return;
+      } catch (IOException e) {
+        // Http client already retried on IO exception, skip retires
+        break;
       } catch (SFException e1) {
         // Exponential backoff retries
         try {


### PR DESCRIPTION
`testCreateOAuthClient` is taking too much time due to the unnecessary retries in `OAuthManager`. Remove retries logic when receiving IOException in `OAuthManager`. As `httpClient` already retried when getting response code which is not 2xx.