### PR TITLE
SNOW-1357377 Add request Id in all streaming ingest APIs

### DIFF
--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -678,18 +678,23 @@ public class RequestBuilder {
    */
   public HttpPost generateStreamingIngestPostRequest(
       String payload, String endPoint, String message) {
-    LOGGER.debug("Generate Snowpipe streaming request: endpoint={}, payload={}", endPoint, payload);
+    final String requestId = UUID.randomUUID().toString();
+    LOGGER.debug(
+        "Generate Snowpipe streaming request: endpoint={}, payload={}, requestId={}",
+        endPoint,
+        payload,
+        requestId);
     // Make the corresponding URI
     URI uri = null;
     try {
       uri =
           new URIBuilder()
-                  .setScheme(scheme)
-                  .setHost(host)
-                  .setPort(port)
-                  .setPath(endPoint)
-                  .setParameter(REQUEST_ID, UUID.randomUUID().toString())
-                  .build();
+              .setScheme(scheme)
+              .setHost(host)
+              .setPort(port)
+              .setPath(endPoint)
+              .setParameter(REQUEST_ID, requestId)
+              .build();
     } catch (URISyntaxException e) {
       throw new SFException(e, ErrorCode.BUILD_REQUEST_FAILURE, message);
     }

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -683,7 +683,13 @@ public class RequestBuilder {
     URI uri = null;
     try {
       uri =
-          new URIBuilder().setScheme(scheme).setHost(host).setPort(port).setPath(endPoint).build();
+          new URIBuilder()
+                  .setScheme(scheme)
+                  .setHost(host)
+                  .setPort(port)
+                  .setPath(endPoint)
+                  .setParameter(REQUEST_ID, UUID.randomUUID().toString())
+                  .build();
     } catch (URISyntaxException e) {
       throw new SFException(e, ErrorCode.BUILD_REQUEST_FAILURE, message);
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelsStatusRequest.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelsStatusRequest.java
@@ -61,19 +61,11 @@ class ChannelsStatusRequest {
     }
   }
 
-  // Optional Request ID. Used for diagnostic purposes.
-  private String requestId;
-
   // Channels in request
   private List<ChannelStatusRequestDTO> channels;
 
   // Snowflake role used by client
   private String role;
-
-  @JsonProperty("request_id")
-  String getRequestId() {
-    return requestId;
-  }
 
   @JsonProperty("role")
   public String getRole() {
@@ -83,11 +75,6 @@ class ChannelsStatusRequest {
   @JsonProperty("role")
   public void setRole(String role) {
     this.role = role;
-  }
-
-  @JsonProperty("request_id")
-  void setRequestId(String requestId) {
-    this.requestId = requestId;
   }
 
   @JsonProperty("channels")

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -493,7 +493,6 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
               .collect(Collectors.toList());
       request.setChannels(requestDTOs);
       request.setRole(this.role);
-      request.setRequestId(this.flushService.getClientPrefix() + "_" + counter.getAndIncrement());
 
       String payload = objectMapper.writeValueAsString(request);
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -309,13 +309,13 @@ public class SnowflakeStreamingIngestChannelTest {
             payload, OPEN_CHANNEL_ENDPOINT, "open channel");
 
     String expectedUrlPattern =
-            String.format("%s%s", urlStr, OPEN_CHANNEL_ENDPOINT) + "(\\?requestId=[a-f0-9\\-]{36})?";
+        String.format("%s%s", urlStr, OPEN_CHANNEL_ENDPOINT) + "(\\?requestId=[a-f0-9\\-]{36})?";
 
     Assert.assertTrue(
-            String.format(
-                    "Expected URL to match pattern: %s but was: %s",
-                    expectedUrlPattern, request.getRequestLine().getUri()),
-            request.getRequestLine().getUri().matches(expectedUrlPattern));
+        String.format(
+            "Expected URL to match pattern: %s but was: %s",
+            expectedUrlPattern, request.getRequestLine().getUri()),
+        request.getRequestLine().getUri().matches(expectedUrlPattern));
     Assert.assertNotNull(request.getFirstHeader(HttpHeaders.USER_AGENT));
     Assert.assertNotNull(request.getFirstHeader(HttpHeaders.AUTHORIZATION));
     Assert.assertEquals("POST", request.getMethod());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -1,7 +1,12 @@
 package net.snowflake.ingest.streaming.internal;
 
 import static java.time.ZoneOffset.UTC;
-import static net.snowflake.ingest.utils.Constants.*;
+import static net.snowflake.ingest.utils.Constants.ACCOUNT_URL;
+import static net.snowflake.ingest.utils.Constants.OPEN_CHANNEL_ENDPOINT;
+import static net.snowflake.ingest.utils.Constants.PRIVATE_KEY;
+import static net.snowflake.ingest.utils.Constants.RESPONSE_SUCCESS;
+import static net.snowflake.ingest.utils.Constants.ROLE;
+import static net.snowflake.ingest.utils.Constants.USER;
 import static org.mockito.ArgumentMatchers.argThat;
 
 import java.security.KeyPair;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -1,12 +1,7 @@
 package net.snowflake.ingest.streaming.internal;
 
 import static java.time.ZoneOffset.UTC;
-import static net.snowflake.ingest.utils.Constants.ACCOUNT_URL;
-import static net.snowflake.ingest.utils.Constants.OPEN_CHANNEL_ENDPOINT;
-import static net.snowflake.ingest.utils.Constants.PRIVATE_KEY;
-import static net.snowflake.ingest.utils.Constants.RESPONSE_SUCCESS;
-import static net.snowflake.ingest.utils.Constants.ROLE;
-import static net.snowflake.ingest.utils.Constants.USER;
+import static net.snowflake.ingest.utils.Constants.*;
 import static org.mockito.ArgumentMatchers.argThat;
 
 import java.security.KeyPair;
@@ -313,8 +308,14 @@ public class SnowflakeStreamingIngestChannelTest {
         requestBuilder.generateStreamingIngestPostRequest(
             payload, OPEN_CHANNEL_ENDPOINT, "open channel");
 
-    Assert.assertEquals(
-        String.format("%s%s", urlStr, OPEN_CHANNEL_ENDPOINT), request.getRequestLine().getUri());
+    String expectedUrlPattern =
+            String.format("%s%s", urlStr, OPEN_CHANNEL_ENDPOINT) + "(\\?requestId=[a-f0-9\\-]{36})?";
+
+    Assert.assertTrue(
+            String.format(
+                    "Expected URL to match pattern: %s but was: %s",
+                    expectedUrlPattern, request.getRequestLine().getUri()),
+            request.getRequestLine().getUri().matches(expectedUrlPattern));
     Assert.assertNotNull(request.getFirstHeader(HttpHeaders.USER_AGENT));
     Assert.assertNotNull(request.getFirstHeader(HttpHeaders.AUTHORIZATION));
     Assert.assertEquals("POST", request.getMethod());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -368,7 +368,6 @@ public class SnowflakeStreamingIngestClientTest {
     ChannelsStatusRequest.ChannelStatusRequestDTO dto =
         new ChannelsStatusRequest.ChannelStatusRequestDTO(channel);
     ChannelsStatusRequest request = new ChannelsStatusRequest();
-    request.setRequestId("null_0");
     request.setChannels(Collections.singletonList(dto));
     ChannelsStatusResponse result = client.getChannelsStatus(Collections.singletonList(channel));
     Assert.assertEquals(response.getMessage(), result.getMessage());
@@ -547,9 +546,15 @@ public class SnowflakeStreamingIngestClientTest {
     HttpPost request =
         requestBuilder.generateStreamingIngestPostRequest(
             payload, REGISTER_BLOB_ENDPOINT, "register blob");
+    String expectedUrlPattern =
+        String.format("%s%s", urlStr, REGISTER_BLOB_ENDPOINT) + "(\\?requestId=[a-f0-9\\-]{36})?";
 
-    Assert.assertEquals(
-        String.format("%s%s", urlStr, REGISTER_BLOB_ENDPOINT), request.getRequestLine().getUri());
+    Assert.assertTrue(
+        String.format(
+            "Expected URL to match pattern: %s but was: %s",
+            expectedUrlPattern, request.getRequestLine().getUri()),
+        request.getRequestLine().getUri().matches(expectedUrlPattern));
+
     Assert.assertNotNull(request.getFirstHeader(HttpHeaders.USER_AGENT));
     Assert.assertNotNull(request.getFirstHeader(HttpHeaders.AUTHORIZATION));
     Assert.assertEquals("POST", request.getMethod());
@@ -1432,7 +1437,6 @@ public class SnowflakeStreamingIngestClientTest {
     ChannelsStatusRequest.ChannelStatusRequestDTO dto =
         new ChannelsStatusRequest.ChannelStatusRequestDTO(channel);
     ChannelsStatusRequest request = new ChannelsStatusRequest();
-    request.setRequestId("null_0");
     request.setChannels(Collections.singletonList(dto));
     Map<String, String> result =
         client.getLatestCommittedOffsetTokens(Collections.singletonList(channel));


### PR DESCRIPTION
- Add requestId as a Query Parameter. 
- Remove requestId from payload since it is not used anywhere on server side. 

Along with this, our response should also include requestId but that can come later since they can still rely on offsetToken API. (Wont work for other APIs but there hasn't been any request)

This is for internal logging purposes. 