### PR TITLE
Add error log for flush task scheduling

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -305,7 +305,8 @@ class FlushService<T> {
           } catch (Exception e) {
             String errorMessage =
                 String.format(
-                    "Failed to schedule a flush task, client=%s, exception=%s, detail=%s, trace=%s.",
+                    "Failed to schedule a flush task, client=%s, exception=%s, detail=%s,"
+                        + " trace=%s.",
                     this.owningClient.getName(),
                     e.getClass().getName(),
                     e.getMessage(),

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -312,6 +312,11 @@ class FlushService<T> {
                     e.getMessage(),
                     getStackTrace(e));
             logger.logError(errorMessage);
+            if (this.owningClient.getTelemetryService() != null) {
+              this.owningClient
+                  .getTelemetryService()
+                  .reportClientFailure(this.getClass().getSimpleName(), errorMessage);
+            }
           }
         },
         0,

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -317,6 +317,7 @@ class FlushService<T> {
                   .getTelemetryService()
                   .reportClientFailure(this.getClass().getSimpleName(), errorMessage);
             }
+            throw e;
           }
         },
         0,


### PR DESCRIPTION
Add error log for flush task scheduling. This could happen when [getCachedMaxClientLagInMs](https://github.com/snowflakedb/snowflake-ingest-java/blob/eb87281a6a1f5ee3e2e959594bb571b40b770b90/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java#L268C65-L268C92) throw cast exception when provided parameter is `int` not `long`.