### PR TITLE
SNOW-1262359 Upgrade commons-configuration2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,11 @@
     <commonscodec.version>1.15</commonscodec.version>
     <commonscollections.version>3.2.2</commonscollections.version>
     <commonscompress.version>1.26.0</commonscompress.version>
+    <commonsconfiguration2.version>2.10.1</commonsconfiguration2.version>
     <commonsio.version>2.15.1</commonsio.version>
     <commonslang3.version>3.14.0</commonslang3.version>
-    <commonslogging.version>1.2</commonslogging.version>
-    <commonstext.version>1.10.0</commonstext.version>
+    <commonslogging.version>1.3.1</commonslogging.version>
+    <commonstext.version>1.11.0</commonstext.version>
     <fasterxml.version>2.16.1</fasterxml.version>
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.3.6</hadoop.version>
@@ -138,6 +139,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
         <version>${commonscompress.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-configuration2</artifactId>
+        <version>${commonsconfiguration2.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -446,6 +452,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>
+
+    <!-- Transitive dependency; declared here to use a specific version -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
@@ -710,10 +722,11 @@
               <failOnWarning>true</failOnWarning>
               <ignoreNonCompile>true</ignoreNonCompile>
               <ignoredDependencies>
-                <!-- We defined common-compress as a direct dependency (as opposed to just declaring it in dependencyManagement)
+                <!-- We defined these as direct dependencies (as opposed to just declaring it in dependencyManagement)
                 to workaround https://issues.apache.org/jira/browse/MNG-7982. Now the dependency analyzer complains that
                 the dependency is unused, so we ignore it here-->
                 <ignoredDependency>org.apache.commons:commons-compress</ignoredDependency>
+                <ignoredDependency>org.apache.commons:commons-configuration2</ignoredDependency>
               </ignoredDependencies>
             </configuration>
           </execution>


### PR DESCRIPTION
This PR updates the vulnerable dependency `commons-configuration2`, which was found by Snyk.

This PR also upgrades some additional dependencies to satisfy the `RequireUpperBoundDeps` [rule](https://maven.apache.org/enforcer/enforcer-rules/requireUpperBoundDeps.html) of the maven enforcer plugin. 