### PR TITLE
SNOW-1435061 Upgrade JDBC driver for domains fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ authentication. Currently, we support ingestion through the following APIs:
 
 The Snowflake Ingest Service SDK depends on the following libraries:
 
-* snowflake-jdbc (3.13.30 to 3.14.5) 
+* snowflake-jdbc (3.16.1+) 
 * slf4j-api
 * com.github.luben:zstd-jni (1.5.0-1)
 

--- a/e2e-jar-test/pom.xml
+++ b/e2e-jar-test/pom.xml
@@ -35,7 +35,7 @@
       <dependency>
         <groupId>net.snowflake</groupId>
         <artifactId>snowflake-jdbc-fips</artifactId>
-        <version>3.13.34</version>
+        <version>3.16.1</version>
       </dependency>
       <dependency>
         <groupId>net.snowflake.snowflake-ingest-java-e2e-jar-test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <shadeBase>net.snowflake.ingest.internal</shadeBase>
     <slf4j.version>1.7.36</slf4j.version>
     <snappy.version>1.1.10.4</snappy.version>
-    <snowjdbc.version>3.14.5</snowjdbc.version>
+    <snowjdbc.version>3.16.1</snowjdbc.version>
     <yetus.version>0.13.0</yetus.version>
   </properties>
 

--- a/public_pom.xml
+++ b/public_pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.14.5</version>
+            <version>3.16.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Updates JDBC driver to 3.16.1, which fixes regional AWS domain names in some regions. 

Related JDBC PR: https://github.com/snowflakedb/snowflake-jdbc/pull/1768