### PR TITLE
SNOW-1437884 Flush service supports uploading file to Iceberg tables

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractCloudStorage.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractCloudStorage.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import static net.snowflake.ingest.connection.ServiceResponseHandler.ApiName.STREAMING_CLIENT_CONFIGURE;
+import static net.snowflake.ingest.streaming.internal.StreamingIngestUtils.executeWithRetries;
+import static net.snowflake.ingest.utils.Constants.RESPONSE_SUCCESS;
+import static net.snowflake.ingest.utils.HttpUtil.generateProxyPropertiesForJDBC;
+import static net.snowflake.ingest.utils.Utils.getStackTrace;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import net.snowflake.client.core.OCSPMode;
+import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
+import net.snowflake.client.jdbc.SnowflakeFileTransferConfig;
+import net.snowflake.client.jdbc.SnowflakeFileTransferMetadataV1;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.cloud.storage.StageInfo;
+import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
+import net.snowflake.ingest.connection.IngestResponseException;
+import net.snowflake.ingest.connection.RequestBuilder;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.Logging;
+import net.snowflake.ingest.utils.SFException;
+import net.snowflake.ingest.utils.Utils;
+
+/** Handles uploading files to the Snowflake Streaming Ingest Cloud Storage */
+abstract class AbstractCloudStorage {
+  protected static final Logging logger = new Logging(StreamingIngestStage.class);
+
+  protected static final long REFRESH_THRESHOLD_IN_MS =
+      TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES);
+
+  /**
+   * Wrapper class containing SnowflakeFileTransferMetadata and the timestamp at which the metadata
+   * was refreshed
+   */
+  static class SnowflakeFileTransferMetadataWithAge {
+    SnowflakeFileTransferMetadataV1 fileTransferMetadata;
+    protected final boolean isLocalFS;
+    protected final String localLocation;
+
+    /* Do not always know the age of the metadata, so we use the empty
+    state to record unknown age.
+     */
+    Optional<Long> timestamp;
+
+    SnowflakeFileTransferMetadataWithAge(
+        SnowflakeFileTransferMetadataV1 fileTransferMetadata, Optional<Long> timestamp) {
+      this.isLocalFS = false;
+      this.fileTransferMetadata = fileTransferMetadata;
+      this.timestamp = timestamp;
+      this.localLocation = null;
+    }
+
+    SnowflakeFileTransferMetadataWithAge(String localLocation, Optional<Long> timestamp) {
+      this.isLocalFS = true;
+      this.localLocation = localLocation;
+      this.timestamp = timestamp;
+    }
+  }
+
+  protected static class MapStatusGetter<T> implements Function<T, Long> {
+    public MapStatusGetter() {}
+
+    public Long apply(T input) {
+      try {
+        return ((Integer) ((Map<String, Object>) input).get("status_code")).longValue();
+      } catch (Exception e) {
+        throw new SFException(ErrorCode.INTERNAL_ERROR, "failed to get status_code from response");
+      }
+    }
+  }
+
+  protected static final MapStatusGetter statusGetter = new MapStatusGetter();
+
+  protected static final ObjectMapper mapper = new ObjectMapper();
+
+  protected SnowflakeFileTransferMetadataWithAge fileTransferMetadataWithAge;
+  protected final CloseableHttpClient httpClient;
+  protected final RequestBuilder requestBuilder;
+  protected final String role;
+  protected final String clientName;
+  protected String clientPrefix;
+  protected final String configureEndpoint;
+
+  private final int maxUploadRetries;
+
+  // Proxy parameters that we set while calling the Snowflake JDBC to upload the streams
+  private final Properties proxyProperties;
+
+  /**
+   * Constructor of abstract cloud storage use to upload file to external volume
+   *
+   * @param role Snowflake role used by the Client
+   * @param httpClient http client reference
+   * @param requestBuilder request builder to build the HTTP request
+   * @param clientName the client name
+   * @param configureEndpoint endpoint for configuration call
+   * @param maxUploadRetries maximum time of upload retries
+   */
+  AbstractCloudStorage(
+      String role,
+      CloseableHttpClient httpClient,
+      RequestBuilder requestBuilder,
+      String clientName,
+      String configureEndpoint,
+      int maxUploadRetries) {
+    this.httpClient = httpClient;
+    this.role = role;
+    this.requestBuilder = requestBuilder;
+    this.clientName = clientName;
+    this.configureEndpoint = configureEndpoint;
+    this.proxyProperties = generateProxyPropertiesForJDBC();
+    this.maxUploadRetries = maxUploadRetries;
+  }
+
+  /**
+   * Upload file to internal stage with previously cached credentials. Will refetch and cache
+   * credentials if they've expired.
+   *
+   * @param fullFilePath Full file name to be uploaded
+   * @param data Data string to be uploaded
+   */
+  void putRemote(String fullFilePath, byte[] data) throws SnowflakeSQLException, IOException {
+    this.putRemote(fullFilePath, data, 0);
+  }
+
+  private void putRemote(String fullFilePath, byte[] data, int retryCount)
+      throws SnowflakeSQLException, IOException {
+    SnowflakeFileTransferMetadataV1 fileTransferMetadataCopy;
+    if (this.fileTransferMetadataWithAge.fileTransferMetadata.isForOneFile()) {
+      fileTransferMetadataCopy = this.fetchSignedURL(fullFilePath);
+    } else {
+      // Set file path to be uploaded
+      SnowflakeFileTransferMetadataV1 fileTransferMetadata =
+          fileTransferMetadataWithAge.fileTransferMetadata;
+
+      /*
+      Since we can have multiple calls to putRemote in parallel and because the metadata includes the file path
+      we use a copy for the upload to prevent us from using the wrong file path.
+       */
+      fileTransferMetadataCopy =
+          new SnowflakeFileTransferMetadataV1(
+              fileTransferMetadata.getPresignedUrl(),
+              fullFilePath,
+              fileTransferMetadata.getEncryptionMaterial() != null
+                  ? fileTransferMetadata.getEncryptionMaterial().getQueryStageMasterKey()
+                  : null,
+              fileTransferMetadata.getEncryptionMaterial() != null
+                  ? fileTransferMetadata.getEncryptionMaterial().getQueryId()
+                  : null,
+              fileTransferMetadata.getEncryptionMaterial() != null
+                  ? fileTransferMetadata.getEncryptionMaterial().getSmkId()
+                  : null,
+              fileTransferMetadata.getCommandType(),
+              fileTransferMetadata.getStageInfo());
+    }
+    InputStream inStream = new ByteArrayInputStream(data);
+
+    try {
+      SnowflakeFileTransferAgent.uploadWithoutConnection(
+          SnowflakeFileTransferConfig.Builder.newInstance()
+              .setSnowflakeFileTransferMetadata(fileTransferMetadataCopy)
+              .setUploadStream(inStream)
+              .setRequireCompress(false)
+              .setOcspMode(OCSPMode.FAIL_OPEN)
+              .setStreamingIngestClientKey(this.clientPrefix)
+              .setStreamingIngestClientName(this.clientName)
+              .setProxyProperties(this.proxyProperties)
+              .setDestFileName(fullFilePath)
+              .build());
+    } catch (Exception e) {
+      if (retryCount == 0) {
+        // for the first exception, we always perform a metadata refresh.
+        logger.logInfo(
+            "Stage metadata need to be refreshed due to upload error: {} on first retry attempt",
+            e.getMessage());
+        this.refreshCloudStorageMetadata();
+      }
+      if (retryCount >= maxUploadRetries) {
+        logger.logError(
+            "Failed to upload to stage, retry attempts exhausted ({}), client={}, message={}",
+            maxUploadRetries,
+            clientName,
+            e.getMessage());
+        throw new SFException(e, ErrorCode.IO_ERROR);
+      }
+      retryCount++;
+      StreamingIngestUtils.sleepForRetry(retryCount);
+      logger.logInfo(
+          "Retrying upload, attempt {}/{} msg: {}, stackTrace:{}",
+          retryCount,
+          maxUploadRetries,
+          e.getMessage(),
+          getStackTrace(e));
+      this.putRemote(fullFilePath, data, retryCount);
+    }
+  }
+
+  SnowflakeFileTransferMetadataWithAge refreshCloudStorageMetadata()
+      throws SnowflakeSQLException, IOException {
+    logger.logInfo("Refresh Snowflake metadata, client={}", clientName);
+    return refreshCloudStorageMetadata(false);
+  }
+
+  /**
+   * Creates a client-specific prefix that will be also part of the files registered by this client.
+   * The prefix will include a server-side generated string and the GlobalID of the deployment the
+   * client is registering blobs to. The latter (deploymentId) is needed in order to guarantee that
+   * blob filenames are unique across deployments even with replication enabled.
+   *
+   * @param response the client/configure response from the server
+   * @return the client prefix.
+   */
+  protected String createClientPrefix(final JsonNode response) {
+    final String prefix = response.get("prefix").textValue();
+    final String deploymentId =
+        response.has("deployment_id") ? "_" + response.get("deployment_id").longValue() : "";
+    return prefix + deploymentId;
+  }
+
+  boolean isLocalFS() {
+    return this.fileTransferMetadataWithAge.isLocalFS;
+  }
+
+  /** Get the server generated unique prefix for this client */
+  String getClientPrefix() {
+    return this.clientPrefix;
+  }
+
+  /**
+   * GCS requires a signed url per file. We need to fetch this from the server for each put
+   *
+   * @throws SnowflakeSQLException
+   * @throws IOException
+   */
+  SnowflakeFileTransferMetadataV1 fetchSignedURL(String fileName)
+      throws SnowflakeSQLException, IOException {
+
+    Map<Object, Object> payload = getConfigurePayload();
+    payload.put("file_name", fileName);
+    Map<String, Object> response = this.makeConfigureCall(payload);
+
+    JsonNode responseNode =
+        this.parseStageLocation(mapper.valueToTree(response).get("stage_location"));
+
+    SnowflakeFileTransferMetadataV1 metadata =
+        (SnowflakeFileTransferMetadataV1)
+            SnowflakeFileTransferAgent.getFileTransferMetadatas(responseNode).get(0);
+    // Transfer agent trims path for fileName
+    metadata.setPresignedUrlFileName(fileName);
+    return metadata;
+  }
+
+  protected JsonNode parseStageLocation(JsonNode stageLocation) {
+    ObjectNode responseNode = mapper.createObjectNode();
+
+    // Currently there are a few mismatches between the client/configure response and what
+    // SnowflakeFileTransferAgent expects
+    responseNode.putObject("data");
+    ObjectNode dataNode = (ObjectNode) responseNode.get("data");
+    dataNode.set("stageInfo", stageLocation);
+
+    // JDBC expects this field which maps to presignedFileUrlName.  We will set this later
+    dataNode.putArray("src_locations").add("placeholder");
+    return responseNode;
+  }
+
+  /**
+   * Gets new storage credentials and other metadata from Snowflake. Synchronized to prevent
+   * multiple calls to putRemote from trying to refresh at the same time
+   *
+   * @param force if true will ignore REFRESH_THRESHOLD and force metadata refresh
+   * @return refreshed metadata
+   * @throws SnowflakeSQLException
+   * @throws IOException
+   */
+  synchronized SnowflakeFileTransferMetadataWithAge refreshCloudStorageMetadata(boolean force)
+      throws SnowflakeSQLException, IOException {
+    if (!force
+        && fileTransferMetadataWithAge != null
+        && fileTransferMetadataWithAge.timestamp.isPresent()
+        && fileTransferMetadataWithAge.timestamp.get()
+            > System.currentTimeMillis() - REFRESH_THRESHOLD_IN_MS) {
+      return fileTransferMetadataWithAge;
+    }
+
+    Map<Object, Object> payload = getConfigurePayload();
+    Map<String, Object> response = this.makeConfigureCall(payload);
+
+    JsonNode responseNode =
+        this.parseStageLocation(mapper.valueToTree(response).get("stage_location"));
+    // Do not change the prefix everytime we have to refresh credentials
+    if (Utils.isNullOrEmpty(this.clientPrefix)) {
+      this.clientPrefix = createClientPrefix(responseNode);
+    }
+    Utils.assertStringNotNullOrEmpty("client prefix", this.clientPrefix);
+
+    if (responseNode
+        .get("data")
+        .get("stageInfo")
+        .get("locationType")
+        .toString()
+        .replaceAll(
+            "^[\"]|[\"]$", "") // Replace the first and last character if they're double quotes
+        .equals(StageInfo.StageType.LOCAL_FS.name())) {
+      this.fileTransferMetadataWithAge =
+          new SnowflakeFileTransferMetadataWithAge(
+              responseNode
+                  .get("data")
+                  .get("stageInfo")
+                  .get("location")
+                  .toString()
+                  .replaceAll(
+                      "^[\"]|[\"]$",
+                      ""), // Replace the first and last character if they're double quotes
+              Optional.of(System.currentTimeMillis()));
+    } else {
+      this.fileTransferMetadataWithAge =
+          new SnowflakeFileTransferMetadataWithAge(
+              (SnowflakeFileTransferMetadataV1)
+                  SnowflakeFileTransferAgent.getFileTransferMetadatas(responseNode).get(0),
+              Optional.of(System.currentTimeMillis()));
+    }
+    return this.fileTransferMetadataWithAge;
+  }
+
+  private Map<String, Object> makeConfigureCall(Map<Object, Object> payload) throws IOException {
+    try {
+      Map<String, Object> response =
+          executeWithRetries(
+              Map.class,
+              this.configureEndpoint,
+              mapper.writeValueAsString(payload),
+              "client configure",
+              STREAMING_CLIENT_CONFIGURE,
+              httpClient,
+              requestBuilder,
+              statusGetter);
+
+      // Check for Snowflake specific response code
+      if (!response.get("status_code").equals((int) RESPONSE_SUCCESS)) {
+        throw new SFException(
+            ErrorCode.CLIENT_CONFIGURE_FAILURE, response.get("message").toString());
+      }
+      return response;
+    } catch (IngestResponseException e) {
+      throw new SFException(e, ErrorCode.CLIENT_CONFIGURE_FAILURE, e.getMessage());
+    }
+  }
+
+  protected abstract Map<Object, Object> getConfigurePayload();
+
+  /**
+   * Upload file
+   *
+   * @param filePath
+   * @param blob
+   */
+  abstract void put(String filePath, byte[] blob);
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -671,6 +671,7 @@ class FlushService<T> {
       try {
         StreamingIngestExternalVolume streamingIngestExternalVolume =
             new StreamingIngestExternalVolume(
+                this.isTestMode,
                 this.owningClient.getRole(),
                 this.owningClient.getHttpClient(),
                 this.owningClient.getRequestBuilder(),

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -152,6 +152,9 @@ class FlushService<T> {
     this.owningClient = client;
     this.channelCache = cache;
     this.targetStage = targetStage;
+    if (this.targetStage != null) {
+      this.clientPrefix = this.targetStage.getClientPrefix();
+    }
     this.counter = new AtomicLong(0);
     this.registerService = new RegisterService<>(client, isTestMode);
     this.isNeedFlush = false;
@@ -188,7 +191,7 @@ class FlushService<T> {
                 client.getRequestBuilder(),
                 client.getName(),
                 DEFAULT_MAX_UPLOAD_RETRIES);
-        this.clientPrefix = this.targetStage.clientPrefix;
+        this.clientPrefix = this.targetStage.getClientPrefix();
       } else {
         this.targetStage = null;
       }
@@ -730,7 +733,7 @@ class FlushService<T> {
 
   /** For TESTING */
   String getBlobPath(Calendar calendar, String volumeHash) {
-    if (isTestMode) {
+    if (isTestMode && this.clientPrefix == null) {
       this.clientPrefix = "testPrefix";
     }
     Utils.assertStringNotNullOrEmpty("client prefix", this.clientPrefix);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -123,10 +123,6 @@ class FlushService<T> {
   // blob encoding version
   private final Constants.BdecVersion bdecVersion;
 
-  // Indicates if it's flushing to Iceberg tables, a blob could only contain one chunk under Iceberg
-  // mode
-  private final boolean isIcebergMode;
-
   /**
    * Constructor for TESTING that takes (usually mocked) StreamingIngestStage
    *
@@ -138,7 +134,6 @@ class FlushService<T> {
       SnowflakeStreamingIngestClientInternal<T> client,
       ChannelCache<T> cache,
       StreamingIngestStage targetStage, // For testing
-      boolean isIcebergMode,
       boolean isTestMode) {
     this.owningClient = client;
     this.channelCache = cache;
@@ -147,7 +142,6 @@ class FlushService<T> {
     this.registerService = new RegisterService<>(client, isTestMode);
     this.isNeedFlush = false;
     this.lastFlushTime = System.currentTimeMillis();
-    this.isIcebergMode = isIcebergMode;
     this.isTestMode = isTestMode;
     this.latencyTimerContextMap = new ConcurrentHashMap<>();
     this.bdecVersion = this.owningClient.getParameterProvider().getBlobFormatVersion();
@@ -162,10 +156,7 @@ class FlushService<T> {
    * @param isTestMode
    */
   FlushService(
-      SnowflakeStreamingIngestClientInternal<T> client,
-      ChannelCache<T> cache,
-      boolean isIcebergMode,
-      boolean isTestMode) {
+      SnowflakeStreamingIngestClientInternal<T> client, ChannelCache<T> cache, boolean isTestMode) {
     this.owningClient = client;
     this.channelCache = cache;
     try {
@@ -185,7 +176,6 @@ class FlushService<T> {
     this.counter = new AtomicLong(0);
     this.isNeedFlush = false;
     this.lastFlushTime = System.currentTimeMillis();
-    this.isIcebergMode = isIcebergMode;
     this.isTestMode = isTestMode;
     this.latencyTimerContextMap = new ConcurrentHashMap<>();
     this.bdecVersion = this.owningClient.getParameterProvider().getBlobFormatVersion();
@@ -447,7 +437,7 @@ class FlushService<T> {
           }
           // Add processed channels to the current blob, stop if we need to create a new blob
           blobData.add(channelsDataPerTable.subList(0, idx));
-          if (idx != channelsDataPerTable.size() || isIcebergMode) {
+          if (idx != channelsDataPerTable.size()) {
             break;
           }
         }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -5,14 +5,19 @@
 package net.snowflake.ingest.streaming.internal;
 
 import static net.snowflake.ingest.utils.Constants.BLOB_EXTENSION_TYPE;
+import static net.snowflake.ingest.utils.Constants.BdecVersion;
 import static net.snowflake.ingest.utils.Constants.DISABLE_BACKGROUND_FLUSH;
+import static net.snowflake.ingest.utils.Constants.ICEBERG_MODE_BLOB_EXTENSION_TYPE;
+import static net.snowflake.ingest.utils.Constants.ICEBERG_MODE_BLOB_PREFIX;
 import static net.snowflake.ingest.utils.Constants.MAX_BLOB_SIZE_IN_BYTES;
 import static net.snowflake.ingest.utils.Constants.MAX_THREAD_COUNT;
 import static net.snowflake.ingest.utils.Constants.THREAD_SHUTDOWN_TIMEOUT_IN_SEC;
 import static net.snowflake.ingest.utils.Utils.getStackTrace;
+import static net.snowflake.ingest.utils.Utils.isNullOrEmpty;
 
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
+import com.sun.management.OperatingSystemMXBean;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.security.InvalidAlgorithmParameterException;
@@ -40,7 +45,6 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
 import net.snowflake.client.jdbc.internal.google.common.util.concurrent.ThreadFactoryBuilder;
-import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.Pair;
@@ -102,8 +106,11 @@ class FlushService<T> {
   // Reference to the channel cache
   private final ChannelCache<T> channelCache;
 
-  // Reference to the Streaming Ingest stage
+  // Reference to the Streaming Ingest stage, used when streaming to Snowflake tables
   private final StreamingIngestStage targetStage;
+
+  // Reference to the external volume per table, used when streaming to Iceberg tables
+  private final Map<String, StreamingIngestExternalVolume> externalVolumeMap;
 
   // Reference to register service
   private final RegisterService<T> registerService;
@@ -114,6 +121,9 @@ class FlushService<T> {
   // Latest flush time
   @VisibleForTesting volatile long lastFlushTime;
 
+  // Indicates whether it's running on Iceberg mode
+  private final boolean isIcebergMode;
+
   // Indicates whether it's running as part of the test
   private final boolean isTestMode;
 
@@ -121,7 +131,10 @@ class FlushService<T> {
   private final Map<String, Timer.Context> latencyTimerContextMap;
 
   // blob encoding version
-  private final Constants.BdecVersion bdecVersion;
+  private final BdecVersion bdecVersion;
+
+  // server generated unique prefix for this client
+  private String clientPrefix;
 
   /**
    * Constructor for TESTING that takes (usually mocked) StreamingIngestStage
@@ -134,6 +147,7 @@ class FlushService<T> {
       SnowflakeStreamingIngestClientInternal<T> client,
       ChannelCache<T> cache,
       StreamingIngestStage targetStage, // For testing
+      boolean isIcebergMode,
       boolean isTestMode) {
     this.owningClient = client;
     this.channelCache = cache;
@@ -142,7 +156,9 @@ class FlushService<T> {
     this.registerService = new RegisterService<>(client, isTestMode);
     this.isNeedFlush = false;
     this.lastFlushTime = System.currentTimeMillis();
+    this.isIcebergMode = isIcebergMode;
     this.isTestMode = isTestMode;
+    this.externalVolumeMap = isIcebergMode ? new ConcurrentHashMap<>() : null;
     this.latencyTimerContextMap = new ConcurrentHashMap<>();
     this.bdecVersion = this.owningClient.getParameterProvider().getBlobFormatVersion();
     createWorkers();
@@ -156,18 +172,26 @@ class FlushService<T> {
    * @param isTestMode
    */
   FlushService(
-      SnowflakeStreamingIngestClientInternal<T> client, ChannelCache<T> cache, boolean isTestMode) {
+      SnowflakeStreamingIngestClientInternal<T> client,
+      ChannelCache<T> cache,
+      boolean isIcebergMode,
+      boolean isTestMode) {
     this.owningClient = client;
     this.channelCache = cache;
     try {
-      this.targetStage =
-          new StreamingIngestStage(
-              isTestMode,
-              client.getRole(),
-              client.getHttpClient(),
-              client.getRequestBuilder(),
-              client.getName(),
-              DEFAULT_MAX_UPLOAD_RETRIES);
+      if (!isIcebergMode) {
+        this.targetStage =
+            new StreamingIngestStage(
+                isTestMode,
+                client.getRole(),
+                client.getHttpClient(),
+                client.getRequestBuilder(),
+                client.getName(),
+                DEFAULT_MAX_UPLOAD_RETRIES);
+        this.clientPrefix = this.targetStage.clientPrefix;
+      } else {
+        this.targetStage = null;
+      }
     } catch (SnowflakeSQLException | IOException err) {
       throw new SFException(err, ErrorCode.UNABLE_TO_CONNECT_TO_STAGE);
     }
@@ -176,7 +200,9 @@ class FlushService<T> {
     this.counter = new AtomicLong(0);
     this.isNeedFlush = false;
     this.lastFlushTime = System.currentTimeMillis();
+    this.isIcebergMode = isIcebergMode;
     this.isTestMode = isTestMode;
+    this.externalVolumeMap = isIcebergMode ? new ConcurrentHashMap<>() : null;
     this.latencyTimerContextMap = new ConcurrentHashMap<>();
     this.bdecVersion = this.owningClient.getParameterProvider().getBlobFormatVersion();
     createWorkers();
@@ -192,7 +218,7 @@ class FlushService<T> {
         () -> {
           if (this.owningClient.cpuHistogram != null) {
             double cpuLoad =
-                ManagementFactory.getPlatformMXBean(com.sun.management.OperatingSystemMXBean.class)
+                ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class)
                     .getProcessCpuLoad();
             this.owningClient.cpuHistogram.update((long) (cpuLoad * 100));
           }
@@ -359,11 +385,16 @@ class FlushService<T> {
         itr = this.channelCache.iterator();
     List<Pair<BlobData<T>, CompletableFuture<BlobMetadata>>> blobs = new ArrayList<>();
     List<ChannelData<T>> leftoverChannelsDataPerTable = new ArrayList<>();
+    String currentTableName = "";
 
     while (itr.hasNext() || !leftoverChannelsDataPerTable.isEmpty()) {
       List<List<ChannelData<T>>> blobData = new ArrayList<>();
       float totalBufferSizeInBytes = 0F;
-      final String blobPath = getBlobPath(this.targetStage.getClientPrefix());
+      String blobPath =
+          getBlobPath(
+              (this.isIcebergMode && !isNullOrEmpty(currentTableName))
+                  ? externalVolumeMap.get(currentTableName).getVolumeHash()
+                  : null);
 
       // Distribute work at table level, split the blob if reaching the blob size limit or the
       // channel has different encryption key ids
@@ -385,8 +416,12 @@ class FlushService<T> {
               blobPath);
           break;
         } else {
+          Map.Entry<String, ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<T>>>
+              currentEntry = itr.next();
           ConcurrentHashMap<String, SnowflakeStreamingIngestChannelInternal<T>> table =
-              itr.next().getValue();
+              currentEntry.getValue();
+          currentTableName = currentEntry.getKey();
+
           // Use parallel stream since getData could be the performance bottleneck when we have a
           // high number of channels
           table.values().parallelStream()
@@ -549,32 +584,53 @@ class FlushService<T> {
           NoSuchPaddingException, IllegalBlockSizeException, BadPaddingException,
           InvalidKeyException {
     Timer.Context buildContext = Utils.createTimerContext(this.owningClient.buildLatency);
-
     // Construct the blob along with the metadata of the blob
-    BlobBuilder.Blob blob = BlobBuilder.constructBlobAndMetadata(blobPath, blobData, bdecVersion);
+    BlobBuilder.Blob blob =
+        BlobBuilder.constructBlobAndMetadata(
+            blobPath,
+            blobData,
+            bdecVersion,
+            this.owningClient.getParameterProvider().getDisableChunkEncryption());
 
     blob.blobStats.setBuildDurationMs(buildContext);
 
-    return upload(blobPath, blob.blobBytes, blob.chunksMetadataList, blob.blobStats);
+    AbstractCloudStorage cloudStorage = this.targetStage;
+    if (isIcebergMode) {
+      // Only one chunk per blob in Iceberg mode.
+      ChannelFlushContext channelContext = blobData.get(0).get(0).getChannelContext();
+      cloudStorage = this.externalVolumeMap.get(channelContext.getFullyQualifiedTableName());
+
+      // All data in the same chunk is from the same table, use any channel context for cloud
+      // storage metadata refresh.
+      ((StreamingIngestExternalVolume) cloudStorage)
+          .setArbitraryValidChannelFlushContext(channelContext);
+    }
+
+    return upload(blobPath, blob.blobBytes, blob.chunksMetadataList, blob.blobStats, cloudStorage);
   }
 
   /**
-   * Upload a blob to Streaming Ingest dedicated stage
+   * Upload a blob to cloud storage
    *
    * @param blobPath full path of the blob
    * @param blob blob data
    * @param metadata a list of chunk metadata
    * @param blobStats an object to track latencies and other stats of the blob
+   * @param cloudStorage the cloud storage object responsible for file upload
    * @return BlobMetadata object used to create the register blob request
    */
   BlobMetadata upload(
-      String blobPath, byte[] blob, List<ChunkMetadata> metadata, BlobStats blobStats)
+      String blobPath,
+      byte[] blob,
+      List<ChunkMetadata> metadata,
+      BlobStats blobStats,
+      AbstractCloudStorage cloudStorage)
       throws NoSuchAlgorithmException {
     logger.logInfo("Start uploading blob={}, size={}", blobPath, blob.length);
     long startTime = System.currentTimeMillis();
 
     Timer.Context uploadContext = Utils.createTimerContext(this.owningClient.uploadLatency);
-    this.targetStage.put(blobPath, blob);
+    cloudStorage.put(blobPath, blob);
 
     if (uploadContext != null) {
       blobStats.setUploadDurationMs(uploadContext);
@@ -599,6 +655,33 @@ class FlushService<T> {
         metadata,
         blobStats,
         metadata == null ? false : metadata.size() > 1);
+  }
+
+  /**
+   * Register the external volume of a table
+   *
+   * @param fullyQualifiedTableName The table using the external volume
+   * @param openChannelResponse Open channel response including storage metadata
+   */
+  void addExternalVolume(String fullyQualifiedTableName, OpenChannelResponse openChannelResponse) {
+    if (this.isIcebergMode) {
+      try {
+        StreamingIngestExternalVolume streamingIngestExternalVolume =
+            new StreamingIngestExternalVolume(
+                this.owningClient.getRole(),
+                this.owningClient.getHttpClient(),
+                this.owningClient.getRequestBuilder(),
+                this.owningClient.getName(),
+                openChannelResponse.getStageLocation(),
+                DEFAULT_MAX_UPLOAD_RETRIES);
+        externalVolumeMap.putIfAbsent(fullyQualifiedTableName, streamingIngestExternalVolume);
+        if (isNullOrEmpty(this.clientPrefix)) {
+          this.clientPrefix = streamingIngestExternalVolume.getClientPrefix();
+        }
+      } catch (SnowflakeSQLException err) {
+        throw new SFException(err, ErrorCode.UNABLE_TO_CONNECT_TO_STAGE);
+      }
+    }
   }
 
   /**
@@ -632,42 +715,68 @@ class FlushService<T> {
   }
 
   /**
-   * Generate a blob path, which is: "YEAR/MONTH/DAY_OF_MONTH/HOUR_OF_DAY/MINUTE/<current utc
-   * timestamp + client unique prefix + thread id + counter>.BDEC"
+   * Generate blob path. Blob path of an internal stage is:
+   * "YEAR/MONTH/DAY_OF_MONTH/HOUR_OF_DAY/MINUTE/<current utc timestamp + client unique prefix +
+   * thread id + counter>.BDEC". Blob path of an external volume is: "snow_<volume hash + current
+   * utc timestamp + client unique prefix + thread id + counter>.parquet".
    *
+   * @param volumeHash volume hash of an external volume, only works when isIcebergMode is true
    * @return the generated blob file path
    */
-  private String getBlobPath(String clientPrefix) {
+  private String getBlobPath(String volumeHash) {
     Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-    return getBlobPath(calendar, clientPrefix);
+    return getBlobPath(calendar, volumeHash);
   }
 
   /** For TESTING */
-  String getBlobPath(Calendar calendar, String clientPrefix) {
-    if (isTestMode && clientPrefix == null) {
-      clientPrefix = "testPrefix";
+  String getBlobPath(Calendar calendar, String volumeHash) {
+    if (isTestMode) {
+      this.clientPrefix = "testPrefix";
+    }
+    Utils.assertStringNotNullOrEmpty("client prefix", this.clientPrefix);
+
+    if (isIcebergMode) {
+      return ICEBERG_MODE_BLOB_PREFIX + "_" + volumeHash + "_" + getBlobShortName(calendar);
     }
 
-    Utils.assertStringNotNullOrEmpty("client prefix", clientPrefix);
     int year = calendar.get(Calendar.YEAR);
     int month = calendar.get(Calendar.MONTH) + 1; // Gregorian calendar starts from 0
     int day = calendar.get(Calendar.DAY_OF_MONTH);
     int hour = calendar.get(Calendar.HOUR_OF_DAY);
     int minute = calendar.get(Calendar.MINUTE);
+
+    return year
+        + "/"
+        + month
+        + "/"
+        + day
+        + "/"
+        + hour
+        + "/"
+        + minute
+        + "/"
+        + getBlobShortName(calendar);
+  }
+
+  /**
+   * Create the blob short name, the clientPrefix contains the deployment id
+   *
+   * @param calendar calendar of target time
+   * @return the generated blob short name
+   */
+  private String getBlobShortName(Calendar calendar) {
     long time = TimeUnit.MILLISECONDS.toSeconds(calendar.getTimeInMillis());
     long threadId = Thread.currentThread().getId();
-    // Create the blob short name, the clientPrefix contains the deployment id
-    String blobShortName =
-        Long.toString(time, 36)
-            + "_"
-            + clientPrefix
-            + "_"
-            + threadId
-            + "_"
-            + this.counter.getAndIncrement()
-            + "."
-            + BLOB_EXTENSION_TYPE;
-    return year + "/" + month + "/" + day + "/" + hour + "/" + minute + "/" + blobShortName;
+    //
+    return Long.toString(time, 36)
+        + "_"
+        + this.clientPrefix
+        + "_"
+        + threadId
+        + "_"
+        + this.counter.getAndIncrement()
+        + "."
+        + (this.isIcebergMode ? ICEBERG_MODE_BLOB_EXTENSION_TYPE : BLOB_EXTENSION_TYPE);
   }
 
   /**
@@ -695,7 +804,7 @@ class FlushService<T> {
 
   /** Get the server generated unique prefix for this client */
   String getClientPrefix() {
-    return this.targetStage.getClientPrefix();
+    return this.clientPrefix;
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -123,6 +123,10 @@ class FlushService<T> {
   // blob encoding version
   private final Constants.BdecVersion bdecVersion;
 
+  // Indicates if it's flushing to Iceberg tables, a blob could only contain one chunk under Iceberg
+  // mode
+  private final boolean isIcebergMode;
+
   /**
    * Constructor for TESTING that takes (usually mocked) StreamingIngestStage
    *
@@ -134,6 +138,7 @@ class FlushService<T> {
       SnowflakeStreamingIngestClientInternal<T> client,
       ChannelCache<T> cache,
       StreamingIngestStage targetStage, // For testing
+      boolean isIcebergMode,
       boolean isTestMode) {
     this.owningClient = client;
     this.channelCache = cache;
@@ -142,6 +147,7 @@ class FlushService<T> {
     this.registerService = new RegisterService<>(client, isTestMode);
     this.isNeedFlush = false;
     this.lastFlushTime = System.currentTimeMillis();
+    this.isIcebergMode = isIcebergMode;
     this.isTestMode = isTestMode;
     this.latencyTimerContextMap = new ConcurrentHashMap<>();
     this.bdecVersion = this.owningClient.getParameterProvider().getBlobFormatVersion();
@@ -156,7 +162,10 @@ class FlushService<T> {
    * @param isTestMode
    */
   FlushService(
-      SnowflakeStreamingIngestClientInternal<T> client, ChannelCache<T> cache, boolean isTestMode) {
+      SnowflakeStreamingIngestClientInternal<T> client,
+      ChannelCache<T> cache,
+      boolean isIcebergMode,
+      boolean isTestMode) {
     this.owningClient = client;
     this.channelCache = cache;
     try {
@@ -176,6 +185,7 @@ class FlushService<T> {
     this.counter = new AtomicLong(0);
     this.isNeedFlush = false;
     this.lastFlushTime = System.currentTimeMillis();
+    this.isIcebergMode = isIcebergMode;
     this.isTestMode = isTestMode;
     this.latencyTimerContextMap = new ConcurrentHashMap<>();
     this.bdecVersion = this.owningClient.getParameterProvider().getBlobFormatVersion();
@@ -437,7 +447,7 @@ class FlushService<T> {
           }
           // Add processed channels to the current blob, stop if we need to create a new blob
           blobData.add(channelsDataPerTable.subList(0, idx));
-          if (idx != channelsDataPerTable.size()) {
+          if (idx != channelsDataPerTable.size() || isIcebergMode) {
             break;
           }
         }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -605,7 +605,7 @@ class FlushService<T> {
             blobPath,
             blobData,
             bdecVersion,
-            this.owningClient.getParameterProvider().getDisableChunkEncryption());
+            this.owningClient.getParameterProvider().getEnableChunkEncryption());
 
     blob.blobStats.setBuildDurationMs(buildContext);
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
@@ -4,10 +4,10 @@
 
 package net.snowflake.ingest.streaming.internal;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import net.snowflake.ingest.utils.ExtendedByteArrayOutputStream;
 import net.snowflake.ingest.utils.Pair;
 
 /**
@@ -34,7 +34,7 @@ public interface Flusher<T> {
     final Map<String, RowBufferStats> columnEpStatsMapCombined;
     final long rowCount;
     final float chunkEstimatedUncompressedSize;
-    final ByteArrayOutputStream chunkData;
+    final ExtendedByteArrayOutputStream chunkData;
     final Pair<Long, Long> chunkMinMaxInsertTimeInMs;
 
     public SerializationResult(
@@ -42,7 +42,7 @@ public interface Flusher<T> {
         Map<String, RowBufferStats> columnEpStatsMapCombined,
         long rowCount,
         float chunkEstimatedUncompressedSize,
-        ByteArrayOutputStream chunkData,
+        ExtendedByteArrayOutputStream chunkData,
         Pair<Long, Long> chunkMinMaxInsertTimeInMs) {
       this.channelsMetadataList = channelsMetadataList;
       this.columnEpStatsMapCombined = columnEpStatsMapCombined;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/OpenChannelResponse.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/OpenChannelResponse.java
@@ -6,6 +6,7 @@ package net.snowflake.ingest.streaming.internal;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
 
 /** Response to the OpenChannelRequest */
 class OpenChannelResponse extends StreamingIngestResponse {
@@ -21,6 +22,7 @@ class OpenChannelResponse extends StreamingIngestResponse {
   private List<ColumnMetadata> tableColumns;
   private String encryptionKey;
   private Long encryptionKeyId;
+  private JsonNode stageLocation;
 
   @JsonProperty("status_code")
   void setStatusCode(Long statusCode) {
@@ -129,5 +131,14 @@ class OpenChannelResponse extends StreamingIngestResponse {
 
   Long getEncryptionKeyId() {
     return this.encryptionKeyId;
+  }
+
+  @JsonProperty("stage_location")
+  void setStageLocation(JsonNode stageLocation) {
+    this.stageLocation = stageLocation;
+  }
+
+  JsonNode getStageLocation() {
+    return this.stageLocation;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
@@ -4,9 +4,9 @@
 
 package net.snowflake.ingest.streaming.internal;
 
-import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.Map;
+import net.snowflake.ingest.utils.ExtendedByteArrayOutputStream;
 import org.apache.parquet.hadoop.BdecParquetWriter;
 
 /** Parquet data holder to buffer rows. */
@@ -15,7 +15,7 @@ public class ParquetChunkData {
   final List<List<Object>> rows;
 
   final BdecParquetWriter parquetWriter;
-  final ByteArrayOutputStream output;
+  final ExtendedByteArrayOutputStream output;
   final Map<String, String> metadata;
 
   /**
@@ -29,7 +29,7 @@ public class ParquetChunkData {
   public ParquetChunkData(
       List<List<Object>> rows,
       BdecParquetWriter parquetWriter,
-      ByteArrayOutputStream output,
+      ExtendedByteArrayOutputStream output,
       Map<String, String> metadata) {
     this.rows = rows;
     this.parquetWriter = parquetWriter;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -4,13 +4,13 @@
 
 package net.snowflake.ingest.streaming.internal;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.ExtendedByteArrayOutputStream;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.SFException;
@@ -64,7 +64,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
     String firstChannelFullyQualifiedTableName = null;
     Map<String, RowBufferStats> columnEpStatsMapCombined = null;
     BdecParquetWriter mergedChannelWriter = null;
-    ByteArrayOutputStream mergedChunkData = new ByteArrayOutputStream();
+    ExtendedByteArrayOutputStream mergedChunkData = new ExtendedByteArrayOutputStream();
     Pair<Long, Long> chunkMinMaxInsertTimeInMs = null;
 
     for (ChannelData<ParquetChunkData> data : channelsDataPerTable) {
@@ -144,7 +144,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
     Map<String, RowBufferStats> columnEpStatsMapCombined = null;
     List<List<Object>> rows = null;
     BdecParquetWriter parquetWriter;
-    ByteArrayOutputStream mergedData = new ByteArrayOutputStream();
+    ExtendedByteArrayOutputStream mergedData = new ExtendedByteArrayOutputStream();
     Pair<Long, Long> chunkMinMaxInsertTimeInMs = null;
 
     for (ChannelData<ParquetChunkData> data : channelsDataPerTable) {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -4,7 +4,6 @@
 
 package net.snowflake.ingest.streaming.internal;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -24,6 +23,7 @@ import net.snowflake.ingest.streaming.OffsetTokenVerificationFunction;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.ExtendedByteArrayOutputStream;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.hadoop.BdecParquetWriter;
 import org.apache.parquet.schema.MessageType;
@@ -48,7 +48,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   /* BDEC Parquet writer. It is used to buffer unflushed data in Parquet internal buffers instead of using Java objects */
   private BdecParquetWriter bdecParquetWriter;
 
-  private ByteArrayOutputStream fileOutput;
+  private ExtendedByteArrayOutputStream fileOutput;
   private final List<List<Object>> tempData;
 
   private MessageType schema;
@@ -119,7 +119,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
 
   /** Create BDEC file writer if Parquet memory optimization is enabled. */
   private void createFileWriter() {
-    fileOutput = new ByteArrayOutputStream();
+    fileOutput = new ExtendedByteArrayOutputStream();
     try {
       if (clientBufferParameters.getEnableParquetInternalBuffering()) {
         bdecParquetWriter =

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -235,8 +235,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
     }
 
     try {
-      this.flushService =
-          new FlushService<>(this, this.channelCache, this.isIcebergMode, this.isTestMode);
+      this.flushService = new FlushService<>(this, this.channelCache, this.isTestMode);
     } catch (Exception e) {
       // Need to clean up the resources before throwing any exceptions
       cleanUpResources();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -338,7 +338,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
       payload.put("schema", request.getSchemaName());
       payload.put("write_mode", Constants.WriteMode.CLOUD_STORAGE.name());
       payload.put("role", this.role);
-      payload.put("is_iceberg_client", isIcebergMode);
+      payload.put("is_iceberg", isIcebergMode);
       if (request.isOffsetTokenProvided()) {
         payload.put("offset_token", request.getOffsetToken());
       }
@@ -427,6 +427,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
       payload.put("database", request.getDBName());
       payload.put("schema", request.getSchemaName());
       payload.put("role", this.role);
+      payload.put("is_iceberg", isIcebergMode);
       Long clientSequencer = null;
       if (request instanceof DropChannelVersionRequest) {
         clientSequencer = ((DropChannelVersionRequest) request).getClientSequencer();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -235,7 +235,8 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
     }
 
     try {
-      this.flushService = new FlushService<>(this, this.channelCache, this.isTestMode);
+      this.flushService =
+          new FlushService<>(this, this.channelCache, this.isIcebergMode, this.isTestMode);
     } catch (Exception e) {
       // Need to clean up the resources before throwing any exceptions
       cleanUpResources();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestExternalVolume.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestExternalVolume.java
@@ -123,4 +123,10 @@ class StreamingIngestExternalVolume extends AbstractCloudStorage {
   public String getVolumeHash() {
     return volumeHash;
   }
+
+  private JsonNode parseStageLocation(JsonNode stageLocation) {
+    Map<String, Object> response = new HashMap<>();
+    response.put("stage_location", stageLocation);
+    return parseConfigureResponse(response);
+  }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestExternalVolume.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestExternalVolume.java
@@ -62,6 +62,15 @@ class StreamingIngestExternalVolume extends AbstractCloudStorage {
       this.volumeHash = stageLocation.get("volume_hash").asText();
     } else {
       this.volumeHash = "testVolumeHash";
+      this.arbitraryValidChannelFlushContext =
+          new ChannelFlushContext(
+              "testChannelFlushContext",
+              "dbName",
+              "schemaName",
+              "tableName",
+              0L,
+              "encryptionKey",
+              0L);
     }
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestExternalVolume.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestExternalVolume.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2021-2024 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal;
+
+import static net.snowflake.ingest.utils.Constants.CHANNEL_CONFIGURE_ENDPOINT;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
+import net.snowflake.client.jdbc.SnowflakeFileTransferMetadataV1;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
+import net.snowflake.ingest.connection.RequestBuilder;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.SFException;
+
+/** Handles uploading files to an external volume */
+class StreamingIngestExternalVolume extends AbstractCloudStorage {
+
+  // Any valid channel flush context that points to the external volume used for making channel
+  // configure calls
+  private volatile ChannelFlushContext arbitraryValidChannelFlushContext;
+
+  // Hash of the volume
+  private final String volumeHash;
+
+  /**
+   * General constructor
+   *
+   * @param role Snowflake role used by the Client
+   * @param httpClient http client reference
+   * @param requestBuilder request builder to build the HTTP request
+   * @param clientName the client name
+   * @param stageLocation external volume information received from open channel
+   * @param maxUploadRetries maximum time of upload retries
+   */
+  StreamingIngestExternalVolume(
+      String role,
+      CloseableHttpClient httpClient,
+      RequestBuilder requestBuilder,
+      String clientName,
+      JsonNode stageLocation,
+      int maxUploadRetries)
+      throws SnowflakeSQLException {
+    super(
+        role, httpClient, requestBuilder, clientName, CHANNEL_CONFIGURE_ENDPOINT, maxUploadRetries);
+    this.fileTransferMetadataWithAge =
+        new SnowflakeFileTransferMetadataWithAge(
+            (SnowflakeFileTransferMetadataV1)
+                SnowflakeFileTransferAgent.getFileTransferMetadatas(
+                        parseStageLocation(stageLocation))
+                    .get(0),
+            Optional.of(System.currentTimeMillis()));
+    this.volumeHash = stageLocation.get("volume_hash").asText();
+  }
+
+  /**
+   * Constructor for TESTING that takes SnowflakeFileTransferMetadataWithAge as input
+   *
+   * @param isTestMode must be true
+   * @param role Snowflake role used by the Client
+   * @param httpClient http client reference
+   * @param requestBuilder request builder to build the HTTP request
+   * @param clientName the client name
+   * @param stageLocation external volume information received from open channel
+   * @param testMetadata SnowflakeFileTransferMetadataWithAge to test with
+   */
+  StreamingIngestExternalVolume(
+      boolean isTestMode,
+      String role,
+      CloseableHttpClient httpClient,
+      RequestBuilder requestBuilder,
+      String clientName,
+      JsonNode stageLocation,
+      AbstractCloudStorage.SnowflakeFileTransferMetadataWithAge testMetadata,
+      int maxRetryCount)
+      throws SnowflakeSQLException {
+    this(role, httpClient, requestBuilder, clientName, stageLocation, maxRetryCount);
+    if (!isTestMode) {
+      throw new SFException(ErrorCode.INTERNAL_ERROR);
+    }
+    this.fileTransferMetadataWithAge = testMetadata;
+  }
+
+  public void setArbitraryValidChannelFlushContext(
+      ChannelFlushContext arbitraryValidChannelFlushContext) {
+    this.arbitraryValidChannelFlushContext = arbitraryValidChannelFlushContext;
+  }
+
+  @Override
+  protected Map<Object, Object> getConfigurePayload() {
+    Map<Object, Object> payload = new HashMap<>();
+    payload.put("role", this.role);
+    Map<Object, Object> channelPayload = new HashMap<>();
+    channelPayload.put("database", this.arbitraryValidChannelFlushContext.getDbName());
+    channelPayload.put("schema", this.arbitraryValidChannelFlushContext.getSchemaName());
+    channelPayload.put("table", this.arbitraryValidChannelFlushContext.getTableName());
+    channelPayload.put("channel_name", this.arbitraryValidChannelFlushContext.getName());
+    payload.put("channel", channelPayload);
+    return payload;
+  }
+
+  /**
+   * Upload file to external volume
+   *
+   * @param filePath
+   * @param blob
+   */
+  @Override
+  void put(String filePath, byte[] blob) {
+    try {
+      putRemote(filePath, blob);
+    } catch (SnowflakeSQLException | IOException e) {
+      throw new SFException(e, ErrorCode.BLOB_UPLOAD_FAILURE);
+    }
+  }
+
+  public String getVolumeHash() {
+    return volumeHash;
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestStage.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestStage.java
@@ -4,12 +4,7 @@
 
 package net.snowflake.ingest.streaming.internal;
 
-import static net.snowflake.ingest.connection.ServiceResponseHandler.ApiName.STREAMING_CLIENT_CONFIGURE;
-import static net.snowflake.ingest.streaming.internal.StreamingIngestUtils.executeWithRetries;
 import static net.snowflake.ingest.utils.Constants.CLIENT_CONFIGURE_ENDPOINT;
-import static net.snowflake.ingest.utils.Constants.RESPONSE_SUCCESS;
-import static net.snowflake.ingest.utils.HttpUtil.generateProxyPropertiesForJDBC;
-import static net.snowflake.ingest.utils.Utils.getStackTrace;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayInputStream;
@@ -19,77 +14,26 @@ import java.io.InputStream;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import net.snowflake.client.core.OCSPMode;
-import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
-import net.snowflake.client.jdbc.SnowflakeFileTransferConfig;
-import net.snowflake.client.jdbc.SnowflakeFileTransferMetadataV1;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
-import net.snowflake.client.jdbc.cloud.storage.StageInfo;
 import net.snowflake.client.jdbc.internal.apache.commons.io.FileUtils;
 import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
-import net.snowflake.ingest.connection.IngestResponseException;
 import net.snowflake.ingest.connection.RequestBuilder;
 import net.snowflake.ingest.utils.ErrorCode;
-import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.SFException;
-import net.snowflake.ingest.utils.Utils;
 
 /** Handles uploading files to the Snowflake Streaming Ingest Stage */
-class StreamingIngestStage {
-  private static final ObjectMapper mapper = new ObjectMapper();
-  private static final long REFRESH_THRESHOLD_IN_MS =
-      TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES);
-
-  private static final Logging logger = new Logging(StreamingIngestStage.class);
+class StreamingIngestStage extends AbstractCloudStorage {
 
   /**
-   * Wrapper class containing SnowflakeFileTransferMetadata and the timestamp at which the metadata
-   * was refreshed
+   * General constructor
+   *
+   * @param isTestMode whether it's testing mode
+   * @param role Snowflake role used by the Client
+   * @param httpClient http client reference
+   * @param requestBuilder request builder to build the HTTP request
+   * @param clientName the client name
+   * @param maxUploadRetries maximum time of upload retries
    */
-  static class SnowflakeFileTransferMetadataWithAge {
-    SnowflakeFileTransferMetadataV1 fileTransferMetadata;
-    private final boolean isLocalFS;
-    private final String localLocation;
-
-    /* Do not always know the age of the metadata, so we use the empty
-    state to record unknown age.
-     */
-    Optional<Long> timestamp;
-
-    SnowflakeFileTransferMetadataWithAge(
-        SnowflakeFileTransferMetadataV1 fileTransferMetadata, Optional<Long> timestamp) {
-      this.isLocalFS = false;
-      this.fileTransferMetadata = fileTransferMetadata;
-      this.timestamp = timestamp;
-      this.localLocation = null;
-    }
-
-    SnowflakeFileTransferMetadataWithAge(String localLocation, Optional<Long> timestamp) {
-      this.isLocalFS = true;
-      this.localLocation = localLocation;
-      this.timestamp = timestamp;
-    }
-  }
-
-  private SnowflakeFileTransferMetadataWithAge fileTransferMetadataWithAge;
-  private final CloseableHttpClient httpClient;
-  private final RequestBuilder requestBuilder;
-  private final String role;
-  private final String clientName;
-  private String clientPrefix;
-
-  private final int maxUploadRetries;
-
-  // Proxy parameters that we set while calling the Snowflake JDBC to upload the streams
-  private final Properties proxyProperties;
-
   StreamingIngestStage(
       boolean isTestMode,
       String role,
@@ -98,15 +42,10 @@ class StreamingIngestStage {
       String clientName,
       int maxUploadRetries)
       throws SnowflakeSQLException, IOException {
-    this.httpClient = httpClient;
-    this.role = role;
-    this.requestBuilder = requestBuilder;
-    this.clientName = clientName;
-    this.proxyProperties = generateProxyPropertiesForJDBC();
-    this.maxUploadRetries = maxUploadRetries;
-
+    super(
+        role, httpClient, requestBuilder, clientName, CLIENT_CONFIGURE_ENDPOINT, maxUploadRetries);
     if (!isTestMode) {
-      refreshSnowflakeMetadata();
+      refreshCloudStorageMetadata();
     }
   }
 
@@ -136,247 +75,11 @@ class StreamingIngestStage {
     this.fileTransferMetadataWithAge = testMetadata;
   }
 
-  /**
-   * Upload file to internal stage with previously cached credentials. Will refetch and cache
-   * credentials if they've expired.
-   *
-   * @param fullFilePath Full file name to be uploaded
-   * @param data Data string to be uploaded
-   */
-  void putRemote(String fullFilePath, byte[] data) throws SnowflakeSQLException, IOException {
-    this.putRemote(fullFilePath, data, 0);
-  }
-
-  private void putRemote(String fullFilePath, byte[] data, int retryCount)
-      throws SnowflakeSQLException, IOException {
-    SnowflakeFileTransferMetadataV1 fileTransferMetadataCopy;
-    if (this.fileTransferMetadataWithAge.fileTransferMetadata.isForOneFile()) {
-      fileTransferMetadataCopy = this.fetchSignedURL(fullFilePath);
-    } else {
-      // Set file path to be uploaded
-      SnowflakeFileTransferMetadataV1 fileTransferMetadata =
-          fileTransferMetadataWithAge.fileTransferMetadata;
-
-      /*
-      Since we can have multiple calls to putRemote in parallel and because the metadata includes the file path
-      we use a copy for the upload to prevent us from using the wrong file path.
-       */
-      fileTransferMetadataCopy =
-          new SnowflakeFileTransferMetadataV1(
-              fileTransferMetadata.getPresignedUrl(),
-              fullFilePath,
-              fileTransferMetadata.getEncryptionMaterial() != null
-                  ? fileTransferMetadata.getEncryptionMaterial().getQueryStageMasterKey()
-                  : null,
-              fileTransferMetadata.getEncryptionMaterial() != null
-                  ? fileTransferMetadata.getEncryptionMaterial().getQueryId()
-                  : null,
-              fileTransferMetadata.getEncryptionMaterial() != null
-                  ? fileTransferMetadata.getEncryptionMaterial().getSmkId()
-                  : null,
-              fileTransferMetadata.getCommandType(),
-              fileTransferMetadata.getStageInfo());
-    }
-    InputStream inStream = new ByteArrayInputStream(data);
-
-    try {
-      SnowflakeFileTransferAgent.uploadWithoutConnection(
-          SnowflakeFileTransferConfig.Builder.newInstance()
-              .setSnowflakeFileTransferMetadata(fileTransferMetadataCopy)
-              .setUploadStream(inStream)
-              .setRequireCompress(false)
-              .setOcspMode(OCSPMode.FAIL_OPEN)
-              .setStreamingIngestClientKey(this.clientPrefix)
-              .setStreamingIngestClientName(this.clientName)
-              .setProxyProperties(this.proxyProperties)
-              .setDestFileName(fullFilePath)
-              .build());
-    } catch (Exception e) {
-      if (retryCount == 0) {
-        // for the first exception, we always perform a metadata refresh.
-        logger.logInfo(
-            "Stage metadata need to be refreshed due to upload error: {} on first retry attempt",
-            e.getMessage());
-        this.refreshSnowflakeMetadata();
-      }
-      if (retryCount >= maxUploadRetries) {
-        logger.logError(
-            "Failed to upload to stage, retry attempts exhausted ({}), client={}, message={}",
-            maxUploadRetries,
-            clientName,
-            e.getMessage());
-        throw new SFException(e, ErrorCode.IO_ERROR);
-      }
-      retryCount++;
-      StreamingIngestUtils.sleepForRetry(retryCount);
-      logger.logInfo(
-          "Retrying upload, attempt {}/{} msg: {}, stackTrace:{}",
-          retryCount,
-          maxUploadRetries,
-          e.getMessage(),
-          getStackTrace(e));
-      this.putRemote(fullFilePath, data, retryCount);
-    }
-  }
-
-  SnowflakeFileTransferMetadataWithAge refreshSnowflakeMetadata()
-      throws SnowflakeSQLException, IOException {
-    logger.logInfo("Refresh Snowflake metadata, client={}", clientName);
-    return refreshSnowflakeMetadata(false);
-  }
-
-  /**
-   * Gets new stage credentials and other metadata from Snowflake. Synchronized to prevent multiple
-   * calls to putRemote from trying to refresh at the same time
-   *
-   * @param force if true will ignore REFRESH_THRESHOLD and force metadata refresh
-   * @return refreshed metadata
-   * @throws SnowflakeSQLException
-   * @throws IOException
-   */
-  synchronized SnowflakeFileTransferMetadataWithAge refreshSnowflakeMetadata(boolean force)
-      throws SnowflakeSQLException, IOException {
-    if (!force
-        && fileTransferMetadataWithAge != null
-        && fileTransferMetadataWithAge.timestamp.isPresent()
-        && fileTransferMetadataWithAge.timestamp.get()
-            > System.currentTimeMillis() - REFRESH_THRESHOLD_IN_MS) {
-      return fileTransferMetadataWithAge;
-    }
-
+  @Override
+  protected Map<Object, Object> getConfigurePayload() {
     Map<Object, Object> payload = new HashMap<>();
     payload.put("role", this.role);
-    Map<String, Object> response = this.makeClientConfigureCall(payload);
-
-    JsonNode responseNode = this.parseClientConfigureResponse(response);
-    // Do not change the prefix everytime we have to refresh credentials
-    if (Utils.isNullOrEmpty(this.clientPrefix)) {
-      this.clientPrefix = createClientPrefix(responseNode);
-    }
-    Utils.assertStringNotNullOrEmpty("client prefix", this.clientPrefix);
-
-    if (responseNode
-        .get("data")
-        .get("stageInfo")
-        .get("locationType")
-        .toString()
-        .replaceAll(
-            "^[\"]|[\"]$", "") // Replace the first and last character if they're double quotes
-        .equals(StageInfo.StageType.LOCAL_FS.name())) {
-      this.fileTransferMetadataWithAge =
-          new SnowflakeFileTransferMetadataWithAge(
-              responseNode
-                  .get("data")
-                  .get("stageInfo")
-                  .get("location")
-                  .toString()
-                  .replaceAll(
-                      "^[\"]|[\"]$",
-                      ""), // Replace the first and last character if they're double quotes
-              Optional.of(System.currentTimeMillis()));
-    } else {
-      this.fileTransferMetadataWithAge =
-          new SnowflakeFileTransferMetadataWithAge(
-              (SnowflakeFileTransferMetadataV1)
-                  SnowflakeFileTransferAgent.getFileTransferMetadatas(responseNode).get(0),
-              Optional.of(System.currentTimeMillis()));
-    }
-    return this.fileTransferMetadataWithAge;
-  }
-
-  /**
-   * Creates a client-specific prefix that will be also part of the files registered by this client.
-   * The prefix will include a server-side generated string and the GlobalID of the deployment the
-   * client is registering blobs to. The latter (deploymentId) is needed in order to guarantee that
-   * blob filenames are unique across deployments even with replication enabled.
-   *
-   * @param response the client/configure response from the server
-   * @return the client prefix.
-   */
-  private String createClientPrefix(final JsonNode response) {
-    final String prefix = response.get("prefix").textValue();
-    final String deploymentId =
-        response.has("deployment_id") ? "_" + response.get("deployment_id").longValue() : "";
-    return prefix + deploymentId;
-  }
-
-  /**
-   * GCS requires a signed url per file. We need to fetch this from the server for each put
-   *
-   * @throws SnowflakeSQLException
-   * @throws IOException
-   */
-  SnowflakeFileTransferMetadataV1 fetchSignedURL(String fileName)
-      throws SnowflakeSQLException, IOException {
-
-    Map<Object, Object> payload = new HashMap<>();
-    payload.put("role", this.role);
-    payload.put("file_name", fileName);
-    Map<String, Object> response = this.makeClientConfigureCall(payload);
-
-    JsonNode responseNode = this.parseClientConfigureResponse(response);
-
-    SnowflakeFileTransferMetadataV1 metadata =
-        (SnowflakeFileTransferMetadataV1)
-            SnowflakeFileTransferAgent.getFileTransferMetadatas(responseNode).get(0);
-    // Transfer agent trims path for fileName
-    metadata.setPresignedUrlFileName(fileName);
-    return metadata;
-  }
-
-  private static class MapStatusGetter<T> implements Function<T, Long> {
-    public MapStatusGetter() {}
-
-    public Long apply(T input) {
-      try {
-        return ((Integer) ((Map<String, Object>) input).get("status_code")).longValue();
-      } catch (Exception e) {
-        throw new SFException(ErrorCode.INTERNAL_ERROR, "failed to get status_code from response");
-      }
-    }
-  }
-
-  private static final MapStatusGetter statusGetter = new MapStatusGetter();
-
-  private JsonNode parseClientConfigureResponse(Map<String, Object> response) {
-    JsonNode responseNode = mapper.valueToTree(response);
-
-    // Currently there are a few mismatches between the client/configure response and what
-    // SnowflakeFileTransferAgent expects
-    ObjectNode mutable = (ObjectNode) responseNode;
-    mutable.putObject("data");
-    ObjectNode dataNode = (ObjectNode) mutable.get("data");
-    dataNode.set("stageInfo", responseNode.get("stage_location"));
-
-    // JDBC expects this field which maps to presignedFileUrlName.  We will set this later
-    dataNode.putArray("src_locations").add("placeholder");
-    return responseNode;
-  }
-
-  private Map<String, Object> makeClientConfigureCall(Map<Object, Object> payload)
-      throws IOException {
-    try {
-
-      Map<String, Object> response =
-          executeWithRetries(
-              Map.class,
-              CLIENT_CONFIGURE_ENDPOINT,
-              mapper.writeValueAsString(payload),
-              "client configure",
-              STREAMING_CLIENT_CONFIGURE,
-              httpClient,
-              requestBuilder,
-              statusGetter);
-
-      // Check for Snowflake specific response code
-      if (!response.get("status_code").equals((int) RESPONSE_SUCCESS)) {
-        throw new SFException(
-            ErrorCode.CLIENT_CONFIGURE_FAILURE, response.get("message").toString());
-      }
-      return response;
-    } catch (IngestResponseException e) {
-      throw new SFException(e, ErrorCode.CLIENT_CONFIGURE_FAILURE, e.getMessage());
-    }
+    return payload;
   }
 
   /**
@@ -385,6 +88,7 @@ class StreamingIngestStage {
    * @param filePath
    * @param blob
    */
+  @Override
   void put(String filePath, byte[] blob) {
     if (this.isLocalFS()) {
       putLocal(filePath, blob);
@@ -395,10 +99,6 @@ class StreamingIngestStage {
         throw new SFException(e, ErrorCode.BLOB_UPLOAD_FAILURE);
       }
     }
-  }
-
-  boolean isLocalFS() {
-    return this.fileTransferMetadataWithAge.isLocalFS;
   }
 
   /**
@@ -421,10 +121,5 @@ class StreamingIngestStage {
     } catch (Exception ex) {
       throw new SFException(ex, ErrorCode.BLOB_UPLOAD_FAILURE);
     }
-  }
-
-  /** Get the server generated unique prefix for this client */
-  String getClientPrefix() {
-    return this.clientPrefix;
   }
 }

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -50,8 +50,11 @@ public class Constants {
   public static final int BLOB_CHUNK_METADATA_LENGTH_SIZE_IN_BYTES = 4;
   public static final long THREAD_SHUTDOWN_TIMEOUT_IN_SEC = 300L;
   public static final String BLOB_EXTENSION_TYPE = "bdec";
+  public static final String ICEBERG_MODE_BLOB_EXTENSION_TYPE = "parquet";
+  public static final String ICEBERG_MODE_BLOB_PREFIX = "snow";
   public static final int MAX_THREAD_COUNT = Integer.MAX_VALUE;
   public static final String CLIENT_CONFIGURE_ENDPOINT = "/v1/streaming/client/configure/";
+  public static final String CHANNEL_CONFIGURE_ENDPOINT = "/v1/streaming/channels/configure/";
   public static final int COMMIT_MAX_RETRY_COUNT = 60;
   public static final int COMMIT_RETRY_INTERVAL_IN_MS = 1000;
   public static final String ENCRYPTION_ALGORITHM = "AES/CTR/NoPadding";

--- a/src/main/java/net/snowflake/ingest/utils/Cryptor.java
+++ b/src/main/java/net/snowflake/ingest/utils/Cryptor.java
@@ -91,13 +91,14 @@ public class Cryptor {
    * Encrypts input bytes using AES CTR mode with zero initialization vector.
    *
    * @param compressedChunkData bytes to encrypt
+   * @param length length of the bytes to encrypt
    * @param encryptionKey symmetric encryption key
    * @param diversifier diversifier for the encryption key
    * @param iv IV to use for encryption
    * @return encrypted bytes, padded, prefixed with initialization vector
    */
   public static byte[] encrypt(
-      byte[] compressedChunkData, String encryptionKey, String diversifier, long iv)
+      byte[] compressedChunkData, int length, String encryptionKey, String diversifier, long iv)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException,
           InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
     // Generate the derived key
@@ -107,7 +108,7 @@ public class Cryptor {
     Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
     byte[] ivBytes = ByteBuffer.allocate(2 * Long.BYTES).putLong(0).putLong(iv).array();
     cipher.init(Cipher.ENCRYPT_MODE, derivedKey, new IvParameterSpec(ivBytes));
-    return cipher.doFinal(compressedChunkData);
+    return cipher.doFinal(compressedChunkData, 0, length);
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/utils/ExtendedByteArrayOutputStream.java
+++ b/src/main/java/net/snowflake/ingest/utils/ExtendedByteArrayOutputStream.java
@@ -1,0 +1,19 @@
+package net.snowflake.ingest.utils;
+
+import java.io.ByteArrayOutputStream;
+
+/* An extension of ByteArrayOutputStream to access buffer without using toByteArray() to avoid copy */
+public class ExtendedByteArrayOutputStream extends ByteArrayOutputStream {
+  public ExtendedByteArrayOutputStream() {
+    super();
+  }
+
+  public ExtendedByteArrayOutputStream(int size) {
+    super(size);
+  }
+
+  /* The returned byte array does not match the length of OutputStream, size() should be called to get the length */
+  public byte[] getBytes() {
+    return buf;
+  }
+}

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -75,9 +75,6 @@ public class ParameterProvider {
   public static final boolean DISABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT = true;
   public static final long MAX_CLIENT_LAG_ICEBERG_MODE_DEFAULT = 30000;
 
-  // If the provided parameters need to be verified and modified to meet Iceberg mode
-  private final boolean isIcebergMode;
-
   /* Parameter that enables using internal Parquet buffers for buffering of rows before serializing.
   It reduces memory consumption compared to using Java Objects for buffering.*/
   public static final boolean ENABLE_PARQUET_INTERNAL_BUFFERING_DEFAULT = false;
@@ -230,7 +227,8 @@ public class ParameterProvider {
       icebergModeValidation(
           MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST,
           MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_ICEBERG_MODE_DEFAULT);
-      icebergModeValidation(DISABLE_CHUNK_ENCRYPTION, DISABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT);
+      icebergModeValidation(
+          DISABLE_CHUNK_ENCRYPTION, DISABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT);
     }
   }
 

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -41,7 +41,7 @@ public class ParameterProvider {
   public static final String BDEC_PARQUET_COMPRESSION_ALGORITHM =
       "BDEC_PARQUET_COMPRESSION_ALGORITHM".toLowerCase();
 
-  public static final String DISABLE_CHUNK_ENCRYPTION = "DISABLE_CHUNK_ENCRYPTION".toLowerCase();
+  public static final String ENABLE_CHUNK_ENCRYPTION = "ENABLE_CHUNK_ENCRYPTION".toLowerCase();
 
   // Default values
   public static final long BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT = 100;
@@ -68,11 +68,11 @@ public class ParameterProvider {
   public static final Constants.BdecParquetCompression BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT =
       Constants.BdecParquetCompression.GZIP;
 
-  public static final boolean DISABLE_CHUNK_ENCRYPTION_DEFAULT = false;
+  public static final boolean ENABLE_CHUNK_ENCRYPTION_DEFAULT = true;
 
   /* Iceberg mode parameters: When streaming to Iceberg mode, different default parameters are required because it generates Parquet files instead of BDEC files. */
   public static final int MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_ICEBERG_MODE_DEFAULT = 1;
-  public static final boolean DISABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT = true;
+  public static final boolean ENABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT = false;
   public static final long MAX_CLIENT_LAG_ICEBERG_MODE_DEFAULT = 30000;
 
   /* Parameter that enables using internal Parquet buffers for buffering of rows before serializing.
@@ -214,21 +214,20 @@ public class ParameterProvider {
         parameterOverrides,
         props);
 
+    // Restricted parameters
     this.updateValue(
-        DISABLE_CHUNK_ENCRYPTION,
+        ENABLE_CHUNK_ENCRYPTION,
         isIcebergMode
-            ? DISABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT
-            : DISABLE_CHUNK_ENCRYPTION_DEFAULT,
-        parameterOverrides,
-        props);
+            ? ENABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT
+            : ENABLE_CHUNK_ENCRYPTION_DEFAULT,
+        null,
+        null);
 
     // Required parameter override for Iceberg mode
     if (isIcebergMode) {
       icebergModeValidation(
           MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST,
           MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_ICEBERG_MODE_DEFAULT);
-      icebergModeValidation(
-          DISABLE_CHUNK_ENCRYPTION, DISABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT);
     }
   }
 
@@ -449,11 +448,11 @@ public class ParameterProvider {
     return Constants.BdecParquetCompression.fromName((String) val);
   }
 
-  /** @return If the chunk encryption is disabled */
-  public boolean getDisableChunkEncryption() {
+  /** @return If the chunk encryption is enabled */
+  public boolean getEnableChunkEncryption() {
     Object val =
-        this.parameterMap.getOrDefault(DISABLE_CHUNK_ENCRYPTION, DISABLE_CHUNK_ENCRYPTION_DEFAULT);
-    return (val instanceof String) ? Boolean.parseBoolean((String) val) : (boolean) val;
+        this.parameterMap.getOrDefault(ENABLE_CHUNK_ENCRYPTION, ENABLE_CHUNK_ENCRYPTION_DEFAULT);
+    return (boolean) val;
   }
 
   @Override

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -98,7 +98,7 @@ public class FlushServiceTest {
     TestContext(boolean isIcebergMode) {
       stage = Mockito.mock(StreamingIngestStage.class);
       Mockito.when(stage.getClientPrefix()).thenReturn("client_prefix");
-      parameterProvider = new ParameterProvider(isIcebergMode);
+      parameterProvider = new ParameterProvider();
       client = Mockito.mock(SnowflakeStreamingIngestClientInternal.class);
       Mockito.when(client.getParameterProvider()).thenReturn(parameterProvider);
       channelCache = new ChannelCache<>();

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -57,6 +57,7 @@ import org.mockito.Mockito;
 @RunWith(Parameterized.class)
 public class FlushServiceTest {
 
+  // TODO: Add IcebergMode = True
   @Parameterized.Parameters(name = "isIcebergMode: {0}")
   public static Object[] isIcebergMode() {
     return new Object[] {false};

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -76,7 +76,7 @@ public class FlushServiceTest {
       this.name = name;
     }
 
-    abstract TestContext<T> create();
+    abstract TestContext<T> create(boolean isIcebergMode);
 
     @Override
     public String toString() {
@@ -95,7 +95,7 @@ public class FlushServiceTest {
 
     final List<ChannelData<T>> channelData = new ArrayList<>();
 
-    TestContext() {
+    TestContext(boolean isIcebergMode) {
       stage = Mockito.mock(StreamingIngestStage.class);
       Mockito.when(stage.getClientPrefix()).thenReturn("client_prefix");
       parameterProvider = new ParameterProvider(isIcebergMode);
@@ -104,7 +104,8 @@ public class FlushServiceTest {
       channelCache = new ChannelCache<>();
       Mockito.when(client.getChannelCache()).thenReturn(channelCache);
       registerService = Mockito.spy(new RegisterService(client, client.isTestMode()));
-      flushService = Mockito.spy(new FlushService<>(client, channelCache, stage, true));
+      flushService =
+          Mockito.spy(new FlushService<>(client, channelCache, stage, isIcebergMode, true));
     }
 
     ChannelData<T> flushChannel(String name) {
@@ -245,6 +246,10 @@ public class FlushServiceTest {
 
   private static class ParquetTestContext extends TestContext<List<List<Object>>> {
 
+    ParquetTestContext(boolean isIcebergMode) {
+      super(isIcebergMode);
+    }
+
     SnowflakeStreamingIngestChannelInternal<List<List<Object>>> createChannel(
         String name,
         String dbName,
@@ -280,8 +285,8 @@ public class FlushServiceTest {
     static TestContextFactory<List<List<Object>>> createFactory() {
       return new TestContextFactory<List<List<Object>>>("Parquet") {
         @Override
-        TestContext<List<List<Object>>> create() {
-          return new ParquetTestContext();
+        TestContext<List<List<Object>>> create(boolean isIcebergMode) {
+          return new ParquetTestContext(isIcebergMode);
         }
       };
     }
@@ -400,7 +405,7 @@ public class FlushServiceTest {
 
   @Test
   public void testGetFilePath() {
-    TestContext<?> testContext = testContextFactory.create();
+    TestContext<?> testContext = testContextFactory.create(false);
     FlushService<?> flushService = testContext.flushService;
     Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
     String clientPrefix = "honk";
@@ -434,7 +439,7 @@ public class FlushServiceTest {
 
   @Test
   public void testFlush() throws Exception {
-    TestContext<?> testContext = testContextFactory.create();
+    TestContext<?> testContext = testContextFactory.create(false);
     FlushService<?> flushService = testContext.flushService;
     Mockito.when(flushService.isTestMode()).thenReturn(false);
 
@@ -462,7 +467,7 @@ public class FlushServiceTest {
 
   @Test
   public void testBlobCreation() throws Exception {
-    TestContext<?> testContext = testContextFactory.create();
+    TestContext<?> testContext = testContextFactory.create(false);
     SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1(testContext);
     SnowflakeStreamingIngestChannelInternal<?> channel2 = addChannel2(testContext);
     SnowflakeStreamingIngestChannelInternal<?> channel4 = addChannel4(testContext);
@@ -497,7 +502,7 @@ public class FlushServiceTest {
 
   @Test
   public void testBlobSplitDueToDifferentSchema() throws Exception {
-    TestContext<?> testContext = testContextFactory.create();
+    TestContext<?> testContext = testContextFactory.create(false);
     SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1(testContext);
     SnowflakeStreamingIngestChannelInternal<?> channel2 = addChannel2(testContext);
     String colName1 = "testBlobSplitDueToDifferentSchema1";
@@ -546,7 +551,7 @@ public class FlushServiceTest {
 
   @Test
   public void testBlobSplitDueToChunkSizeLimit() throws Exception {
-    TestContext<?> testContext = testContextFactory.create();
+    TestContext<?> testContext = testContextFactory.create(false);
     SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1(testContext);
     SnowflakeStreamingIngestChannelInternal<?> channel2 = addChannel2(testContext);
     String colName1 = "testBlobSplitDueToChunkSizeLimit1";
@@ -602,7 +607,7 @@ public class FlushServiceTest {
                         ? MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_ICEBERG_MODE_DEFAULT
                         : ParameterProvider.MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_DEFAULT));
 
-    final TestContext<List<List<Object>>> testContext = testContextFactory.create();
+    final TestContext<List<List<Object>>> testContext = testContextFactory.create(false);
 
     for (int i = 0; i < numberOfRows; i++) {
       SnowflakeStreamingIngestChannelInternal<List<List<Object>>> channel =
@@ -628,7 +633,7 @@ public class FlushServiceTest {
 
   @Test
   public void testBlobSplitDueToNumberOfChunksWithLeftoverChannels() throws Exception {
-    final TestContext<List<List<Object>>> testContext = testContextFactory.create();
+    final TestContext<List<List<Object>>> testContext = testContextFactory.create(false);
 
     for (int i = 0; i < 99; i++) { // 19 simple chunks
       SnowflakeStreamingIngestChannelInternal<List<List<Object>>> channel =
@@ -669,6 +674,32 @@ public class FlushServiceTest {
     Assert.assertEquals(102, getRows(allUploadedBlobs).size());
   }
 
+  @Test
+  public void testBlobSplitDueToIcebergMode() throws Exception {
+    int numberOfTables = 5;
+    int channelsPerTable = 5;
+    final TestContext<List<List<Object>>> testContext = testContextFactory.create(true);
+
+    for (int i = 0; i < numberOfTables * channelsPerTable; i++) {
+      SnowflakeStreamingIngestChannelInternal<List<List<Object>>> channel =
+          addChannel(testContext, i % numberOfTables, 1);
+      channel.setupSchema(Collections.singletonList(createTestTextColumn("C1")));
+      channel.insertRow(Collections.singletonMap("C1", i), "");
+    }
+
+    FlushService<List<List<Object>>> flushService = testContext.flushService;
+    flushService.flush(true).get();
+
+    ArgumentCaptor<List<List<ChannelData<List<List<Object>>>>>> blobDataCaptor =
+        ArgumentCaptor.forClass(List.class);
+    Mockito.verify(flushService, Mockito.times(numberOfTables))
+        .buildAndUpload(Mockito.any(), blobDataCaptor.capture());
+
+    List<List<List<ChannelData<List<List<Object>>>>>> allUploadedBlobs =
+        blobDataCaptor.getAllValues();
+    allUploadedBlobs.forEach(chunks -> Assert.assertEquals(1, chunks.size()));
+  }
+
   private List<List<Object>> getRows(List<List<List<ChannelData<List<List<Object>>>>>> blobs) {
     List<List<Object>> result = new ArrayList<>();
     blobs.forEach(
@@ -686,7 +717,7 @@ public class FlushServiceTest {
     long expectedBuildLatencyMs = 100;
     long expectedUploadLatencyMs = 200;
 
-    TestContext<?> testContext = testContextFactory.create();
+    TestContext<?> testContext = testContextFactory.create(false);
     SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1(testContext);
     SnowflakeStreamingIngestChannelInternal<?> channel2 = addChannel2(testContext);
     String colName1 = "testBuildAndUpload1";
@@ -834,7 +865,7 @@ public class FlushServiceTest {
 
   @Test
   public void testBuildErrors() throws Exception {
-    TestContext<?> testContext = testContextFactory.create();
+    TestContext<?> testContext = testContextFactory.create(false);
     SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1(testContext);
     SnowflakeStreamingIngestChannelInternal<?> channel3 = addChannel3(testContext);
     String colName1 = "testBuildErrors1";
@@ -929,7 +960,7 @@ public class FlushServiceTest {
     StreamingIngestStage stage = Mockito.mock(StreamingIngestStage.class);
     Mockito.when(stage.getClientPrefix()).thenReturn("client_prefix");
     FlushService<StubChunkData> flushService =
-        new FlushService<>(client, channelCache, stage, false);
+        new FlushService<>(client, channelCache, stage, false, false);
     flushService.invalidateAllChannelsInBlob(blobData, "Invalidated by test");
 
     Assert.assertFalse(channel1.isValid());
@@ -938,7 +969,7 @@ public class FlushServiceTest {
 
   @Test
   public void testBlobBuilder() throws Exception {
-    TestContext<?> testContext = testContextFactory.create();
+    TestContext<?> testContext = testContextFactory.create(false);
     SnowflakeStreamingIngestChannelInternal<?> channel1 = addChannel1(testContext);
 
     ObjectMapper mapper = new ObjectMapper();
@@ -1040,7 +1071,7 @@ public class FlushServiceTest {
 
   @Test
   public void testShutDown() throws Exception {
-    TestContext<?> testContext = testContextFactory.create();
+    TestContext<?> testContext = testContextFactory.create(false);
     FlushService<?> flushService = testContext.flushService;
 
     Assert.assertFalse(flushService.buildUploadWorkers.isShutdown());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -409,7 +409,7 @@ public class FlushServiceTest {
     FlushService<?> flushService = testContext.flushService;
     Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
     String clientPrefix = "honk";
-    String outputString = flushService.getBlobPath(calendar, clientPrefix);
+    String outputString = flushService.getBlobPath(calendar, null);
     Path outputPath = Paths.get(outputString);
     Assert.assertTrue(outputPath.getFileName().toString().contains(clientPrefix));
     Assert.assertTrue(
@@ -809,6 +809,8 @@ public class FlushServiceTest {
             .build();
 
     // Check FlushService.upload called with correct arguments
+    final ArgumentCaptor<AbstractCloudStorage> cloudStorageCaptor =
+        ArgumentCaptor.forClass(AbstractCloudStorage.class);
     final ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass(String.class);
     final ArgumentCaptor<byte[]> blobCaptor = ArgumentCaptor.forClass(byte[].class);
     final ArgumentCaptor<List<ChunkMetadata>> metadataCaptor = ArgumentCaptor.forClass(List.class);
@@ -818,7 +820,8 @@ public class FlushServiceTest {
             nameCaptor.capture(),
             blobCaptor.capture(),
             metadataCaptor.capture(),
-            ArgumentMatchers.any());
+            ArgumentMatchers.any(),
+            cloudStorageCaptor.capture());
     Assert.assertEquals("file_name", nameCaptor.getValue());
 
     ChunkMetadata metadataResult = metadataCaptor.getValue().get(0);
@@ -960,7 +963,7 @@ public class FlushServiceTest {
     StreamingIngestStage stage = Mockito.mock(StreamingIngestStage.class);
     Mockito.when(stage.getClientPrefix()).thenReturn("client_prefix");
     FlushService<StubChunkData> flushService =
-        new FlushService<>(client, channelCache, stage, false, false);
+        new FlushService<>(client, channelCache, stage, isIcebergMode, false);
     flushService.invalidateAllChannelsInBlob(blobData, "Invalidated by test");
 
     Assert.assertFalse(channel1.isValid());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -1,6 +1,14 @@
 package net.snowflake.ingest.streaming.internal;
 
-import static net.snowflake.ingest.utils.Constants.*;
+import static net.snowflake.ingest.utils.Constants.BLOB_CHECKSUM_SIZE_IN_BYTES;
+import static net.snowflake.ingest.utils.Constants.BLOB_CHUNK_METADATA_LENGTH_SIZE_IN_BYTES;
+import static net.snowflake.ingest.utils.Constants.BLOB_EXTENSION_TYPE;
+import static net.snowflake.ingest.utils.Constants.BLOB_FILE_SIZE_SIZE_IN_BYTES;
+import static net.snowflake.ingest.utils.Constants.BLOB_NO_HEADER;
+import static net.snowflake.ingest.utils.Constants.BLOB_TAG_SIZE_IN_BYTES;
+import static net.snowflake.ingest.utils.Constants.BLOB_VERSION_SIZE_IN_BYTES;
+import static net.snowflake.ingest.utils.Constants.ICEBERG_MODE_BLOB_EXTENSION_TYPE;
+import static net.snowflake.ingest.utils.Constants.ICEBERG_MODE_BLOB_PREFIX;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_CHUNK_SIZE_IN_BYTES_DEFAULT;
 
 import com.codahale.metrics.Histogram;
@@ -19,7 +27,18 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -47,6 +47,7 @@ import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.Cryptor;
 import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import org.junit.Assert;
@@ -985,12 +986,12 @@ public class FlushServiceTest {
 
     ObjectMapper mapper = new ObjectMapper();
     List<ChunkMetadata> chunksMetadataList = new ArrayList<>();
-    List<byte[]> chunksDataList = new ArrayList<>();
+    List<Pair<byte[], Integer>> chunksDataAndSizeList = new ArrayList<>();
     long checksum = 100;
     byte[] data = "fake data".getBytes(StandardCharsets.UTF_8);
     int dataSize = data.length;
 
-    chunksDataList.add(data);
+    chunksDataAndSizeList.add(new Pair<>(data, dataSize));
 
     Map<String, RowBufferStats> eps1 = new HashMap<>();
 
@@ -1026,7 +1027,8 @@ public class FlushServiceTest {
 
     final Constants.BdecVersion bdecVersion = ParameterProvider.BLOB_FORMAT_VERSION_DEFAULT;
     byte[] blob =
-        BlobBuilder.buildBlob(chunksMetadataList, chunksDataList, checksum, dataSize, bdecVersion);
+        BlobBuilder.buildBlob(
+            chunksMetadataList, chunksDataAndSizeList, checksum, dataSize, bdecVersion);
 
     // Read the blob byte array back to valid the behavior
     InputStream input = new ByteArrayInputStream(blob);
@@ -1105,7 +1107,7 @@ public class FlushServiceTest {
         Base64.getEncoder().encodeToString("encryption_key".getBytes(StandardCharsets.UTF_8));
     String diversifier = "2021/08/10/blob.bdec";
 
-    byte[] encryptedData = Cryptor.encrypt(data, encryptionKey, diversifier, 0);
+    byte[] encryptedData = Cryptor.encrypt(data, data.length, encryptionKey, diversifier, 0);
     byte[] decryptedData = Cryptor.decrypt(encryptedData, encryptionKey, diversifier, 0);
 
     Assert.assertArrayEquals(data, decryptedData);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -408,10 +408,9 @@ public class FlushServiceTest {
     TestContext<?> testContext = testContextFactory.create(false);
     FlushService<?> flushService = testContext.flushService;
     Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-    String clientPrefix = "honk";
     String outputString = flushService.getBlobPath(calendar, null);
     Path outputPath = Paths.get(outputString);
-    Assert.assertTrue(outputPath.getFileName().toString().contains(clientPrefix));
+    Assert.assertTrue(outputPath.getFileName().toString().contains("client_prefix"));
     Assert.assertTrue(
         calendar.get(Calendar.MINUTE)
                 - Integer.parseInt(outputPath.getParent().getFileName().toString())

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -146,7 +146,7 @@ public class ParameterProviderTest {
     Properties props = new Properties();
     props.put(
         ParameterProvider.MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_ICEBERG_MODE_DEFAULT, 100L);
-    props.put(ParameterProvider.DISABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT, false);
+    props.put(ParameterProvider.ENABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT, false);
     ParameterProvider parameterProvider = new ParameterProvider(null, props, true);
 
     Assert.assertEquals(
@@ -182,8 +182,8 @@ public class ParameterProviderTest {
         MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_ICEBERG_MODE_DEFAULT,
         parameterProvider.getMaxChunksInBlobAndRegistrationRequest());
     Assert.assertEquals(
-        ParameterProvider.DISABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT,
-        parameterProvider.getDisableChunkEncryption());
+        ParameterProvider.ENABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT,
+        parameterProvider.getEnableChunkEncryption());
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -143,10 +143,15 @@ public class ParameterProviderTest {
 
   @Test
   public void withIcebergDefaultValues() {
-    ParameterProvider parameterProvider = new ParameterProvider(true);
+    Properties props = new Properties();
+    props.put(
+        ParameterProvider.MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_ICEBERG_MODE_DEFAULT, 100L);
+    props.put(ParameterProvider.DISABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT, false);
+    ParameterProvider parameterProvider = new ParameterProvider(null, props, true);
 
     Assert.assertEquals(
-        ParameterProvider.MAX_CLIENT_LAG_DEFAULT, parameterProvider.getCachedMaxClientLagInMs());
+        ParameterProvider.MAX_CLIENT_LAG_ICEBERG_MODE_DEFAULT,
+        parameterProvider.getCachedMaxClientLagInMs());
     Assert.assertEquals(
         ParameterProvider.BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT,
         parameterProvider.getBufferFlushCheckIntervalInMs());
@@ -176,6 +181,9 @@ public class ParameterProviderTest {
     Assert.assertEquals(
         MAX_CHUNKS_IN_BLOB_AND_REGISTRATION_REQUEST_ICEBERG_MODE_DEFAULT,
         parameterProvider.getMaxChunksInBlobAndRegistrationRequest());
+    Assert.assertEquals(
+        ParameterProvider.DISABLE_CHUNK_ENCRYPTION_ICEBERG_MODE_DEFAULT,
+        parameterProvider.getDisableChunkEncryption());
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
@@ -281,7 +281,7 @@ public class StreamingIngestStageTest {
         new StreamingIngestStage(true, "role", mockClient, mockBuilder, "clientName", 1);
 
     StreamingIngestStage.SnowflakeFileTransferMetadataWithAge metadataWithAge =
-        stage.refreshSnowflakeMetadata(true);
+        stage.refreshCloudStorageMetadata(true);
 
     final ArgumentCaptor<String> endpointCaptor = ArgumentCaptor.forClass(String.class);
     final ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
@@ -376,7 +376,7 @@ public class StreamingIngestStageTest {
     workers.submit(
         () -> {
           try {
-            stage.refreshSnowflakeMetadata();
+            stage.refreshCloudStorageMetadata();
           } catch (Exception e) {
             throw new RuntimeException(e);
           }
@@ -384,7 +384,7 @@ public class StreamingIngestStageTest {
     workers.submit(
         () -> {
           try {
-            stage.refreshSnowflakeMetadata();
+            stage.refreshCloudStorageMetadata();
           } catch (Exception e) {
             throw new RuntimeException(e);
           }


### PR DESCRIPTION
Modify flush service to support uploading file to external volume. This PR includes following change:

- Add default parameter `MAX_CLIENT_LAG` for Iceberg mode
- Introduce new parameter `DISABLE_CHUNK_ENCRYPTION` to disable chunk encryption in Iceberg mode
- Move stage from client level to table level when using Iceberg mode, see: `StreamingIngestExternalVolume.java`
- Move stage/volume configure logic to channel level when using Iceberg
- Fix `FlushServiceTest` and `StreamingIngestStage`, more test cases is expected