### PR TITLE
DO NOT MERGE: Make binary string encoding configurable, add support for base64

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
@@ -18,6 +18,8 @@ public class ClientBufferParameters {
 
   private Constants.BdecParquetCompression bdecParquetCompression;
 
+  private Constants.BinaryStringEncoding binaryStringEncoding;
+
   /**
    * Private constructor used for test methods
    *
@@ -30,11 +32,13 @@ public class ClientBufferParameters {
       boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
       long maxAllowedRowSizeInBytes,
-      Constants.BdecParquetCompression bdecParquetCompression) {
+      Constants.BdecParquetCompression bdecParquetCompression,
+      Constants.BinaryStringEncoding binaryStringEncoding) {
     this.enableParquetInternalBuffering = enableParquetInternalBuffering;
     this.maxChunkSizeInBytes = maxChunkSizeInBytes;
     this.maxAllowedRowSizeInBytes = maxAllowedRowSizeInBytes;
     this.bdecParquetCompression = bdecParquetCompression;
+    this.binaryStringEncoding = binaryStringEncoding;
   }
 
   /** @param clientInternal reference to the client object where the relevant parameters are set */
@@ -55,6 +59,10 @@ public class ClientBufferParameters {
         clientInternal != null
             ? clientInternal.getParameterProvider().getBdecParquetCompressionAlgorithm()
             : ParameterProvider.BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT;
+    this.binaryStringEncoding =
+            clientInternal != null
+                    ? clientInternal.getParameterProvider().getBinaryStringEncoding()
+                    : ParameterProvider.BINARY_STRING_ENCODING_DEFAULT;
   }
 
   /**
@@ -68,12 +76,14 @@ public class ClientBufferParameters {
       boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
       long maxAllowedRowSizeInBytes,
-      Constants.BdecParquetCompression bdecParquetCompression) {
+      Constants.BdecParquetCompression bdecParquetCompression,
+      Constants.BinaryStringEncoding binaryStringEncoding) {
     return new ClientBufferParameters(
         enableParquetInternalBuffering,
         maxChunkSizeInBytes,
         maxAllowedRowSizeInBytes,
-        bdecParquetCompression);
+        bdecParquetCompression,
+        binaryStringEncoding);
   }
 
   public boolean getEnableParquetInternalBuffering() {
@@ -90,5 +100,9 @@ public class ClientBufferParameters {
 
   public Constants.BdecParquetCompression getBdecParquetCompression() {
     return bdecParquetCompression;
+  }
+
+  public Constants.BinaryStringEncoding getBinaryStringEncoding() {
+    return binaryStringEncoding;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -207,7 +207,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       ColumnMetadata column = parquetColumn.columnMetadata;
       ParquetValueParser.ParquetBufferValue valueWithSize =
           ParquetValueParser.parseColumnValueToParquet(
-              value, column, parquetColumn.type, forkedStats, defaultTimezone, insertRowsCurrIndex);
+              value, column, parquetColumn.type, forkedStats, defaultTimezone, insertRowsCurrIndex, clientBufferParameters.getBinaryStringEncoding());
       indexedRow[colIndex] = valueWithSize.getValue();
       size += valueWithSize.getSize();
     }

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -141,6 +141,24 @@ public class Constants {
               name, Arrays.asList(BdecParquetCompression.values())));
     }
   }
+
+  public enum BinaryStringEncoding {
+    HEX,
+    BASE64;
+
+    public static BinaryStringEncoding fromName(String name) {
+      for (BinaryStringEncoding e : BinaryStringEncoding.values()) {
+        if (e.name().toLowerCase().equals(name.toLowerCase())) {
+          return e;
+        }
+      }
+      throw new IllegalArgumentException(
+              String.format(
+                      "Unsupported BinaryStringEncoding = '%s', allowed values are %s",
+                      name, Arrays.asList(BinaryStringEncoding.values())));
+    }
+  }
+
   // Parameters
   public static final boolean DISABLE_BACKGROUND_FLUSH = false;
   public static final boolean COMPRESS_BLOB_TWICE = false;

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -39,6 +39,9 @@ public class ParameterProvider {
   public static final String BDEC_PARQUET_COMPRESSION_ALGORITHM =
       "BDEC_PARQUET_COMPRESSION_ALGORITHM".toLowerCase();
 
+  public static final String BINARY_STRING_ENCODING =
+          "BINARY_STRING_ENCODING".toLowerCase();
+
   // Default values
   public static final long BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT = 100;
   public static final long INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT = 1000;
@@ -63,6 +66,9 @@ public class ParameterProvider {
 
   public static final Constants.BdecParquetCompression BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT =
       Constants.BdecParquetCompression.GZIP;
+
+  public static final Constants.BinaryStringEncoding BINARY_STRING_ENCODING_DEFAULT =
+          Constants.BinaryStringEncoding.HEX;
 
   /* Parameter that enables using internal Parquet buffers for buffering of rows before serializing.
   It reduces memory consumption compared to using Java Objects for buffering.*/
@@ -188,6 +194,13 @@ public class ParameterProvider {
         BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT,
         parameterOverrides,
         props);
+
+    this.updateValue(
+        BINARY_STRING_ENCODING,
+        BINARY_STRING_ENCODING_DEFAULT,
+        parameterOverrides,
+        props);
+
   }
 
   /** @return Longest interval in milliseconds between buffer flushes */
@@ -406,6 +419,18 @@ public class ParameterProvider {
     }
     return Constants.BdecParquetCompression.fromName((String) val);
   }
+
+  /** @return binary string encoding */
+  public Constants.BinaryStringEncoding getBinaryStringEncoding() {
+    Object val =
+            this.parameterMap.getOrDefault(
+                    BINARY_STRING_ENCODING, BINARY_STRING_ENCODING_DEFAULT);
+    if (val instanceof Constants.BinaryStringEncoding) {
+      return (Constants.BinaryStringEncoding) val;
+    }
+    return Constants.BinaryStringEncoding.fromName((String) val);
+  }
+
 
   @Override
   public String toString() {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -45,6 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
+
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.commons.codec.DecoderException;
@@ -888,76 +890,76 @@ public class DataValidationUtilTest {
     assertArrayEquals(
         "honk".getBytes(StandardCharsets.UTF_8),
         validateAndParseBinary(
-            "COL", "honk".getBytes(StandardCharsets.UTF_8), Optional.empty(), 0));
+            "COL", "honk".getBytes(StandardCharsets.UTF_8), Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
 
     assertArrayEquals(
         new byte[] {-1, 0, 1},
-        validateAndParseBinary("COL", new byte[] {-1, 0, 1}, Optional.empty(), 0));
+        validateAndParseBinary("COL", new byte[] {-1, 0, 1}, Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
     assertArrayEquals(
         Hex.decodeHex("1234567890abcdef"), // pragma: allowlist secret NOT A SECRET
         validateAndParseBinary(
             "COL",
             "1234567890abcdef", // pragma: allowlist secret NOT A SECRET
             Optional.empty(),
-            0)); // pragma: allowlist secret NOT A SECRET
+            0, Constants.BinaryStringEncoding.HEX)); // pragma: allowlist secret NOT A SECRET
     assertArrayEquals(
         Hex.decodeHex("1234567890abcdef"), // pragma: allowlist secret NOT A SECRET
         validateAndParseBinary(
             "COL",
             "  1234567890abcdef \t\n",
             Optional.empty(),
-            0)); // pragma: allowlist secret NOT A SECRET
+            0, Constants.BinaryStringEncoding.HEX)); // pragma: allowlist secret NOT A SECRET
 
     assertArrayEquals(
-        maxAllowedArray, validateAndParseBinary("COL", maxAllowedArray, Optional.empty(), 0));
+        maxAllowedArray, validateAndParseBinary("COL", maxAllowedArray, Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
     assertArrayEquals(
         maxAllowedArrayMinusOne,
-        validateAndParseBinary("COL", maxAllowedArrayMinusOne, Optional.empty(), 0));
+        validateAndParseBinary("COL", maxAllowedArrayMinusOne, Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
 
     // Too large arrays should be rejected
     expectError(
         ErrorCode.INVALID_VALUE_ROW,
-        () -> validateAndParseBinary("COL", new byte[1], Optional.of(0), 0));
+        () -> validateAndParseBinary("COL", new byte[1], Optional.of(0), 0, Constants.BinaryStringEncoding.HEX));
     expectError(
         ErrorCode.INVALID_VALUE_ROW,
-        () -> validateAndParseBinary("COL", new byte[BYTES_8_MB + 1], Optional.empty(), 0));
+        () -> validateAndParseBinary("COL", new byte[BYTES_8_MB + 1], Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
     expectError(
         ErrorCode.INVALID_VALUE_ROW,
-        () -> validateAndParseBinary("COL", new byte[8], Optional.of(7), 0));
+        () -> validateAndParseBinary("COL", new byte[8], Optional.of(7), 0, Constants.BinaryStringEncoding.HEX));
     expectError(
         ErrorCode.INVALID_VALUE_ROW,
-        () -> validateAndParseBinary("COL", "aabb", Optional.of(1), 0));
+        () -> validateAndParseBinary("COL", "aabb", Optional.of(1), 0, Constants.BinaryStringEncoding.HEX));
 
     // unsupported data types should fail
     expectError(
         ErrorCode.INVALID_VALUE_ROW,
-        () -> validateAndParseBinary("COL", "000", Optional.empty(), 0));
+        () -> validateAndParseBinary("COL", "000", Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
     expectError(
         ErrorCode.INVALID_VALUE_ROW,
-        () -> validateAndParseBinary("COL", "abcg", Optional.empty(), 0));
+        () -> validateAndParseBinary("COL", "abcg", Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
     expectError(
-        ErrorCode.INVALID_VALUE_ROW, () -> validateAndParseBinary("COL", "c", Optional.empty(), 0));
+        ErrorCode.INVALID_VALUE_ROW, () -> validateAndParseBinary("COL", "c", Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
     expectError(
         ErrorCode.INVALID_FORMAT_ROW,
         () ->
             validateAndParseBinary(
-                "COL", Arrays.asList((byte) 1, (byte) 2, (byte) 3), Optional.empty(), 0));
+                "COL", Arrays.asList((byte) 1, (byte) 2, (byte) 3), Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
     expectError(
-        ErrorCode.INVALID_FORMAT_ROW, () -> validateAndParseBinary("COL", 1, Optional.empty(), 0));
+        ErrorCode.INVALID_FORMAT_ROW, () -> validateAndParseBinary("COL", 1, Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
     expectError(
-        ErrorCode.INVALID_FORMAT_ROW, () -> validateAndParseBinary("COL", 12, Optional.empty(), 0));
-    expectError(
-        ErrorCode.INVALID_FORMAT_ROW,
-        () -> validateAndParseBinary("COL", 1.5, Optional.empty(), 0));
+        ErrorCode.INVALID_FORMAT_ROW, () -> validateAndParseBinary("COL", 12, Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
     expectError(
         ErrorCode.INVALID_FORMAT_ROW,
-        () -> validateAndParseBinary("COL", BigInteger.ONE, Optional.empty(), 0));
+        () -> validateAndParseBinary("COL", 1.5, Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
     expectError(
         ErrorCode.INVALID_FORMAT_ROW,
-        () -> validateAndParseBinary("COL", false, Optional.empty(), 0));
+        () -> validateAndParseBinary("COL", BigInteger.ONE, Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
     expectError(
         ErrorCode.INVALID_FORMAT_ROW,
-        () -> validateAndParseBinary("COL", new Object(), Optional.empty(), 0));
+        () -> validateAndParseBinary("COL", false, Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
+    expectError(
+        ErrorCode.INVALID_FORMAT_ROW,
+        () -> validateAndParseBinary("COL", new Object(), Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
   }
 
   @Test
@@ -1179,19 +1181,19 @@ public class DataValidationUtilTest {
         "The given row cannot be converted to the internal format: Object of type java.lang.Object"
             + " cannot be ingested into Snowflake column COL of type BINARY, rowIndex:0. Allowed"
             + " Java types: byte[], String",
-        () -> validateAndParseBinary("COL", new Object(), Optional.empty(), 0));
+        () -> validateAndParseBinary("COL", new Object(), Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
     expectErrorCodeAndMessage(
         ErrorCode.INVALID_VALUE_ROW,
         "The given row cannot be converted to the internal format due to invalid value: Value"
             + " cannot be ingested into Snowflake column COL of type BINARY, rowIndex:0, reason:"
             + " Binary too long: length=2 maxLength=1",
-        () -> validateAndParseBinary("COL", new byte[] {1, 2}, Optional.of(1), 0));
+        () -> validateAndParseBinary("COL", new byte[] {1, 2}, Optional.of(1), 0, Constants.BinaryStringEncoding.HEX));
     expectErrorCodeAndMessage(
         ErrorCode.INVALID_VALUE_ROW,
         "The given row cannot be converted to the internal format due to invalid value: Value"
             + " cannot be ingested into Snowflake column COL of type BINARY, rowIndex:0, reason:"
             + " Not a valid hex string",
-        () -> validateAndParseBinary("COL", "ghi", Optional.empty(), 0));
+        () -> validateAndParseBinary("COL", "ghi", Optional.empty(), 0, Constants.BinaryStringEncoding.HEX));
 
     // VARIANT
     expectErrorCodeAndMessage(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
@@ -10,6 +10,8 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.schema.PrimitiveType;
 import org.junit.Assert;
@@ -31,7 +33,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            12, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0);
+            12, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -57,7 +59,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            1234, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0);
+            1234, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -83,7 +85,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            123456789, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0);
+            123456789, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -114,7 +116,7 @@ public class ParquetValueParserTest {
             PrimitiveType.PrimitiveTypeName.INT64,
             rowBufferStats,
             UTC,
-            0);
+            0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -145,7 +147,7 @@ public class ParquetValueParserTest {
             PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
             rowBufferStats,
             UTC,
-            0);
+            0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -178,7 +180,7 @@ public class ParquetValueParserTest {
             PrimitiveType.PrimitiveTypeName.DOUBLE,
             rowBufferStats,
             UTC,
-            0);
+            0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -202,7 +204,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            12345.54321d, testCol, PrimitiveType.PrimitiveTypeName.DOUBLE, rowBufferStats, UTC, 0);
+            12345.54321d, testCol, PrimitiveType.PrimitiveTypeName.DOUBLE, rowBufferStats, UTC, 0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -226,7 +228,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            true, testCol, PrimitiveType.PrimitiveTypeName.BOOLEAN, rowBufferStats, UTC, 0);
+            true, testCol, PrimitiveType.PrimitiveTypeName.BOOLEAN, rowBufferStats, UTC, 0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -255,7 +257,7 @@ public class ParquetValueParserTest {
             PrimitiveType.PrimitiveTypeName.BINARY,
             rowBufferStats,
             UTC,
-            0);
+            0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -292,7 +294,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0);
+            var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -333,7 +335,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0);
+            var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -363,7 +365,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            input, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0);
+            input, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0, Constants.BinaryStringEncoding.HEX);
 
     String resultArray = "[{\"a\":\"1\",\"b\":\"2\",\"c\":\"3\"}]";
 
@@ -395,7 +397,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            text, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0);
+            text, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0, Constants.BinaryStringEncoding.HEX);
 
     String result = text;
 
@@ -434,7 +436,7 @@ public class ParquetValueParserTest {
                     PrimitiveType.PrimitiveTypeName.INT32,
                     rowBufferStats,
                     UTC,
-                    0));
+                    0, Constants.BinaryStringEncoding.HEX));
     Assert.assertEquals(
         "Unknown data type for logical: TIMESTAMP_NTZ, physical: SB4.", exception.getMessage());
   }
@@ -458,7 +460,7 @@ public class ParquetValueParserTest {
             PrimitiveType.PrimitiveTypeName.INT64,
             rowBufferStats,
             UTC,
-            0);
+            0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -488,7 +490,7 @@ public class ParquetValueParserTest {
             PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
             rowBufferStats,
             UTC,
-            0);
+            0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -514,7 +516,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "2021-01-01", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0);
+            "2021-01-01", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -539,7 +541,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "01:00:00", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0);
+            "01:00:00", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -564,7 +566,7 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "01:00:00.123", testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats, UTC, 0);
+            "01:00:00.123", testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats, UTC, 0, Constants.BinaryStringEncoding.HEX);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -597,7 +599,7 @@ public class ParquetValueParserTest {
                     PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
                     rowBufferStats,
                     UTC,
-                    0));
+                    0, Constants.BinaryStringEncoding.HEX));
     Assert.assertEquals(
         "Unknown data type for logical: TIME, physical: SB16.", exception.getMessage());
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -126,7 +126,8 @@ public class RowBufferTest {
             enableParquetMemoryOptimization,
             MAX_CHUNK_SIZE_IN_BYTES_DEFAULT,
             MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT,
-            Constants.BdecParquetCompression.GZIP),
+            Constants.BdecParquetCompression.GZIP,
+            Constants.BinaryStringEncoding.HEX),
         null,
         null);
   }


### PR DESCRIPTION
Addresses issue where streaming client receives base64-encoded strings for binary.  

Adds new parameter `BINARY_STRING_ENCODING` which supports values `hex` and `base64`.   The default value is `hex`.