### PR TITLE
Various performance improvements in the `insertRows` path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,16 +329,6 @@
         <version>${objenesis.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.openjdk.jmh</groupId>
-        <artifactId>jmh-core</artifactId>
-        <version>1.34</version>
-      </dependency>
-      <dependency>
-        <groupId>org.openjdk.jmh</groupId>
-        <artifactId>jmh-generator-annprocess</artifactId>
-        <version>1.34</version>
-      </dependency>
-      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
@@ -372,6 +362,18 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>3.7.7</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>1.34</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-generator-annprocess</artifactId>
+        <version>1.34</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,16 @@
         <version>${objenesis.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>1.34</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-generator-annprocess</artifactId>
+        <version>1.34</version>
+      </dependency>
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
@@ -535,6 +545,16 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -16,7 +16,6 @@ import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import net.snowflake.ingest.connection.TelemetryService;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OffsetTokenVerificationFunction;
@@ -403,7 +402,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
     Set<String> originalKeys = row.keySet();
     Map<String, String> inputColNamesMap = new HashMap<>();
     for (String key : originalKeys) {
-        inputColNamesMap.put(LiteralQuoteUtils.unquoteColumnName(key), key);
+      inputColNamesMap.put(LiteralQuoteUtils.unquoteColumnName(key), key);
     }
     // Check for extra columns in the row
     List<String> extraCols = new ArrayList<>();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -401,9 +401,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
     // Map of unquoted column name -> original column name
     Set<String> originalKeys = row.keySet();
     Map<String, String> inputColNamesMap = new HashMap<>();
-    for (String key : originalKeys) {
-      inputColNamesMap.put(LiteralQuoteUtils.unquoteColumnName(key), key);
-    }
+    originalKeys.forEach(
+        key -> inputColNamesMap.put(LiteralQuoteUtils.unquoteColumnName(key), key));
     // Check for extra columns in the row
     List<String> extraCols = new ArrayList<>();
     for (String columnName : inputColNamesMap.keySet()) {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -400,10 +400,11 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
   Set<String> verifyInputColumns(
       Map<String, Object> row, InsertValidationResponse.InsertError error, int rowIndex) {
     // Map of unquoted column name -> original column name
-    Map<String, String> inputColNamesMap =
-        row.keySet().stream()
-            .collect(Collectors.toMap(LiteralQuoteUtils::unquoteColumnName, value -> value));
-
+    Set<String> originalKeys = row.keySet();
+    Map<String, String> inputColNamesMap = new HashMap<>();
+    for (String key : originalKeys) {
+        inputColNamesMap.put(LiteralQuoteUtils.unquoteColumnName(key), key);
+    }
     // Check for extra columns in the row
     List<String> extraCols = new ArrayList<>();
     for (String columnName : inputColNamesMap.keySet()) {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -86,6 +86,8 @@ class DataValidationUtil {
     objectMapper.registerModule(module);
   }
 
+  // Caching the powers of 10 that are used for checking the range of numbers because computing them
+  // on-demand is expensive.
   private static final BigDecimal[] POWER_10 = makePower10Table();
 
   private static BigDecimal[] makePower10Table() {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -833,9 +833,9 @@ class DataValidationUtil {
 
   static void checkValueInRange(
       BigDecimal bigDecimalValue, int scale, int precision, final long insertRowIndex) {
-//    if (bigDecimalValue.abs().compareTo(BigDecimal.TEN.pow(precision - scale)) >= 0) {
-      if (bigDecimalValue.abs().compareTo(POWER_10[precision - scale]) >= 0) {
-        throw new SFException(
+    //    if (bigDecimalValue.abs().compareTo(BigDecimal.TEN.pow(precision - scale)) >= 0) {
+    if (bigDecimalValue.abs().compareTo(POWER_10[precision - scale]) >= 0) {
+      throw new SFException(
           ErrorCode.INVALID_FORMAT_ROW,
           String.format(
               "Number out of representable exclusive range of (-1e%s..1e%s), rowIndex:%d",

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -833,7 +833,11 @@ class DataValidationUtil {
 
   static void checkValueInRange(
       BigDecimal bigDecimalValue, int scale, int precision, final long insertRowIndex) {
-    if (bigDecimalValue.abs().compareTo(POWER_10[precision - scale]) >= 0) {
+    BigDecimal comparand =
+        (precision >= scale) && (precision - scale) < POWER_10.length
+            ? POWER_10[precision - scale]
+            : BigDecimal.TEN.pow(precision - scale);
+    if (bigDecimalValue.abs().compareTo(comparand) >= 0) {
       throw new SFException(
           ErrorCode.INVALID_FORMAT_ROW,
           String.format(

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -833,7 +833,6 @@ class DataValidationUtil {
 
   static void checkValueInRange(
       BigDecimal bigDecimalValue, int scale, int precision, final long insertRowIndex) {
-    //    if (bigDecimalValue.abs().compareTo(BigDecimal.TEN.pow(precision - scale)) >= 0) {
     if (bigDecimalValue.abs().compareTo(POWER_10[precision - scale]) >= 0) {
       throw new SFException(
           ErrorCode.INVALID_FORMAT_ROW,

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -86,6 +86,16 @@ class DataValidationUtil {
     objectMapper.registerModule(module);
   }
 
+  private static final BigDecimal[] POWER_10 = makePower10Table();
+
+  private static BigDecimal[] makePower10Table() {
+    BigDecimal[] power10 = new BigDecimal[Power10.sb16Size];
+    for (int i = 0; i < Power10.sb16Size; i++) {
+      power10[i] = new BigDecimal(Power10.sb16Table[i]);
+    }
+    return power10;
+  }
+
   /**
    * Validates and parses input as JSON. All types in the object tree must be valid variant types,
    * see {@link DataValidationUtil#isAllowedSemiStructuredType}.
@@ -823,8 +833,9 @@ class DataValidationUtil {
 
   static void checkValueInRange(
       BigDecimal bigDecimalValue, int scale, int precision, final long insertRowIndex) {
-    if (bigDecimalValue.abs().compareTo(BigDecimal.TEN.pow(precision - scale)) >= 0) {
-      throw new SFException(
+//    if (bigDecimalValue.abs().compareTo(BigDecimal.TEN.pow(precision - scale)) >= 0) {
+      if (bigDecimalValue.abs().compareTo(POWER_10[precision - scale]) >= 0) {
+        throw new SFException(
           ErrorCode.INVALID_FORMAT_ROW,
           String.format(
               "Number out of representable exclusive range of (-1e%s..1e%s), rowIndex:%d",

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -279,7 +279,7 @@ class FlushService<T> {
   private void createWorkers() {
     // Create thread for checking and scheduling flush job
     ThreadFactory flushThreadFactory =
-        new ThreadFactoryBuilder().setNameFormat("ingest-flush-thread").setDaemon(true).build();
+        new ThreadFactoryBuilder().setNameFormat("ingest-flush-thread").build();
     this.flushWorker = Executors.newSingleThreadScheduledExecutor(flushThreadFactory);
     this.flushWorker.scheduleWithFixedDelay(
         () -> {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -361,7 +361,8 @@ class FlushService<T> {
     List<Pair<BlobData<T>, CompletableFuture<BlobMetadata>>> blobs = new ArrayList<>();
     List<ChannelData<T>> leftoverChannelsDataPerTable = new ArrayList<>();
 
-    // The API states that the number of available processors reported can change and therefore, we should poll it occasionally.
+    // The API states that the number of available processors reported can change and therefore, we
+    // should poll it occasionally.
     numProcessors = Runtime.getRuntime().availableProcessors();
     while (itr.hasNext() || !leftoverChannelsDataPerTable.isEmpty()) {
       List<List<ChannelData<T>>> blobData = new ArrayList<>();
@@ -707,8 +708,7 @@ class FlushService<T> {
    */
   boolean throttleDueToQueuedFlushTasks() {
     ThreadPoolExecutor buildAndUpload = (ThreadPoolExecutor) this.buildUploadWorkers;
-    boolean throttleOnQueuedTasks =
-        buildAndUpload.getQueue().size() > numProcessors;
+    boolean throttleOnQueuedTasks = buildAndUpload.getQueue().size() > numProcessors;
     if (throttleOnQueuedTasks) {
       logger.logWarn(
           "Throttled due too many queue flush tasks (probably because of slow uploading speed),"

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -279,7 +279,7 @@ class FlushService<T> {
   private void createWorkers() {
     // Create thread for checking and scheduling flush job
     ThreadFactory flushThreadFactory =
-        new ThreadFactoryBuilder().setNameFormat("ingest-flush-thread").build();
+        new ThreadFactoryBuilder().setNameFormat("ingest-flush-thread").setDaemon(true).build();
     this.flushWorker = Executors.newSingleThreadScheduledExecutor(flushThreadFactory);
     this.flushWorker.scheduleWithFixedDelay(
         () -> {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -122,6 +122,7 @@ class FlushService<T> {
 
   // blob encoding version
   private final Constants.BdecVersion bdecVersion;
+  private volatile int numProcessors = Runtime.getRuntime().availableProcessors();
 
   /**
    * Constructor for TESTING that takes (usually mocked) StreamingIngestStage
@@ -360,6 +361,8 @@ class FlushService<T> {
     List<Pair<BlobData<T>, CompletableFuture<BlobMetadata>>> blobs = new ArrayList<>();
     List<ChannelData<T>> leftoverChannelsDataPerTable = new ArrayList<>();
 
+    // The API states that the number of available processors reported can change and therefore, we should poll it occasionally.
+    numProcessors = Runtime.getRuntime().availableProcessors();
     while (itr.hasNext() || !leftoverChannelsDataPerTable.isEmpty()) {
       List<List<ChannelData<T>>> blobData = new ArrayList<>();
       float totalBufferSizeInBytes = 0F;
@@ -705,7 +708,7 @@ class FlushService<T> {
   boolean throttleDueToQueuedFlushTasks() {
     ThreadPoolExecutor buildAndUpload = (ThreadPoolExecutor) this.buildUploadWorkers;
     boolean throttleOnQueuedTasks =
-        buildAndUpload.getQueue().size() > Runtime.getRuntime().availableProcessors();
+        buildAndUpload.getQueue().size() > numProcessors;
     if (throttleOnQueuedTasks) {
       logger.logWarn(
           "Throttled due too many queue flush tasks (probably because of slow uploading speed),"

--- a/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProvider.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProvider.java
@@ -9,9 +9,6 @@ public interface MemoryInfoProvider {
   /** @return Max memory the JVM can allocate */
   long getMaxMemory();
 
-  /** @return Total allocated JVM memory so far */
-  long getTotalMemory();
-
   /** @return Free JVM memory */
   long getFreeMemory();
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProviderFromRuntime.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProviderFromRuntime.java
@@ -16,17 +16,23 @@ public class MemoryInfoProviderFromRuntime implements MemoryInfoProvider {
 
   public MemoryInfoProviderFromRuntime(long freeMemoryUpdateIntervalMs) {
     maxMemory = Runtime.getRuntime().maxMemory();
-    totalFreeMemory = Runtime.getRuntime().freeMemory() + (maxMemory - Runtime.getRuntime().totalMemory());
-    executorService = new ScheduledThreadPoolExecutor(1, r -> {
-        Thread th = new Thread(r, "MemoryInfoProviderFromRuntime");
-        th.setDaemon(true);
-        return th;
-    });
-    executorService.scheduleAtFixedRate(this::updateFreeMemory, 0, freeMemoryUpdateIntervalMs, TimeUnit.MILLISECONDS);
+    totalFreeMemory =
+        Runtime.getRuntime().freeMemory() + (maxMemory - Runtime.getRuntime().totalMemory());
+    executorService =
+        new ScheduledThreadPoolExecutor(
+            1,
+            r -> {
+              Thread th = new Thread(r, "MemoryInfoProviderFromRuntime");
+              th.setDaemon(true);
+              return th;
+            });
+    executorService.scheduleAtFixedRate(
+        this::updateFreeMemory, 0, freeMemoryUpdateIntervalMs, TimeUnit.MILLISECONDS);
   }
 
   private void updateFreeMemory() {
-    totalFreeMemory = Runtime.getRuntime().freeMemory() + (maxMemory - Runtime.getRuntime().totalMemory());
+    totalFreeMemory =
+        Runtime.getRuntime().freeMemory() + (maxMemory - Runtime.getRuntime().totalMemory());
   }
 
   @Override

--- a/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProviderFromRuntime.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProviderFromRuntime.java
@@ -4,20 +4,38 @@
 
 package net.snowflake.ingest.streaming.internal;
 
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 /** Reads memory information from JVM runtime */
 public class MemoryInfoProviderFromRuntime implements MemoryInfoProvider {
-  @Override
-  public long getMaxMemory() {
-    return Runtime.getRuntime().maxMemory();
+  private final long maxMemory;
+  private volatile long totalFreeMemory;
+  private final ScheduledExecutorService executorService;
+
+  public MemoryInfoProviderFromRuntime(long freeMemoryUpdateIntervalMs) {
+    maxMemory = Runtime.getRuntime().maxMemory();
+    totalFreeMemory = Runtime.getRuntime().freeMemory() + (maxMemory - Runtime.getRuntime().totalMemory());
+    executorService = new ScheduledThreadPoolExecutor(1, r -> {
+        Thread th = new Thread(r, "MemoryInfoProviderFromRuntime");
+        th.setDaemon(true);
+        return th;
+    });
+    executorService.scheduleAtFixedRate(this::updateFreeMemory, 0, freeMemoryUpdateIntervalMs, TimeUnit.MILLISECONDS);
+  }
+
+  private void updateFreeMemory() {
+    totalFreeMemory = Runtime.getRuntime().freeMemory() + (maxMemory - Runtime.getRuntime().totalMemory());
   }
 
   @Override
-  public long getTotalMemory() {
-    return Runtime.getRuntime().totalMemory();
+  public long getMaxMemory() {
+    return maxMemory;
   }
 
   @Override
   public long getFreeMemory() {
-    return Runtime.getRuntime().freeMemory();
+    return totalFreeMemory;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProviderFromRuntime.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProviderFromRuntime.java
@@ -13,8 +13,10 @@ public class MemoryInfoProviderFromRuntime implements MemoryInfoProvider {
   private final long maxMemory;
   private volatile long totalFreeMemory;
   private final ScheduledExecutorService executorService;
+  private static final long FREE_MEMORY_UPDATE_INTERVAL_MS = 1000;
+  private static final MemoryInfoProviderFromRuntime INSTANCE = new MemoryInfoProviderFromRuntime(FREE_MEMORY_UPDATE_INTERVAL_MS);
 
-  public MemoryInfoProviderFromRuntime(long freeMemoryUpdateIntervalMs) {
+  private MemoryInfoProviderFromRuntime(long freeMemoryUpdateIntervalMs) {
     maxMemory = Runtime.getRuntime().maxMemory();
     totalFreeMemory =
         Runtime.getRuntime().freeMemory() + (maxMemory - Runtime.getRuntime().totalMemory());
@@ -33,6 +35,10 @@ public class MemoryInfoProviderFromRuntime implements MemoryInfoProvider {
   private void updateFreeMemory() {
     totalFreeMemory =
         Runtime.getRuntime().freeMemory() + (maxMemory - Runtime.getRuntime().totalMemory());
+  }
+
+  public static MemoryInfoProviderFromRuntime getInstance() {
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProviderFromRuntime.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProviderFromRuntime.java
@@ -14,7 +14,8 @@ public class MemoryInfoProviderFromRuntime implements MemoryInfoProvider {
   private volatile long totalFreeMemory;
   private final ScheduledExecutorService executorService;
   private static final long FREE_MEMORY_UPDATE_INTERVAL_MS = 1000;
-  private static final MemoryInfoProviderFromRuntime INSTANCE = new MemoryInfoProviderFromRuntime(FREE_MEMORY_UPDATE_INTERVAL_MS);
+  private static final MemoryInfoProviderFromRuntime INSTANCE =
+      new MemoryInfoProviderFromRuntime(FREE_MEMORY_UPDATE_INTERVAL_MS);
 
   private MemoryInfoProviderFromRuntime(long freeMemoryUpdateIntervalMs) {
     maxMemory = Runtime.getRuntime().maxMemory();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProviderFromRuntime.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/MemoryInfoProviderFromRuntime.java
@@ -13,7 +13,7 @@ public class MemoryInfoProviderFromRuntime implements MemoryInfoProvider {
   private final long maxMemory;
   private volatile long totalFreeMemory;
   private final ScheduledExecutorService executorService;
-  private static final long FREE_MEMORY_UPDATE_INTERVAL_MS = 1000;
+  private static final long FREE_MEMORY_UPDATE_INTERVAL_MS = 100;
   private static final MemoryInfoProviderFromRuntime INSTANCE =
       new MemoryInfoProviderFromRuntime(FREE_MEMORY_UPDATE_INTERVAL_MS);
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -66,7 +66,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   private String invalidationCause;
 
   private final MemoryInfoProvider memoryInfoProvider;
-  private volatile long freeMemory = 0;
+  private volatile long freeMemoryInBytes = 0;
 
   /**
    * Constructor for TESTING ONLY which allows us to set the test mode
@@ -493,10 +493,10 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
         maxMemoryLimitInBytes == MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT
             ? memoryInfoProvider.getMaxMemory()
             : maxMemoryLimitInBytes;
-    freeMemory = memoryInfoProvider.getFreeMemory();
+    freeMemoryInBytes = memoryInfoProvider.getFreeMemory();
     boolean hasLowRuntimeMemory =
-        freeMemory < insertThrottleThresholdInBytes
-            && freeMemory * 100 / maxMemory < insertThrottleThresholdInPercentage;
+        freeMemoryInBytes < insertThrottleThresholdInBytes
+            && freeMemoryInBytes * 100 / maxMemory < insertThrottleThresholdInPercentage;
     if (hasLowRuntimeMemory) {
       logger.logWarn(
           "Throttled due to memory pressure, client={}, channel={}.",

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -138,7 +138,7 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
     this.maxMemoryLimitInBytes =
         this.owningClient.getParameterProvider().getMaxMemoryLimitInBytes();
 
-    this.memoryInfoProvider = new MemoryInfoProviderFromRuntime(insertThrottleIntervalInMs);
+    this.memoryInfoProvider = MemoryInfoProviderFromRuntime.getInstance();
     this.channelFlushContext =
         new ChannelFlushContext(
             name, dbName, schemaName, tableName, channelSequencer, encryptionKey, encryptionKeyId);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -128,14 +128,15 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
       OffsetTokenVerificationFunction offsetTokenVerificationFunction) {
     this.isClosed = false;
     this.owningClient = client;
+
     this.insertThrottleIntervalInMs =
-            this.owningClient.getParameterProvider().getInsertThrottleIntervalInMs();
+        this.owningClient.getParameterProvider().getInsertThrottleIntervalInMs();
     this.insertThrottleThresholdInBytes =
-            this.owningClient.getParameterProvider().getInsertThrottleThresholdInBytes();
+        this.owningClient.getParameterProvider().getInsertThrottleThresholdInBytes();
     this.insertThrottleThresholdInPercentage =
-            this.owningClient.getParameterProvider().getInsertThrottleThresholdInPercentage();
+        this.owningClient.getParameterProvider().getInsertThrottleThresholdInPercentage();
     this.maxMemoryLimitInBytes =
-            this.owningClient.getParameterProvider().getMaxMemoryLimitInBytes();
+        this.owningClient.getParameterProvider().getMaxMemoryLimitInBytes();
 
     this.memoryInfoProvider = new MemoryInfoProviderFromRuntime(insertThrottleIntervalInMs);
     this.channelFlushContext =

--- a/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
@@ -31,7 +31,7 @@ public class InsertRowsBenchmarkTest {
   private SnowflakeStreamingIngestChannelInternal<?> channel;
   private SnowflakeStreamingIngestClientInternal<?> client;
 
-  @Param({"1000000"})
+  @Param({"100000"})
   private int numRows;
 
   @Setup(Level.Trial)

--- a/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
@@ -1,0 +1,124 @@
+package net.snowflake.ingest.streaming.internal;
+
+import net.snowflake.ingest.streaming.InsertValidationResponse;
+import net.snowflake.ingest.streaming.OpenChannelRequest;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import net.snowflake.ingest.utils.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static java.time.ZoneOffset.UTC;
+
+@State(Scope.Thread)
+public class InsertRowsBenchmarkTest {
+
+        private SnowflakeStreamingIngestChannelInternal<?> channel;
+        private SnowflakeStreamingIngestClientInternal<?> client;
+
+        @Param({"1000000"})
+        private int numRows;
+
+        @Setup(Level.Trial)
+        public void setUpBeforeAll() {
+            client = new SnowflakeStreamingIngestClientInternal<ParquetChunkData>("client_PARQUET");
+            channel =
+                    new SnowflakeStreamingIngestChannelInternal<>(
+                            "channel",
+                            "db",
+                            "schema",
+                            "table",
+                            "0",
+                            0L,
+                            0L,
+                            client,
+                            "key",
+                            1234L,
+                            OpenChannelRequest.OnErrorOption.CONTINUE,
+                            UTC);
+            // Setup column fields and vectors
+            ColumnMetadata col = new ColumnMetadata();
+            col.setOrdinal(1);
+            col.setName("COL");
+            col.setPhysicalType("SB16");
+            col.setNullable(false);
+            col.setLogicalType("FIXED");
+            col.setPrecision(38);
+            col.setScale(0);
+
+            channel.setupSchema(Collections.singletonList(col));
+            assert Utils.getProvider() != null;
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDownAfterAll() throws Exception {
+            channel.close();
+            client.close();
+        }
+
+        @Benchmark
+        public void testInsertRow() {
+            Map<String, Object> row = new HashMap<>();
+            row.put("col", 1);
+
+            for (int i = 0; i < numRows; i++) {
+                InsertValidationResponse response = channel.insertRow(row, String.valueOf(i));
+                Assert.assertFalse(response.hasErrors());
+            }
+        }
+
+        @Test
+        public void insertRow () throws Exception {
+            setUpBeforeAll();
+            Map<String, Object> row = new HashMap<>();
+            row.put("col", 1);
+
+            for (int i = 0; i < 1000000; i++) {
+                InsertValidationResponse response = channel.insertRow(row, String.valueOf(i));
+                Assert.assertFalse(response.hasErrors());
+            }
+            tearDownAfterAll();
+        }
+
+        @Test
+        public void launchBenchmark() throws RunnerException {
+            Options opt = new OptionsBuilder()
+                    // Specify which benchmarks to run.
+                    // You can be more specific if you'd like to run only one benchmark per test.
+                    .include(this.getClass().getName() + ".*")
+                    // Set the following options as needed
+                    .mode (Mode.AverageTime)
+                    .timeUnit(TimeUnit.MICROSECONDS)
+                    .warmupTime(TimeValue.seconds(1))
+                    .warmupIterations(2)
+                    .measurementTime(TimeValue.seconds(1))
+                    .measurementIterations(5)
+                    .threads(2)
+                    .forks(1)
+                    .shouldFailOnError(true)
+                    .shouldDoGC(true)
+                    //.jvmArgs("-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining")
+                    //.addProfiler(WinPerfAsmProfiler.class)
+                    .build();
+
+            new Runner(opt).run();
+        }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
@@ -1,9 +1,13 @@
 package net.snowflake.ingest.streaming.internal;
 
+import static java.time.ZoneOffset.UTC;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
-import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
-import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
 import net.snowflake.ingest.utils.Utils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -21,104 +25,98 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import static java.time.ZoneOffset.UTC;
-
 @State(Scope.Thread)
 public class InsertRowsBenchmarkTest {
 
-        private SnowflakeStreamingIngestChannelInternal<?> channel;
-        private SnowflakeStreamingIngestClientInternal<?> client;
+  private SnowflakeStreamingIngestChannelInternal<?> channel;
+  private SnowflakeStreamingIngestClientInternal<?> client;
 
-        @Param({"1000000"})
-        private int numRows;
+  @Param({"1000000"})
+  private int numRows;
 
-        @Setup(Level.Trial)
-        public void setUpBeforeAll() {
-            client = new SnowflakeStreamingIngestClientInternal<ParquetChunkData>("client_PARQUET");
-            channel =
-                    new SnowflakeStreamingIngestChannelInternal<>(
-                            "channel",
-                            "db",
-                            "schema",
-                            "table",
-                            "0",
-                            0L,
-                            0L,
-                            client,
-                            "key",
-                            1234L,
-                            OpenChannelRequest.OnErrorOption.CONTINUE,
-                            UTC);
-            // Setup column fields and vectors
-            ColumnMetadata col = new ColumnMetadata();
-            col.setOrdinal(1);
-            col.setName("COL");
-            col.setPhysicalType("SB16");
-            col.setNullable(false);
-            col.setLogicalType("FIXED");
-            col.setPrecision(38);
-            col.setScale(0);
+  @Setup(Level.Trial)
+  public void setUpBeforeAll() {
+    client = new SnowflakeStreamingIngestClientInternal<ParquetChunkData>("client_PARQUET");
+    channel =
+        new SnowflakeStreamingIngestChannelInternal<>(
+            "channel",
+            "db",
+            "schema",
+            "table",
+            "0",
+            0L,
+            0L,
+            client,
+            "key",
+            1234L,
+            OpenChannelRequest.OnErrorOption.CONTINUE,
+            UTC);
+    // Setup column fields and vectors
+    ColumnMetadata col = new ColumnMetadata();
+    col.setOrdinal(1);
+    col.setName("COL");
+    col.setPhysicalType("SB16");
+    col.setNullable(false);
+    col.setLogicalType("FIXED");
+    col.setPrecision(38);
+    col.setScale(0);
 
-            channel.setupSchema(Collections.singletonList(col));
-            assert Utils.getProvider() != null;
-        }
+    channel.setupSchema(Collections.singletonList(col));
+    assert Utils.getProvider() != null;
+  }
 
-        @TearDown(Level.Trial)
-        public void tearDownAfterAll() throws Exception {
-            channel.close();
-            client.close();
-        }
+  @TearDown(Level.Trial)
+  public void tearDownAfterAll() throws Exception {
+    channel.close();
+    client.close();
+  }
 
-        @Benchmark
-        public void testInsertRow() {
-            Map<String, Object> row = new HashMap<>();
-            row.put("col", 1);
+  @Benchmark
+  public void testInsertRow() {
+    Map<String, Object> row = new HashMap<>();
+    row.put("col", 1);
 
-            for (int i = 0; i < numRows; i++) {
-                InsertValidationResponse response = channel.insertRow(row, String.valueOf(i));
-                Assert.assertFalse(response.hasErrors());
-            }
-        }
+    for (int i = 0; i < numRows; i++) {
+      InsertValidationResponse response = channel.insertRow(row, String.valueOf(i));
+      Assert.assertFalse(response.hasErrors());
+    }
+  }
 
-        @Test
-        public void insertRow () throws Exception {
-            setUpBeforeAll();
-            Map<String, Object> row = new HashMap<>();
-            row.put("col", 1);
+  @Test
+  public void insertRow() throws Exception {
+    setUpBeforeAll();
+    Map<String, Object> row = new HashMap<>();
+    row.put("col", 1);
 
-            for (int i = 0; i < 1000000; i++) {
-                InsertValidationResponse response = channel.insertRow(row, String.valueOf(i));
-                Assert.assertFalse(response.hasErrors());
-            }
-            tearDownAfterAll();
-        }
+    for (int i = 0; i < 1000000; i++) {
+      InsertValidationResponse response = channel.insertRow(row, String.valueOf(i));
+      Assert.assertFalse(response.hasErrors());
+    }
+    tearDownAfterAll();
+  }
 
-        @Test
-        public void launchBenchmark() throws RunnerException {
-            Options opt = new OptionsBuilder()
-                    // Specify which benchmarks to run.
-                    // You can be more specific if you'd like to run only one benchmark per test.
-                    .include(this.getClass().getName() + ".*")
-                    // Set the following options as needed
-                    .mode (Mode.AverageTime)
-                    .timeUnit(TimeUnit.MICROSECONDS)
-                    .warmupTime(TimeValue.seconds(1))
-                    .warmupIterations(2)
-                    .measurementTime(TimeValue.seconds(1))
-                    .measurementIterations(5)
-                    .threads(2)
-                    .forks(1)
-                    .shouldFailOnError(true)
-                    .shouldDoGC(true)
-                    //.jvmArgs("-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining")
-                    //.addProfiler(WinPerfAsmProfiler.class)
-                    .build();
+  @Test
+  public void launchBenchmark() throws RunnerException {
+    Options opt =
+        new OptionsBuilder()
+            // Specify which benchmarks to run.
+            // You can be more specific if you'd like to run only one benchmark per test.
+            .include(this.getClass().getName() + ".*")
+            // Set the following options as needed
+            .mode(Mode.AverageTime)
+            .timeUnit(TimeUnit.MICROSECONDS)
+            .warmupTime(TimeValue.seconds(1))
+            .warmupIterations(2)
+            .measurementTime(TimeValue.seconds(1))
+            .measurementIterations(10)
+            .threads(2)
+            .forks(1)
+            .shouldFailOnError(true)
+            .shouldDoGC(true)
+            // .jvmArgs("-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining")
+            // .addProfiler(WinPerfAsmProfiler.class)
+            .build();
 
-            new Runner(opt).run();
-        }
+    new Runner(opt).run();
+  }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -62,11 +62,6 @@ public class SnowflakeStreamingIngestChannelTest {
     }
 
     @Override
-    public long getTotalMemory() {
-      return maxMemory;
-    }
-
-    @Override
     public long getFreeMemory() {
       return freeMemory;
     }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -80,9 +80,27 @@ public class SnowflakeStreamingIngestClientTest {
   SnowflakeStreamingIngestChannelInternal<StubChunkData> channel4;
 
   @Before
-  public void setup() {
+  public void setup() throws Exception {
     objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.ANY);
     objectMapper.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.ANY);
+    Properties prop = new Properties();
+    prop.put(USER, TestUtils.getUser());
+    prop.put(ACCOUNT_URL, TestUtils.getHost());
+    prop.put(PRIVATE_KEY, TestUtils.getPrivateKey());
+    prop.put(ROLE, TestUtils.getRole());
+
+    CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+    RequestBuilder requestBuilder =
+        new RequestBuilder(TestUtils.getHost(), TestUtils.getUser(), TestUtils.getKeyPair());
+    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
+        new SnowflakeStreamingIngestClientInternal<>(
+            "client",
+            new SnowflakeURL("snowflake.dev.local:8082"),
+            null,
+            httpClient,
+            true,
+            requestBuilder,
+            null);
     channel1 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel1",
@@ -92,7 +110,7 @@ public class SnowflakeStreamingIngestClientTest {
             "0",
             0L,
             0L,
-            null,
+            client,
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
@@ -108,7 +126,7 @@ public class SnowflakeStreamingIngestClientTest {
             "0",
             2L,
             0L,
-            null,
+            client,
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
@@ -124,7 +142,7 @@ public class SnowflakeStreamingIngestClientTest {
             "0",
             3L,
             0L,
-            null,
+            client,
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
@@ -140,7 +158,7 @@ public class SnowflakeStreamingIngestClientTest {
             "0",
             3L,
             0L,
-            null,
+            client,
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
@@ -357,7 +375,7 @@ public class SnowflakeStreamingIngestClientTest {
             "0",
             0L,
             0L,
-            null,
+            client,
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
@@ -461,7 +479,7 @@ public class SnowflakeStreamingIngestClientTest {
             "0",
             0L,
             0L,
-            null,
+            client,
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
@@ -494,6 +512,16 @@ public class SnowflakeStreamingIngestClientTest {
     RequestBuilder requestBuilder =
         new RequestBuilder(url, prop.get(USER).toString(), keyPair, null, null);
 
+    CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+    SnowflakeStreamingIngestClientInternal<?> client =
+        new SnowflakeStreamingIngestClientInternal<>(
+            "client",
+            new SnowflakeURL("snowflake.dev.local:8082"),
+            null,
+            httpClient,
+            true,
+            requestBuilder,
+            null);
     SnowflakeStreamingIngestChannelInternal<?> channel =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel",
@@ -503,7 +531,7 @@ public class SnowflakeStreamingIngestClientTest {
             "0",
             0L,
             0L,
-            null,
+            client,
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
@@ -1426,7 +1454,7 @@ public class SnowflakeStreamingIngestClientTest {
             "0",
             0L,
             0L,
-            null,
+            client,
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,


### PR DESCRIPTION
Here are the changes in order of high impact to low:
- Use pre-computed powers of 10 instead of computing it fresh for every insertRows call. 
- Periodically compute free memory in the system instead of on-demand.
- Use a for-loop instead of stream and collect in `verifyInputColumns`
- Cache numAvailableProcessors in FlushService.
- Cache parameters used in the hot path in `insertRows`.

I wrote a simple JMH benchmark to measure these changes - see `InsertRowsBenchmarkTest`. This benchmark inserts 1M rows in a tight loop and each row has a single sb16 column. Overall, 35-40% improvement in this benchmark observed. The benchmark results should carry over to real world workloads that have sb16 columns and the improvement in the memory tracking will transfer over to all workloads. 

Before:
```
# Warmup Iteration   1: 1822464.171 us/op
# Warmup Iteration   2: 1835477.606 us/op
Iteration   1: 1592362.119 us/op
Iteration   2: 1675821.530 us/op
Iteration   3: 1698952.582 us/op
Iteration   4: 1728100.495 us/op
Iteration   5: 1527890.615 us/op
Iteration   6: 1530390.389 us/op
Iteration   7: 2039346.448 us/op
Iteration   8: 1846764.755 us/op
Iteration   9: 1514480.481 us/op
Iteration  10: 1510466.306 us/op


Result "net.snowflake.ingest.streaming.internal.InsertRowsBenchmarkTest.testInsertRow":
  1666457.572 ±(99.9%) 260468.722 us/op [Average]
  (min, avg, max) = (1510466.306, 1666457.572, 2039346.448), stdev = 172283.933
  CI (99.9%): [1405988.850, 1926926.294] (assumes normal distribution)

# Run complete. Total time: 00:01:07

Benchmark                              (numRows)  Mode  Cnt        Score        Error  Units
InsertRowsBenchmarkTest.testInsertRow    1000000  avgt   10  1666457.572 ± 260468.722  us/op
```

After:

```
# Warmup Iteration   1: 1139006.469 us/op
# Warmup Iteration   2: 1132933.357 us/op
Iteration   1: 987257.653 us/op
Iteration   2: 1070616.846 us/op
Iteration   3: 982547.952 us/op
Iteration   4: 1225079.558 us/op
Iteration   5: 1198002.424 us/op
Iteration   6: 976386.714 us/op
Iteration   7: 964823.936 us/op
Iteration   8: 1141437.334 us/op
Iteration   9: 1292684.431 us/op
Iteration  10: 940295.781 us/op


Result "net.snowflake.ingest.streaming.internal.InsertRowsBenchmarkTest.testInsertRow":
  1077913.263 ±(99.9%) 192324.330 us/op [Average]
  (min, avg, max) = (940295.781, 1077913.263, 1292684.431), stdev = 127210.636
  CI (99.9%): [885588.933, 1270237.593] (assumes normal distribution)


# Run complete. Total time: 00:00:51

Benchmark                              (numRows)  Mode  Cnt        Score        Error  Units
InsertRowsBenchmarkTest.testInsertRow    1000000  avgt   10  1077913.263 ± 192324.330  us/op
``` 