### PR TITLE
Reject new stage metadata if the deployment id does not match what the client was created with

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestStage.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestStage.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 import net.snowflake.client.core.OCSPMode;
 import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
 import net.snowflake.client.jdbc.SnowflakeFileTransferConfig;
@@ -91,6 +92,7 @@ class StreamingIngestStage {
   private final String role;
   private final String clientName;
   private String clientPrefix;
+  private Long deploymentId;
 
   private final int maxUploadRetries;
 
@@ -258,9 +260,11 @@ class StreamingIngestStage {
     payload.put("role", this.role);
     Map<String, Object> response = this.makeClientConfigureCall(payload);
 
-    JsonNode responseNode = this.parseClientConfigureResponse(response);
+    JsonNode responseNode = this.parseClientConfigureResponse(response, this.deploymentId);
     // Do not change the prefix everytime we have to refresh credentials
     if (Utils.isNullOrEmpty(this.clientPrefix)) {
+      this.deploymentId =
+          responseNode.has("deployment_id") ? responseNode.get("deployment_id").longValue() : null;
       this.clientPrefix = createClientPrefix(responseNode);
     }
     Utils.assertStringNotNullOrEmpty("client prefix", this.clientPrefix);
@@ -326,7 +330,7 @@ class StreamingIngestStage {
     payload.put("file_name", fileName);
     Map<String, Object> response = this.makeClientConfigureCall(payload);
 
-    JsonNode responseNode = this.parseClientConfigureResponse(response);
+    JsonNode responseNode = this.parseClientConfigureResponse(response, this.deploymentId);
 
     SnowflakeFileTransferMetadataV1 metadata =
         (SnowflakeFileTransferMetadataV1)
@@ -350,7 +354,8 @@ class StreamingIngestStage {
 
   private static final MapStatusGetter statusGetter = new MapStatusGetter();
 
-  private JsonNode parseClientConfigureResponse(Map<String, Object> response) {
+  private JsonNode parseClientConfigureResponse(
+      Map<String, Object> response, @Nullable Long expectedDeploymentId) {
     JsonNode responseNode = mapper.valueToTree(response);
 
     // Currently there are a few mismatches between the client/configure response and what
@@ -362,6 +367,14 @@ class StreamingIngestStage {
 
     // JDBC expects this field which maps to presignedFileUrlName.  We will set this later
     dataNode.putArray("src_locations").add("placeholder");
+    if (expectedDeploymentId != null) {
+      Long actualDeploymentId =
+          responseNode.has("deployment_id") ? responseNode.get("deployment_id").longValue() : null;
+      if (actualDeploymentId != null && !actualDeploymentId.equals(expectedDeploymentId)) {
+        throw new SFException(
+            ErrorCode.CLIENT_DEPLOYMENT_ID_MISMATCH, expectedDeploymentId, actualDeploymentId);
+      }
+    }
     return responseNode;
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestStage.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestStage.java
@@ -372,7 +372,10 @@ class StreamingIngestStage {
           responseNode.has("deployment_id") ? responseNode.get("deployment_id").longValue() : null;
       if (actualDeploymentId != null && !actualDeploymentId.equals(expectedDeploymentId)) {
         throw new SFException(
-            ErrorCode.CLIENT_DEPLOYMENT_ID_MISMATCH, expectedDeploymentId, actualDeploymentId);
+            ErrorCode.CLIENT_DEPLOYMENT_ID_MISMATCH,
+            expectedDeploymentId,
+            actualDeploymentId,
+            clientName);
       }
     }
     return responseNode;

--- a/src/main/java/net/snowflake/ingest/utils/ErrorCode.java
+++ b/src/main/java/net/snowflake/ingest/utils/ErrorCode.java
@@ -41,7 +41,9 @@ public enum ErrorCode {
   OAUTH_REFRESH_TOKEN_ERROR("0033"),
   INVALID_CONFIG_PARAMETER("0034"),
   CRYPTO_PROVIDER_ERROR("0035"),
-  DROP_CHANNEL_FAILURE("0036");
+  DROP_CHANNEL_FAILURE("0036"),
+
+  CLIENT_DEPLOYMENT_ID_MISMATCH("0037");
 
   public static final String errorMessageResource = "net.snowflake.ingest.ingest_error_messages";
 

--- a/src/main/java/net/snowflake/ingest/utils/ErrorCode.java
+++ b/src/main/java/net/snowflake/ingest/utils/ErrorCode.java
@@ -42,7 +42,6 @@ public enum ErrorCode {
   INVALID_CONFIG_PARAMETER("0034"),
   CRYPTO_PROVIDER_ERROR("0035"),
   DROP_CHANNEL_FAILURE("0036"),
-
   CLIENT_DEPLOYMENT_ID_MISMATCH("0037");
 
   public static final String errorMessageResource = "net.snowflake.ingest.ingest_error_messages";

--- a/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
+++ b/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
@@ -37,5 +37,6 @@
 0032=URI builder fail to build url: {0}
 0033=OAuth token refresh failure: {0}
 0034=Invalid config parameter: {0}
-0035=Too large batch of rows passed to insertRows, the batch size cannot exceed {0} bytes, recommended batch size for optimal performance and memory utilization is {1} bytes. We recommend splitting large batches into multiple smaller ones and call insertRows for each smaller batch separately.
-0036=Failed to load {0}. If you use FIPS, import BouncyCastleFipsProvider in the application: {1}
+0035=Failed to load {0}. If you use FIPS, import BouncyCastleFipsProvider in the application: {1}
+0036=Failed to drop channel: {0}
+0037=Deployment ID mismatch, Client was created on: {0}, Got upload location for: {1}. Please restart client.

--- a/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
+++ b/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
@@ -39,4 +39,4 @@
 0034=Invalid config parameter: {0}
 0035=Failed to load {0}. If you use FIPS, import BouncyCastleFipsProvider in the application: {1}
 0036=Failed to drop channel: {0}
-0037=Deployment ID mismatch, Client was created on: {0}, Got upload location for: {1}. Please restart client.
+0037=Deployment ID mismatch, Client was created on: {0}, Got upload location for: {1}. Please restart client: {2}.

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestStageTest.java
@@ -360,7 +360,7 @@ public class StreamingIngestStageTest {
             + ", Got upload location for: "
             + (deploymentId + 1)
             + ". Please"
-            + " restart client.",
+            + " restart client: clientName.",
         exception.getMessage());
   }
 


### PR DESCRIPTION
This prevents issues when there is transparent failover using Client Redirect or another similar mechanism. Along the way, I found some missing/misconfigured error message resource and fixed them. 

