### PR TITLE
SNOW-1512935 Reduce client socket timeout from 5 minutes to 1 minute

### DIFF
--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -79,7 +79,7 @@ public class HttpUtil {
   private static final ReentrantLock idleConnectionMonitorThreadLock = new ReentrantLock(true);
 
   private static final int DEFAULT_CONNECTION_TIMEOUT_MINUTES = 1;
-  private static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT_MINUTES = 5;
+  private static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT_MINUTES = 1;
 
   /**
    * After how many seconds of inactivity should be idle connections evicted from the connection


### PR DESCRIPTION
This PR reduces the timeout of waiting for a packet from 5 minutes to 1 minute. 5 minutes is too high, if there is a problem with the connection, it is better to give up earlier and retry.