### PR TITLE
SNOW-1545879 Reduce the max channel/chunk sizes

### DIFF
--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -50,8 +50,8 @@ public class ParameterProvider {
   public static final int IO_TIME_CPU_RATIO_DEFAULT = 2;
   public static final int BLOB_UPLOAD_MAX_RETRY_COUNT_DEFAULT = 24;
   public static final long MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT = -1L;
-  public static final long MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT = 128 * 1024 * 1024;
-  public static final long MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 512 * 1024 * 1024;
+  public static final long MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT = 64 * 1024 * 1024;
+  public static final long MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 256 * 1024 * 1024;
 
   // Lag related parameters
   public static final long MAX_CLIENT_LAG_DEFAULT = 1000; // 1 second

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -8,6 +8,7 @@ import static net.snowflake.ingest.utils.Constants.USER;
 import static net.snowflake.ingest.utils.ParameterProvider.BDEC_PARQUET_COMPRESSION_ALGORITHM;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.atLeastOnce;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -187,7 +188,7 @@ public class StreamingIngestIT {
     // verify expected request sent to server
     String[] expectedPayloadParams = {"request_id", "blobs", "role", "blob_stats"};
     for (String expectedParam : expectedPayloadParams) {
-      Mockito.verify(requestBuilder)
+      Mockito.verify(requestBuilder, atLeastOnce())
           .generateStreamingIngestPostRequest(
               ArgumentMatchers.contains(expectedParam),
               ArgumentMatchers.refEq(REGISTER_BLOB_ENDPOINT),


### PR DESCRIPTION
We [previously](https://github.com/snowflakedb/snowflake-ingest-java/pull/730) increased the limits 4 times, which turned out to cause OOMs in some cases where memory is limited, so this PR reduces the limits by 1/2, which is still double of the original values. 

This PR also fixes a flaky test. 