### PR TITLE
SNOW-1618257 Fix PRIMARY_FILE_ID_KEY

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
@@ -5,6 +5,7 @@
 package net.snowflake.ingest.streaming.internal;
 
 import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.parquet.hadoop.BdecParquetWriter;
@@ -34,6 +35,16 @@ public class ParquetChunkData {
     this.rows = rows;
     this.parquetWriter = parquetWriter;
     this.output = output;
-    this.metadata = metadata;
+    // create a defensive copy of the parameter map because the argument map passed here
+    // may currently be shared across multiple threads.
+    this.metadata = createDefensiveCopy(metadata);
+  }
+
+  private Map<String, String> createDefensiveCopy(final Map<String, String> metadata) {
+    final Map<String, String> copy = new HashMap<>(metadata);
+    for (String k : metadata.keySet()) {
+      copy.put(k, metadata.get(k));
+    }
+    return copy;
   }
 }


### PR DESCRIPTION
As part of the investigation for https://snowflakecomputing.atlassian.net/browse/SNOW-1506753 we discovered that the SDK has a concurrency issue when populating the `PRIMARY_FILE_ID_KEY` and there are concurrent uploads due to high load. 

In a nutshell, the problem is that the `ParquetRowBuffer#metadata` which is a map that contains some metadata that will be written as parquet metadata in the BDEC file, is shared across all uploading threads. So if one of those threads changes it, the others will see the changes. One of those metadata is also the  `PRIMARY_FILE_ID_KEY`.