### PR TITLE
SNOW-1566045 Preserve numeric format for variants

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,6 +426,10 @@
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
 
     <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->
     <dependency>

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
@@ -16,6 +16,8 @@ public class ClientBufferParameters {
 
   private long maxAllowedRowSizeInBytes;
 
+  private final boolean enableNewJsonParsingLogic;
+
   private Constants.BdecParquetCompression bdecParquetCompression;
 
   /**
@@ -30,11 +32,13 @@ public class ClientBufferParameters {
       boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
       long maxAllowedRowSizeInBytes,
-      Constants.BdecParquetCompression bdecParquetCompression) {
+      Constants.BdecParquetCompression bdecParquetCompression,
+      boolean enableNewJsonParsingLogic) {
     this.enableParquetInternalBuffering = enableParquetInternalBuffering;
     this.maxChunkSizeInBytes = maxChunkSizeInBytes;
     this.maxAllowedRowSizeInBytes = maxAllowedRowSizeInBytes;
     this.bdecParquetCompression = bdecParquetCompression;
+    this.enableNewJsonParsingLogic = enableNewJsonParsingLogic;
   }
 
   /** @param clientInternal reference to the client object where the relevant parameters are set */
@@ -55,6 +59,11 @@ public class ClientBufferParameters {
         clientInternal != null
             ? clientInternal.getParameterProvider().getBdecParquetCompressionAlgorithm()
             : ParameterProvider.BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT;
+
+    this.enableNewJsonParsingLogic =
+        clientInternal != null
+            ? clientInternal.getParameterProvider().isEnableNewJsonParsingLogic()
+            : ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT;
   }
 
   /**
@@ -68,12 +77,14 @@ public class ClientBufferParameters {
       boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
       long maxAllowedRowSizeInBytes,
-      Constants.BdecParquetCompression bdecParquetCompression) {
+      Constants.BdecParquetCompression bdecParquetCompression,
+      boolean enableNewJsonParsingLogic) {
     return new ClientBufferParameters(
         enableParquetInternalBuffering,
         maxChunkSizeInBytes,
         maxAllowedRowSizeInBytes,
-        bdecParquetCompression);
+        bdecParquetCompression,
+        enableNewJsonParsingLogic);
   }
 
   public boolean getEnableParquetInternalBuffering() {
@@ -90,5 +101,9 @@ public class ClientBufferParameters {
 
   public Constants.BdecParquetCompression getBdecParquetCompression() {
     return bdecParquetCompression;
+  }
+
+  public boolean isEnableNewJsonParsingLogic() {
+    return enableNewJsonParsingLogic;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -207,7 +207,13 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       ColumnMetadata column = parquetColumn.columnMetadata;
       ParquetValueParser.ParquetBufferValue valueWithSize =
           ParquetValueParser.parseColumnValueToParquet(
-              value, column, parquetColumn.type, forkedStats, defaultTimezone, insertRowsCurrIndex);
+              value,
+              column,
+              parquetColumn.type,
+              forkedStats,
+              defaultTimezone,
+              insertRowsCurrIndex,
+              clientBufferParameters.isEnableNewJsonParsingLogic());
       indexedRow[colIndex] = valueWithSize.getValue();
       size += valueWithSize.getSize();
     }

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -46,6 +46,9 @@ public class ParameterProvider {
   public static final String BDEC_PARQUET_COMPRESSION_ALGORITHM =
       "BDEC_PARQUET_COMPRESSION_ALGORITHM".toLowerCase();
 
+  public static final String ENABLE_NEW_JSON_PARSING_LOGIC =
+      "ENABLE_NEW_JSON_PARSING_LOGIC".toLowerCase();
+
   // Default values
   public static final long BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT = 100;
   public static final long INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT = 1000;
@@ -79,6 +82,8 @@ public class ParameterProvider {
   /* Parameter that enables using internal Parquet buffers for buffering of rows before serializing.
   It reduces memory consumption compared to using Java Objects for buffering.*/
   public static final boolean ENABLE_PARQUET_INTERNAL_BUFFERING_DEFAULT = false;
+
+  public static final boolean ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT = true;
 
   /** Map of parameter name to parameter value. This will be set by client/configure API Call. */
   private final Map<String, Object> parameterMap = new HashMap<>();
@@ -248,6 +253,13 @@ public class ParameterProvider {
     this.checkAndUpdate(
         BDEC_PARQUET_COMPRESSION_ALGORITHM,
         BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT,
+        parameterOverrides,
+        props,
+        false);
+
+    this.checkAndUpdate(
+        ENABLE_NEW_JSON_PARSING_LOGIC,
+        ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT,
         parameterOverrides,
         props,
         false);
@@ -484,6 +496,14 @@ public class ParameterProvider {
       return (Constants.BdecParquetCompression) val;
     }
     return Constants.BdecParquetCompression.fromName((String) val);
+  }
+
+  /** @return Whether new JSON parsing logic, which preserves */
+  public boolean isEnableNewJsonParsingLogic() {
+    Object val =
+        this.parameterMap.getOrDefault(
+            ENABLE_NEW_JSON_PARSING_LOGIC, ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
+    return (val instanceof String) ? Boolean.parseBoolean(val.toString()) : (boolean) val;
   }
 
   @Override

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -403,4 +403,22 @@ public class ParameterProviderTest {
           e.getMessage());
     }
   }
+
+  @Test
+  public void EnableNewJsonParsingLogicAsBool() {
+    Properties prop = new Properties();
+    Map<String, Object> parameterMap = getStartingParameterMap();
+    parameterMap.put(ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC, false);
+    ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop, isIcebergMode);
+    Assert.assertFalse(parameterProvider.isEnableNewJsonParsingLogic());
+  }
+
+  @Test
+  public void EnableNewJsonParsingLogicAsString() {
+    Properties prop = new Properties();
+    Map<String, Object> parameterMap = getStartingParameterMap();
+    parameterMap.put(ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC, "false");
+    ParameterProvider parameterProvider = new ParameterProvider(parameterMap, prop, isIcebergMode);
+    Assert.assertFalse(parameterProvider.isEnableNewJsonParsingLogic());
+  }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserTest.java
@@ -10,6 +10,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.schema.PrimitiveType;
 import org.junit.Assert;
@@ -31,7 +32,13 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            12, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0);
+            12,
+            testCol,
+            PrimitiveType.PrimitiveTypeName.INT32,
+            rowBufferStats,
+            UTC,
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -57,7 +64,13 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            1234, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0);
+            1234,
+            testCol,
+            PrimitiveType.PrimitiveTypeName.INT32,
+            rowBufferStats,
+            UTC,
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -83,7 +96,13 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            123456789, testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0);
+            123456789,
+            testCol,
+            PrimitiveType.PrimitiveTypeName.INT32,
+            rowBufferStats,
+            UTC,
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -114,7 +133,8 @@ public class ParquetValueParserTest {
             PrimitiveType.PrimitiveTypeName.INT64,
             rowBufferStats,
             UTC,
-            0);
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -145,7 +165,8 @@ public class ParquetValueParserTest {
             PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
             rowBufferStats,
             UTC,
-            0);
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -178,7 +199,8 @@ public class ParquetValueParserTest {
             PrimitiveType.PrimitiveTypeName.DOUBLE,
             rowBufferStats,
             UTC,
-            0);
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -202,7 +224,13 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            12345.54321d, testCol, PrimitiveType.PrimitiveTypeName.DOUBLE, rowBufferStats, UTC, 0);
+            12345.54321d,
+            testCol,
+            PrimitiveType.PrimitiveTypeName.DOUBLE,
+            rowBufferStats,
+            UTC,
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -226,7 +254,13 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            true, testCol, PrimitiveType.PrimitiveTypeName.BOOLEAN, rowBufferStats, UTC, 0);
+            true,
+            testCol,
+            PrimitiveType.PrimitiveTypeName.BOOLEAN,
+            rowBufferStats,
+            UTC,
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -255,7 +289,8 @@ public class ParquetValueParserTest {
             PrimitiveType.PrimitiveTypeName.BINARY,
             rowBufferStats,
             UTC,
-            0);
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -270,15 +305,17 @@ public class ParquetValueParserTest {
 
   @Test
   public void parseValueVariantToBinary() {
-    testJsonWithLogicalType("VARIANT");
+    testJsonWithLogicalType("VARIANT", true);
+    testJsonWithLogicalType("VARIANT", false);
   }
 
   @Test
   public void parseValueObjectToBinary() {
-    testJsonWithLogicalType("OBJECT");
+    testJsonWithLogicalType("OBJECT", true);
+    testJsonWithLogicalType("OBJECT", false);
   }
 
-  private void testJsonWithLogicalType(String logicalType) {
+  private void testJsonWithLogicalType(String logicalType, boolean enableNewJsonParsingLogic) {
     ColumnMetadata testCol =
         ColumnMetadataBuilder.newBuilder()
             .logicalType(logicalType)
@@ -292,7 +329,13 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0);
+            var,
+            testCol,
+            PrimitiveType.PrimitiveTypeName.BINARY,
+            rowBufferStats,
+            UTC,
+            0,
+            enableNewJsonParsingLogic);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -309,20 +352,23 @@ public class ParquetValueParserTest {
 
   @Test
   public void parseValueNullVariantToBinary() {
-    testNullJsonWithLogicalType(null);
+    testNullJsonWithLogicalType(null, true);
+    testNullJsonWithLogicalType(null, false);
   }
 
   @Test
   public void parseValueEmptyStringVariantToBinary() {
-    testNullJsonWithLogicalType("");
+    testNullJsonWithLogicalType("", true);
+    testNullJsonWithLogicalType("", false);
   }
 
   @Test
   public void parseValueEmptySpaceStringVariantToBinary() {
-    testNullJsonWithLogicalType("     ");
+    testNullJsonWithLogicalType("     ", true);
+    testNullJsonWithLogicalType("     ", false);
   }
 
-  private void testNullJsonWithLogicalType(String var) {
+  private void testNullJsonWithLogicalType(String var, boolean enableNewJsonParsingLogic) {
     ColumnMetadata testCol =
         ColumnMetadataBuilder.newBuilder()
             .logicalType("VARIANT")
@@ -333,7 +379,13 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            var, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0);
+            var,
+            testCol,
+            PrimitiveType.PrimitiveTypeName.BINARY,
+            rowBufferStats,
+            UTC,
+            0,
+            enableNewJsonParsingLogic);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -348,6 +400,11 @@ public class ParquetValueParserTest {
 
   @Test
   public void parseValueArrayToBinary() {
+    parseValueArrayToBinaryInternal(false);
+    parseValueArrayToBinaryInternal(true);
+  }
+
+  public void parseValueArrayToBinaryInternal(boolean enableNewJsonParsingLogic) {
     ColumnMetadata testCol =
         ColumnMetadataBuilder.newBuilder()
             .logicalType("ARRAY")
@@ -363,7 +420,13 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            input, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0);
+            input,
+            testCol,
+            PrimitiveType.PrimitiveTypeName.BINARY,
+            rowBufferStats,
+            UTC,
+            0,
+            enableNewJsonParsingLogic);
 
     String resultArray = "[{\"a\":\"1\",\"b\":\"2\",\"c\":\"3\"}]";
 
@@ -395,7 +458,13 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            text, testCol, PrimitiveType.PrimitiveTypeName.BINARY, rowBufferStats, UTC, 0);
+            text,
+            testCol,
+            PrimitiveType.PrimitiveTypeName.BINARY,
+            rowBufferStats,
+            UTC,
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     String result = text;
 
@@ -434,7 +503,8 @@ public class ParquetValueParserTest {
                     PrimitiveType.PrimitiveTypeName.INT32,
                     rowBufferStats,
                     UTC,
-                    0));
+                    0,
+                    ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT));
     Assert.assertEquals(
         "Unknown data type for logical: TIMESTAMP_NTZ, physical: SB4.", exception.getMessage());
   }
@@ -458,7 +528,8 @@ public class ParquetValueParserTest {
             PrimitiveType.PrimitiveTypeName.INT64,
             rowBufferStats,
             UTC,
-            0);
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -488,7 +559,8 @@ public class ParquetValueParserTest {
             PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
             rowBufferStats,
             UTC,
-            0);
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -514,7 +586,13 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "2021-01-01", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0);
+            "2021-01-01",
+            testCol,
+            PrimitiveType.PrimitiveTypeName.INT32,
+            rowBufferStats,
+            UTC,
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -539,7 +617,13 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "01:00:00", testCol, PrimitiveType.PrimitiveTypeName.INT32, rowBufferStats, UTC, 0);
+            "01:00:00",
+            testCol,
+            PrimitiveType.PrimitiveTypeName.INT32,
+            rowBufferStats,
+            UTC,
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -564,7 +648,13 @@ public class ParquetValueParserTest {
     RowBufferStats rowBufferStats = new RowBufferStats("COL1");
     ParquetValueParser.ParquetBufferValue pv =
         ParquetValueParser.parseColumnValueToParquet(
-            "01:00:00.123", testCol, PrimitiveType.PrimitiveTypeName.INT64, rowBufferStats, UTC, 0);
+            "01:00:00.123",
+            testCol,
+            PrimitiveType.PrimitiveTypeName.INT64,
+            rowBufferStats,
+            UTC,
+            0,
+            ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT);
 
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
@@ -597,7 +687,8 @@ public class ParquetValueParserTest {
                     PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
                     rowBufferStats,
                     UTC,
-                    0));
+                    0,
+                    ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT));
     Assert.assertEquals(
         "Unknown data type for logical: TIME, physical: SB16.", exception.getMessage());
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -1,6 +1,7 @@
 package net.snowflake.ingest.streaming.internal;
 
 import static java.time.ZoneOffset.UTC;
+import static net.snowflake.ingest.utils.ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_CHUNK_SIZE_IN_BYTES_DEFAULT;
 import static org.junit.Assert.fail;
@@ -129,7 +130,8 @@ public class RowBufferTest {
             enableParquetMemoryOptimization,
             MAX_CHUNK_SIZE_IN_BYTES_DEFAULT,
             MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT,
-            Constants.BdecParquetCompression.GZIP),
+            Constants.BdecParquetCompression.GZIP,
+            ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT),
         null,
         null);
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
@@ -222,6 +222,30 @@ public class SemiStructuredIT extends AbstractDataTypeTest {
     assertVariant("ARRAY", Collections.singletonMap("1", "2"), "[{\"1\": \"2\"}]", "ARRAY");
   }
 
+  @Test
+  public void testNumberScientificNotation() throws Exception {
+    assertVariantLiterally("VARIANT", " 12.34\t\n", "12.34", "DECIMAL");
+
+    assertVariantLiterally("VARIANT", " 1.234e1\t\n", "1.234000000000000e+01", "DOUBLE");
+    assertVariantLiterally("VARIANT", " 1.234E1\t\n", "1.234000000000000e+01", "DOUBLE");
+    assertVariantLiterally("VARIANT", " 123.4e-1\t\n", "1.234000000000000e+01", "DOUBLE");
+    assertVariantLiterally("VARIANT", " 123.4E-1\t\n", "1.234000000000000e+01", "DOUBLE");
+
+    assertVariantLiterally("VARIANT", " 1234e1\t\n", "1.234000000000000e+04", "DOUBLE");
+    assertVariantLiterally("VARIANT", " 1234E1\t\n", "1.234000000000000e+04", "DOUBLE");
+    assertVariantLiterally("VARIANT", " 1234e-1\t\n", "1.234000000000000e+02", "DOUBLE");
+    assertVariantLiterally("VARIANT", " 1234E-1\t\n", "1.234000000000000e+02", "DOUBLE");
+
+    assertVariantLiterally(
+        "OBJECT",
+        " {\"key\": 1.234E1\t\n}",
+        "{\n" + "  \"key\": 1.234000000000000e+01\n" + "}",
+        "OBJECT");
+
+    assertVariantLiterally(
+        "ARRAY", " [1.234E1\t\n]\n", "[\n" + "  1.234000000000000e+01\n" + "]", "ARRAY");
+  }
+
   private String createLargeVariantObject(int size) throws JsonProcessingException {
     char[] stringContent = new char[size - 17]; // {"a":"11","b":""}
     Arrays.fill(stringContent, 'c');


### PR DESCRIPTION
Currently, ingesting string JSON values into semi-structured types (i.e. `variant`, `object` and `array`), the SDK may modify the scientific notation of the input, i.e. convert values like `12.34` to `1.234e1` and vice versa. This PR makes sure the input format is preserved.

---

I micro-benchmarked parsing large json documents locally with JMH and the new approach also gives us ~50% speedup, it is likely due to the fact that we don't deserialize into the intermediate Jackson AST anymore:

```plain
NEW WAY
=======
Benchmark                              Mode  Cnt       Score       Error  Units
InsertRowsBenchmarkTest.testInsertRow  avgt   10  406466.888 ± 45677.292  us/op

OLD WAY
=======
Benchmark                              Mode  Cnt       Score       Error  Units
InsertRowsBenchmarkTest.testInsertRow  avgt   10  620401.749 ± 14929.263  us/op
```
