### PR TITLE
SNOW-1654124: Write file name to metadata at the place when we create the file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,6 +357,24 @@
         <artifactId>hadoop-mapreduce-client-core</artifactId>
         <version>${hadoop.version}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
@@ -766,8 +784,8 @@
               <ignoreNonCompile>true</ignoreNonCompile>
               <ignoredDependencies>
                 <!-- We defined these as direct dependencies (as opposed to just declaring it in dependencyManagement)
-                                                                                                                                                                                                                to workaround https://issues.apache.org/jira/browse/MNG-7982. Now the dependency analyzer complains that
-                                                                                                                                                                                                                the dependency is unused, so we ignore it here-->
+                                                                                                                                                                                                                                to workaround https://issues.apache.org/jira/browse/MNG-7982. Now the dependency analyzer complains that
+                                                                                                                                                                                                                                the dependency is unused, so we ignore it here-->
                 <ignoredDependency>org.apache.commons:commons-compress</ignoredDependency>
                 <ignoredDependency>org.apache.commons:commons-configuration2</ignoredDependency>
               </ignoredDependencies>
@@ -862,9 +880,9 @@
         <configuration>
           <errorRemedy>failFast</errorRemedy>
           <!--
-                                                                                                                                                                           The list of allowed licenses. If you see the build failing due to "There are some forbidden licenses used, please
-                                                                                                                                                                          check your dependencies", verify the conditions of the license and add the reference to it here.
-                                                                                                                                                                        -->
+                                                                                                                                                                                     The list of allowed licenses. If you see the build failing due to "There are some forbidden licenses used, please
+                                                                                                                                                                                    check your dependencies", verify the conditions of the license and add the reference to it here.
+                                                                                                                                                                                  -->
           <includedLicenses>
             <includedLicense>Apache License 2.0</includedLicense>
             <includedLicense>BSD 2-Clause License</includedLicense>
@@ -1177,9 +1195,9 @@
             </executions>
           </plugin>
           <!--
-                                                                                                                                                                                    Plugin executes license processing Python script, which copies third party license files into the directory
-                                                                                                                                                                                    target/generated-licenses-info/META-INF/third-party-licenses, which is then included in the shaded JAR.
-                                                                                                                                                                                    -->
+                                                                                                                                                                                              Plugin executes license processing Python script, which copies third party license files into the directory
+                                                                                                                                                                                              target/generated-licenses-info/META-INF/third-party-licenses, which is then included in the shaded JAR.
+                                                                                                                                                                                              -->
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-mapreduce-client-core</artifactId>
+        <version>${hadoop.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>3.7.7</version>
@@ -477,6 +483,10 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.apache.parquet/parquet-hadoop -->
     <dependency>
@@ -756,8 +766,8 @@
               <ignoreNonCompile>true</ignoreNonCompile>
               <ignoredDependencies>
                 <!-- We defined these as direct dependencies (as opposed to just declaring it in dependencyManagement)
-                                                                                                                                                                                                to workaround https://issues.apache.org/jira/browse/MNG-7982. Now the dependency analyzer complains that
-                                                                                                                                                                                                the dependency is unused, so we ignore it here-->
+                                                                                                                                                                                                                to workaround https://issues.apache.org/jira/browse/MNG-7982. Now the dependency analyzer complains that
+                                                                                                                                                                                                                the dependency is unused, so we ignore it here-->
                 <ignoredDependency>org.apache.commons:commons-compress</ignoredDependency>
                 <ignoredDependency>org.apache.commons:commons-configuration2</ignoredDependency>
               </ignoredDependencies>
@@ -852,9 +862,9 @@
         <configuration>
           <errorRemedy>failFast</errorRemedy>
           <!--
-                                                                                                                                                                 The list of allowed licenses. If you see the build failing due to "There are some forbidden licenses used, please
-                                                                                                                                                                check your dependencies", verify the conditions of the license and add the reference to it here.
-                                                                                                                                                              -->
+                                                                                                                                                                           The list of allowed licenses. If you see the build failing due to "There are some forbidden licenses used, please
+                                                                                                                                                                          check your dependencies", verify the conditions of the license and add the reference to it here.
+                                                                                                                                                                        -->
           <includedLicenses>
             <includedLicense>Apache License 2.0</includedLicense>
             <includedLicense>BSD 2-Clause License</includedLicense>
@@ -1167,9 +1177,9 @@
             </executions>
           </plugin>
           <!--
-                                                                                                                                                                          Plugin executes license processing Python script, which copies third party license files into the directory
-                                                                                                                                                                          target/generated-licenses-info/META-INF/third-party-licenses, which is then included in the shaded JAR.
-                                                                                                                                                                          -->
+                                                                                                                                                                                    Plugin executes license processing Python script, which copies third party license files into the directory
+                                                                                                                                                                                    target/generated-licenses-info/META-INF/third-party-licenses, which is then included in the shaded JAR.
+                                                                                                                                                                                    -->
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>

--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -614,9 +614,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
     this.statsMap.replaceAll((key, value) -> value.forkEmpty());
   }
 
-  /**
-   * Get buffered data snapshot for later flushing.
-   */
+  /** Get buffered data snapshot for later flushing. */
   abstract Optional<T> getSnapshot();
 
   @VisibleForTesting

--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -496,11 +496,10 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
    * Flush the data in the row buffer by taking the ownership of the old vectors and pass all the
    * required info back to the flush service to build the blob
    *
-   * @param filePath the name of the file the data will be written in
    * @return A ChannelData object that contains the info needed by the flush service to build a blob
    */
   @Override
-  public ChannelData<T> flush(final String filePath) {
+  public ChannelData<T> flush() {
     logger.logDebug("Start get data for channel={}", channelFullyQualifiedName);
     if (this.bufferedRowCount > 0) {
       Optional<T> oldData = Optional.empty();
@@ -518,7 +517,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       try {
         if (this.bufferedRowCount > 0) {
           // Transfer the ownership of the vectors
-          oldData = getSnapshot(filePath);
+          oldData = getSnapshot();
           oldRowCount = this.bufferedRowCount;
           oldBufferSize = this.bufferSize;
           oldRowSequencer = this.channelState.incrementAndGetRowSequencer();
@@ -617,10 +616,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
 
   /**
    * Get buffered data snapshot for later flushing.
-   *
-   * @param filePath the name of the file the data will be written in
    */
-  abstract Optional<T> getSnapshot(final String filePath);
+  abstract Optional<T> getSnapshot();
 
   @VisibleForTesting
   abstract Object getVectorValueAt(String column, int index);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -430,7 +430,7 @@ class FlushService<T> {
               .forEach(
                   channel -> {
                     if (channel.isValid()) {
-                      ChannelData<T> data = channel.getData(blobPath);
+                      ChannelData<T> data = channel.getData();
                       if (data != null) {
                         channelsDataPerTable.add(data);
                       }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
@@ -5,6 +5,7 @@
 package net.snowflake.ingest.streaming.internal;
 
 import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.parquet.hadoop.BdecParquetWriter;
@@ -34,6 +35,16 @@ public class ParquetChunkData {
     this.rows = rows;
     this.parquetWriter = parquetWriter;
     this.output = output;
-    this.metadata = metadata;
+    // create a defensive copy of the parameter map because the argument map passed here
+    // may currently be shared across multiple threads.
+    this.metadata = createDefensiveCopy(metadata);
+  }
+
+  private Map<String, String> createDefensiveCopy(final Map<String, String> metadata) {
+    final Map<String, String> copy = new HashMap<>(metadata);
+    for (String k : metadata.keySet()) {
+      copy.put(k, metadata.get(k));
+    }
+    return copy;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
@@ -5,7 +5,6 @@
 package net.snowflake.ingest.streaming.internal;
 
 import java.io.ByteArrayOutputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.parquet.hadoop.BdecParquetWriter;
@@ -35,16 +34,6 @@ public class ParquetChunkData {
     this.rows = rows;
     this.parquetWriter = parquetWriter;
     this.output = output;
-    // create a defensive copy of the parameter map because the argument map passed here
-    // may currently be shared across multiple threads.
-    this.metadata = createDefensiveCopy(metadata);
-  }
-
-  private Map<String, String> createDefensiveCopy(final Map<String, String> metadata) {
-    final Map<String, String> copy = new HashMap<>(metadata);
-    for (String k : metadata.keySet()) {
-      copy.put(k, metadata.get(k));
-    }
-    return copy;
+    this.metadata = metadata;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -212,6 +212,10 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
     }
 
     Map<String, String> metadata = channelsDataPerTable.get(0).getVectors().metadata;
+    // We insert the filename in the file itself as metadata so that streams can work on replicated
+    // mixed tables. For a more detailed discussion on the topic see SNOW-561447 and
+    // http://go/streams-on-replicated-mixed-tables
+    metadata.put(Constants.PRIMARY_FILE_ID_KEY, StreamingIngestUtils.getShortname(filePath));
     parquetWriter =
         new BdecParquetWriter(
             mergedData,

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -261,7 +261,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   }
 
   @Override
-  Optional<ParquetChunkData> getSnapshot(final String filePath) {
+  Optional<ParquetChunkData> getSnapshot() {
     List<List<Object>> oldData = new ArrayList<>();
     if (!clientBufferParameters.getEnableParquetInternalBuffering()) {
       data.forEach(r -> oldData.add(new ArrayList<>(r)));

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -22,7 +22,6 @@ import net.snowflake.client.jdbc.internal.google.common.collect.Sets;
 import net.snowflake.ingest.connection.TelemetryService;
 import net.snowflake.ingest.streaming.OffsetTokenVerificationFunction;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
-import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.hadoop.BdecParquetWriter;
@@ -263,11 +262,6 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
 
   @Override
   Optional<ParquetChunkData> getSnapshot(final String filePath) {
-    // We insert the filename in the file itself as metadata so that streams can work on replicated
-    // mixed tables. For a more detailed discussion on the topic see SNOW-561447 and
-    // http://go/streams-on-replicated-mixed-tables
-    metadata.put(Constants.PRIMARY_FILE_ID_KEY, StreamingIngestUtils.getShortname(filePath));
-
     List<List<Object>> oldData = new ArrayList<>();
     if (!clientBufferParameters.getEnableParquetInternalBuffering()) {
       data.forEach(r -> oldData.add(new ArrayList<>(r)));

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBuffer.java
@@ -37,10 +37,9 @@ interface RowBuffer<T> {
    * Flush the data in the row buffer by taking the ownership of the old vectors and pass all the
    * required info back to the flush service to build the blob
    *
-   * @param filePath the name of the file the data will be written in
    * @return A ChannelData object that contains the info needed by the flush service to build a blob
    */
-  ChannelData<T> flush(final String filePath);
+  ChannelData<T> flush();
 
   /**
    * Close the row buffer and release resources. Note that the caller needs to handle

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -220,11 +220,10 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
   /**
    * Get all the data needed to build the blob during flush
    *
-   * @param filePath the name of the file the data will be written in
    * @return a ChannelData object
    */
-  ChannelData<T> getData(final String filePath) {
-    ChannelData<T> data = this.rowBuffer.flush(filePath);
+  ChannelData<T> getData() {
+    ChannelData<T> data = this.rowBuffer.flush();
     if (data != null) {
       data.setChannelContext(channelFlushContext);
     }

--- a/src/main/java/org/apache/parquet/hadoop/BdecParquetReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/BdecParquetReader.java
@@ -34,6 +34,7 @@ import org.apache.parquet.schema.MessageType;
  */
 public class BdecParquetReader implements AutoCloseable {
   private final InternalParquetRecordReader<List<Object>> reader;
+  private final ParquetFileReader fileReader;
 
   /**
    * @param data buffer where the data that has to be read resides.
@@ -41,7 +42,7 @@ public class BdecParquetReader implements AutoCloseable {
    */
   public BdecParquetReader(byte[] data) throws IOException {
     ParquetReadOptions options = ParquetReadOptions.builder().build();
-    ParquetFileReader fileReader = ParquetFileReader.open(new BdecInputFile(data), options);
+    fileReader = ParquetFileReader.open(new BdecInputFile(data), options);
     reader = new InternalParquetRecordReader<>(new BdecReadSupport(), options.getRecordFilter());
     reader.initialize(fileReader, options);
   }
@@ -58,6 +59,11 @@ public class BdecParquetReader implements AutoCloseable {
     } catch (InterruptedException e) {
       throw new IOException(e);
     }
+  }
+
+  /** Get the key value metadata in the file */
+  public Map<String, String> getKeyValueMetadata() {
+    return fileReader.getFileMetaData().getKeyValueMetaData();
   }
 
   /**

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -131,7 +131,7 @@ public class FlushServiceTest {
 
     ChannelData<T> flushChannel(String name) {
       SnowflakeStreamingIngestChannelInternal<T> channel = channels.get(name);
-      ChannelData<T> channelData = channel.getRowBuffer().flush(name + "_snowpipe_streaming.bdec");
+      ChannelData<T> channelData = channel.getRowBuffer().flush();
       channelData.setChannelContext(channel.getChannelContext());
       this.channelData.add(channelData);
       return channelData;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -505,11 +505,6 @@ public class RowBufferTest {
     Assert.assertEquals(startOffsetToken, data.getStartOffsetToken());
     Assert.assertEquals(endOffsetToken, data.getEndOffsetToken());
     Assert.assertEquals(bufferSize, data.getBufferSize(), 0);
-
-    final ParquetChunkData chunkData = (ParquetChunkData) data.getVectors();
-    Assert.assertEquals(
-        StreamingIngestUtils.getShortname(filename),
-        chunkData.metadata.get(Constants.PRIMARY_FILE_ID_KEY));
   }
 
   @Test
@@ -782,9 +777,6 @@ public class RowBufferTest {
         columnEpStats.get("COLCHAR").getCurrentMaxStrValue());
     Assert.assertEquals(0, columnEpStats.get("COLCHAR").getCurrentNullCount());
     Assert.assertEquals(-1, columnEpStats.get("COLCHAR").getDistinctValues());
-
-    final ParquetChunkData chunkData = (ParquetChunkData) result.getVectors();
-    Assert.assertEquals(filename, chunkData.metadata.get(Constants.PRIMARY_FILE_ID_KEY));
 
     // Confirm we reset
     ChannelData<?> resetResults = rowBuffer.flush("my_snowpipe_streaming.bdec");

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -4,7 +4,6 @@ import static java.time.ZoneOffset.UTC;
 import static net.snowflake.ingest.utils.ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_CHUNK_SIZE_IN_BYTES_DEFAULT;
-import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -16,8 +15,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Constants;
@@ -149,7 +146,7 @@ public class RowBufferTest {
     collatedColumn.setCollation("en-ci");
     try {
       this.rowBufferOnErrorAbort.setupSchema(Collections.singletonList(collatedColumn));
-      fail("Collated columns are not supported");
+      Assert.fail("Collated columns are not supported");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNSUPPORTED_DATA_TYPE.getMessageCode(), e.getVendorCode());
     }
@@ -169,7 +166,7 @@ public class RowBufferTest {
     testCol.setPrecision(4);
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(testCol));
-      fail("Expected error");
+      Assert.fail("Expected error");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode(), e.getVendorCode());
     }
@@ -181,7 +178,7 @@ public class RowBufferTest {
     testCol.setLogicalType("FIXED");
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(testCol));
-      fail("Expected error");
+      Assert.fail("Expected error");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode(), e.getVendorCode());
     }
@@ -193,7 +190,7 @@ public class RowBufferTest {
     testCol.setLogicalType("TIMESTAMP_NTZ");
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(testCol));
-      fail("Expected error");
+      Assert.fail("Expected error");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode(), e.getVendorCode());
     }
@@ -205,7 +202,7 @@ public class RowBufferTest {
     testCol.setLogicalType("TIMESTAMP_TZ");
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(testCol));
-      fail("Expected error");
+      Assert.fail("Expected error");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode(), e.getVendorCode());
     }
@@ -217,7 +214,7 @@ public class RowBufferTest {
     testCol.setLogicalType("TIME");
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(testCol));
-      fail("Expected error");
+      Assert.fail("Expected error");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode(), e.getVendorCode());
     }
@@ -249,7 +246,7 @@ public class RowBufferTest {
 
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(colInvalidLogical));
-      fail("Setup should fail if invalid column metadata is provided");
+      Assert.fail("Setup should fail if invalid column metadata is provided");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode(), e.getVendorCode());
       // Do nothing
@@ -269,7 +266,7 @@ public class RowBufferTest {
 
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(colInvalidPhysical));
-      fail("Setup should fail if invalid column metadata is provided");
+      Assert.fail("Setup should fail if invalid column metadata is provided");
     } catch (SFException e) {
       Assert.assertEquals(e.getVendorCode(), ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode());
     }
@@ -630,7 +627,7 @@ public class RowBufferTest {
 
     try {
       AbstractRowBuffer.buildEpInfoFromStats(1, colStats);
-      fail("should fail when row count is smaller than null count.");
+      Assert.fail("should fail when row count is smaller than null count.");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.INTERNAL_ERROR.getMessageCode(), e.getVendorCode());
     }
@@ -1721,79 +1718,5 @@ public class RowBufferTest {
     // only validRows and none of the mixedRows are in the buffer
     Assert.assertEquals(1, snapshotAbortParquet.size());
     Assert.assertEquals(Arrays.asList("a"), snapshotAbortParquet.get(0));
-  }
-
-  @Test
-  public void testParquetChunkMetadataCreationIsThreadSafe() throws InterruptedException {
-    final String testFileA = "testFileA";
-    final String testFileB = "testFileB";
-
-    final ParquetRowBuffer bufferUnderTest =
-        (ParquetRowBuffer) createTestBuffer(OpenChannelRequest.OnErrorOption.CONTINUE);
-
-    final ColumnMetadata colChar = new ColumnMetadata();
-    colChar.setOrdinal(1);
-    colChar.setName("COLCHAR");
-    colChar.setPhysicalType("LOB");
-    colChar.setNullable(true);
-    colChar.setLogicalType("TEXT");
-    colChar.setByteLength(14);
-    colChar.setLength(11);
-    colChar.setScale(0);
-
-    bufferUnderTest.setupSchema(Collections.singletonList(colChar));
-
-    loadData(bufferUnderTest, Collections.singletonMap("colChar", "a"));
-
-    final CountDownLatch latch = new CountDownLatch(1);
-    final AtomicReference<ChannelData<ParquetChunkData>> firstFlushResult = new AtomicReference<>();
-    final Thread t =
-        getThreadThatWaitsForLockReleaseAndFlushes(
-            bufferUnderTest, testFileA, latch, firstFlushResult);
-    t.start();
-
-    final ChannelData<ParquetChunkData> secondFlushResult = bufferUnderTest.flush(testFileB);
-    Assert.assertEquals(testFileB, getPrimaryFileId(secondFlushResult));
-
-    latch.countDown();
-    t.join();
-
-    Assert.assertNotNull(firstFlushResult.get());
-    Assert.assertEquals(testFileA, getPrimaryFileId(firstFlushResult.get()));
-    Assert.assertEquals(testFileB, getPrimaryFileId(secondFlushResult));
-  }
-
-  private static Thread getThreadThatWaitsForLockReleaseAndFlushes(
-      final ParquetRowBuffer bufferUnderTest,
-      final String filenameToFlush,
-      final CountDownLatch latch,
-      final AtomicReference<ChannelData<ParquetChunkData>> flushResult) {
-    return new Thread(
-        () -> {
-          try {
-            latch.await();
-          } catch (InterruptedException e) {
-            fail("Thread was unexpectedly interrupted");
-          }
-
-          final ChannelData<ParquetChunkData> flush =
-              loadData(bufferUnderTest, Collections.singletonMap("colChar", "b"))
-                  .flush(filenameToFlush);
-          flushResult.set(flush);
-        });
-  }
-
-  private static ParquetRowBuffer loadData(
-      final ParquetRowBuffer bufferToLoad, final Map<String, Object> data) {
-    final List<Map<String, Object>> validRows = new ArrayList<>();
-    validRows.add(data);
-
-    final InsertValidationResponse nResponse = bufferToLoad.insertRows(validRows, "1", "1");
-    Assert.assertFalse(nResponse.hasErrors());
-    return bufferToLoad;
-  }
-
-  private static String getPrimaryFileId(final ChannelData<ParquetChunkData> chunkData) {
-    return chunkData.getVectors().metadata.get(Constants.PRIMARY_FILE_ID_KEY);
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -4,6 +4,7 @@ import static java.time.ZoneOffset.UTC;
 import static net.snowflake.ingest.utils.ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_CHUNK_SIZE_IN_BYTES_DEFAULT;
+import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -15,6 +16,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Constants;
@@ -146,7 +149,7 @@ public class RowBufferTest {
     collatedColumn.setCollation("en-ci");
     try {
       this.rowBufferOnErrorAbort.setupSchema(Collections.singletonList(collatedColumn));
-      Assert.fail("Collated columns are not supported");
+      fail("Collated columns are not supported");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNSUPPORTED_DATA_TYPE.getMessageCode(), e.getVendorCode());
     }
@@ -166,7 +169,7 @@ public class RowBufferTest {
     testCol.setPrecision(4);
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(testCol));
-      Assert.fail("Expected error");
+      fail("Expected error");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode(), e.getVendorCode());
     }
@@ -178,7 +181,7 @@ public class RowBufferTest {
     testCol.setLogicalType("FIXED");
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(testCol));
-      Assert.fail("Expected error");
+      fail("Expected error");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode(), e.getVendorCode());
     }
@@ -190,7 +193,7 @@ public class RowBufferTest {
     testCol.setLogicalType("TIMESTAMP_NTZ");
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(testCol));
-      Assert.fail("Expected error");
+      fail("Expected error");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode(), e.getVendorCode());
     }
@@ -202,7 +205,7 @@ public class RowBufferTest {
     testCol.setLogicalType("TIMESTAMP_TZ");
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(testCol));
-      Assert.fail("Expected error");
+      fail("Expected error");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode(), e.getVendorCode());
     }
@@ -214,7 +217,7 @@ public class RowBufferTest {
     testCol.setLogicalType("TIME");
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(testCol));
-      Assert.fail("Expected error");
+      fail("Expected error");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode(), e.getVendorCode());
     }
@@ -246,7 +249,7 @@ public class RowBufferTest {
 
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(colInvalidLogical));
-      Assert.fail("Setup should fail if invalid column metadata is provided");
+      fail("Setup should fail if invalid column metadata is provided");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode(), e.getVendorCode());
       // Do nothing
@@ -266,7 +269,7 @@ public class RowBufferTest {
 
     try {
       this.rowBufferOnErrorContinue.setupSchema(Collections.singletonList(colInvalidPhysical));
-      Assert.fail("Setup should fail if invalid column metadata is provided");
+      fail("Setup should fail if invalid column metadata is provided");
     } catch (SFException e) {
       Assert.assertEquals(e.getVendorCode(), ErrorCode.UNKNOWN_DATA_TYPE.getMessageCode());
     }
@@ -627,7 +630,7 @@ public class RowBufferTest {
 
     try {
       AbstractRowBuffer.buildEpInfoFromStats(1, colStats);
-      Assert.fail("should fail when row count is smaller than null count.");
+      fail("should fail when row count is smaller than null count.");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.INTERNAL_ERROR.getMessageCode(), e.getVendorCode());
     }
@@ -1718,5 +1721,79 @@ public class RowBufferTest {
     // only validRows and none of the mixedRows are in the buffer
     Assert.assertEquals(1, snapshotAbortParquet.size());
     Assert.assertEquals(Arrays.asList("a"), snapshotAbortParquet.get(0));
+  }
+
+  @Test
+  public void testParquetChunkMetadataCreationIsThreadSafe() throws InterruptedException {
+    final String testFileA = "testFileA";
+    final String testFileB = "testFileB";
+
+    final ParquetRowBuffer bufferUnderTest =
+        (ParquetRowBuffer) createTestBuffer(OpenChannelRequest.OnErrorOption.CONTINUE);
+
+    final ColumnMetadata colChar = new ColumnMetadata();
+    colChar.setOrdinal(1);
+    colChar.setName("COLCHAR");
+    colChar.setPhysicalType("LOB");
+    colChar.setNullable(true);
+    colChar.setLogicalType("TEXT");
+    colChar.setByteLength(14);
+    colChar.setLength(11);
+    colChar.setScale(0);
+
+    bufferUnderTest.setupSchema(Collections.singletonList(colChar));
+
+    loadData(bufferUnderTest, Collections.singletonMap("colChar", "a"));
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<ChannelData<ParquetChunkData>> firstFlushResult = new AtomicReference<>();
+    final Thread t =
+        getThreadThatWaitsForLockReleaseAndFlushes(
+            bufferUnderTest, testFileA, latch, firstFlushResult);
+    t.start();
+
+    final ChannelData<ParquetChunkData> secondFlushResult = bufferUnderTest.flush(testFileB);
+    Assert.assertEquals(testFileB, getPrimaryFileId(secondFlushResult));
+
+    latch.countDown();
+    t.join();
+
+    Assert.assertNotNull(firstFlushResult.get());
+    Assert.assertEquals(testFileA, getPrimaryFileId(firstFlushResult.get()));
+    Assert.assertEquals(testFileB, getPrimaryFileId(secondFlushResult));
+  }
+
+  private static Thread getThreadThatWaitsForLockReleaseAndFlushes(
+      final ParquetRowBuffer bufferUnderTest,
+      final String filenameToFlush,
+      final CountDownLatch latch,
+      final AtomicReference<ChannelData<ParquetChunkData>> flushResult) {
+    return new Thread(
+        () -> {
+          try {
+            latch.await();
+          } catch (InterruptedException e) {
+            fail("Thread was unexpectedly interrupted");
+          }
+
+          final ChannelData<ParquetChunkData> flush =
+              loadData(bufferUnderTest, Collections.singletonMap("colChar", "b"))
+                  .flush(filenameToFlush);
+          flushResult.set(flush);
+        });
+  }
+
+  private static ParquetRowBuffer loadData(
+      final ParquetRowBuffer bufferToLoad, final Map<String, Object> data) {
+    final List<Map<String, Object>> validRows = new ArrayList<>();
+    validRows.add(data);
+
+    final InsertValidationResponse nResponse = bufferToLoad.insertRows(validRows, "1", "1");
+    Assert.assertFalse(nResponse.hasErrors());
+    return bufferToLoad;
+  }
+
+  private static String getPrimaryFileId(final ChannelData<ParquetChunkData> chunkData) {
+    return chunkData.getVectors().metadata.get(Constants.PRIMARY_FILE_ID_KEY);
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -1745,8 +1745,7 @@ public class RowBufferTest {
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicReference<ChannelData<ParquetChunkData>> firstFlushResult = new AtomicReference<>();
     final Thread t =
-        getThreadThatWaitsForLockReleaseAndFlushes(
-            bufferUnderTest, latch, firstFlushResult);
+        getThreadThatWaitsForLockReleaseAndFlushes(bufferUnderTest, latch, firstFlushResult);
     t.start();
 
     final ChannelData<ParquetChunkData> secondFlushResult = bufferUnderTest.flush();
@@ -1769,10 +1768,9 @@ public class RowBufferTest {
           } catch (InterruptedException e) {
             fail("Thread was unexpectedly interrupted");
           }
-          
+
           final ChannelData<ParquetChunkData> flush =
-              loadData(bufferUnderTest, Collections.singletonMap("colChar", "b"))
-                  .flush();
+              loadData(bufferUnderTest, Collections.singletonMap("colChar", "b")).flush();
           flushResult.set(flush);
         });
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -499,7 +499,7 @@ public class RowBufferTest {
     float bufferSize = rowBuffer.getSize();
 
     final String filename = "2022/7/13/16/56/testFlushHelper_streaming.bdec";
-    ChannelData<?> data = rowBuffer.flush(filename);
+    ChannelData<?> data = rowBuffer.flush();
     Assert.assertEquals(2, data.getRowCount());
     Assert.assertEquals((Long) 1L, data.getRowSequencer());
     Assert.assertEquals(startOffsetToken, data.getStartOffsetToken());
@@ -734,7 +734,7 @@ public class RowBufferTest {
     final String filename = "testStatsE2EHelper_streaming.bdec";
     InsertValidationResponse response = rowBuffer.insertRows(Arrays.asList(row1, row2), null, null);
     Assert.assertFalse(response.hasErrors());
-    ChannelData<?> result = rowBuffer.flush(filename);
+    ChannelData<?> result = rowBuffer.flush();
     Map<String, RowBufferStats> columnEpStats = result.getColumnEps();
 
     Assert.assertEquals(
@@ -779,7 +779,7 @@ public class RowBufferTest {
     Assert.assertEquals(-1, columnEpStats.get("COLCHAR").getDistinctValues());
 
     // Confirm we reset
-    ChannelData<?> resetResults = rowBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> resetResults = rowBuffer.flush();
     Assert.assertNull(resetResults);
   }
 
@@ -838,7 +838,7 @@ public class RowBufferTest {
     InsertValidationResponse response =
         innerBuffer.insertRows(Arrays.asList(row1, row2, row3), null, null);
     Assert.assertFalse(response.hasErrors());
-    ChannelData<?> result = innerBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> result = innerBuffer.flush();
     Assert.assertEquals(3, result.getRowCount());
 
     Assert.assertEquals(
@@ -907,7 +907,7 @@ public class RowBufferTest {
     Assert.assertNull(innerBuffer.getVectorValueAt("COLDATE", 2));
 
     // Check stats generation
-    ChannelData<?> result = innerBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> result = innerBuffer.flush();
     Assert.assertEquals(3, result.getRowCount());
 
     Assert.assertEquals(
@@ -973,7 +973,7 @@ public class RowBufferTest {
     Assert.assertNull(innerBuffer.getVectorValueAt("COLTIMESB8", 2));
 
     // Check stats generation
-    ChannelData<?> result = innerBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> result = innerBuffer.flush();
     Assert.assertEquals(3, result.getRowCount());
 
     Assert.assertEquals(
@@ -1204,7 +1204,7 @@ public class RowBufferTest {
       }
     }
 
-    ChannelData<?> channelData = innerBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> channelData = innerBuffer.flush();
     RowBufferStats statsCol1 = channelData.getColumnEps().get("COLVARCHAR1");
     RowBufferStats statsCol2 = channelData.getColumnEps().get("COLVARCHAR2");
     RowBufferStats statsCol3 = channelData.getColumnEps().get("COLBOOLEAN1");
@@ -1264,7 +1264,7 @@ public class RowBufferTest {
     Assert.assertNull(innerBuffer.getVectorValueAt("COLBOOLEAN", 2));
 
     // Check stats generation
-    ChannelData<?> result = innerBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> result = innerBuffer.flush();
     Assert.assertEquals(3, result.getRowCount());
 
     Assert.assertEquals(
@@ -1319,7 +1319,7 @@ public class RowBufferTest {
     Assert.assertNull(innerBuffer.getVectorValueAt("COLBINARY", 2));
 
     // Check stats generation
-    ChannelData<?> result = innerBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> result = innerBuffer.flush();
 
     Assert.assertEquals(3, result.getRowCount());
     Assert.assertEquals(11L, result.getColumnEps().get("COLBINARY").getCurrentMaxLength());
@@ -1371,7 +1371,7 @@ public class RowBufferTest {
     Assert.assertNull(innerBuffer.getVectorValueAt("COLREAL", 2));
 
     // Check stats generation
-    ChannelData<?> result = innerBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> result = innerBuffer.flush();
 
     Assert.assertEquals(3, result.getRowCount());
     Assert.assertEquals(
@@ -1454,7 +1454,7 @@ public class RowBufferTest {
     Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
     Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
 
-    ChannelData<?> data = innerBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> data = innerBuffer.flush();
     Assert.assertEquals(3, data.getRowCount());
     Assert.assertEquals(0, innerBuffer.bufferedRowCount);
   }
@@ -1528,7 +1528,7 @@ public class RowBufferTest {
     Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
     Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
 
-    ChannelData<?> data = innerBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> data = innerBuffer.flush();
     Assert.assertEquals(3, data.getRowCount());
     Assert.assertEquals(0, innerBuffer.bufferedRowCount);
   }
@@ -1579,7 +1579,7 @@ public class RowBufferTest {
     Assert.assertEquals("3", innerBuffer.getVectorValueAt("COLVARIANT", 4));
 
     // Check stats generation
-    ChannelData<?> result = innerBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> result = innerBuffer.flush();
     Assert.assertEquals(5, result.getRowCount());
     Assert.assertEquals(2, result.getColumnEps().get("COLVARIANT").getCurrentNullCount());
   }
@@ -1613,7 +1613,7 @@ public class RowBufferTest {
     Assert.assertEquals("{\"key\":1}", innerBuffer.getVectorValueAt("COLOBJECT", 0));
 
     // Check stats generation
-    ChannelData<?> result = innerBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> result = innerBuffer.flush();
     Assert.assertEquals(1, result.getRowCount());
   }
 
@@ -1663,7 +1663,7 @@ public class RowBufferTest {
     Assert.assertEquals("[1,2,3]", innerBuffer.getVectorValueAt("COLARRAY", 4));
 
     // Check stats generation
-    ChannelData<?> result = innerBuffer.flush("my_snowpipe_streaming.bdec");
+    ChannelData<?> result = innerBuffer.flush();
     Assert.assertEquals(5, result.getRowCount());
   }
 
@@ -1710,14 +1710,14 @@ public class RowBufferTest {
         SFException.class, () -> innerBufferOnErrorAbort.insertRows(mixedRows, "1", "3"));
 
     List<List<Object>> snapshotContinueParquet =
-        ((ParquetChunkData) innerBufferOnErrorContinue.getSnapshot("fake/filePath").get()).rows;
+        ((ParquetChunkData) innerBufferOnErrorContinue.getSnapshot().get()).rows;
     // validRows and only the good row from mixedRows are in the buffer
     Assert.assertEquals(2, snapshotContinueParquet.size());
     Assert.assertEquals(Arrays.asList("a"), snapshotContinueParquet.get(0));
     Assert.assertEquals(Arrays.asList("b"), snapshotContinueParquet.get(1));
 
     List<List<Object>> snapshotAbortParquet =
-        ((ParquetChunkData) innerBufferOnErrorAbort.getSnapshot("fake/filePath").get()).rows;
+        ((ParquetChunkData) innerBufferOnErrorAbort.getSnapshot().get()).rows;
     // only validRows and none of the mixedRows are in the buffer
     Assert.assertEquals(1, snapshotAbortParquet.size());
     Assert.assertEquals(Arrays.asList("a"), snapshotAbortParquet.get(0));
@@ -1725,9 +1725,6 @@ public class RowBufferTest {
 
   @Test
   public void testParquetChunkMetadataCreationIsThreadSafe() throws InterruptedException {
-    final String testFileA = "testFileA";
-    final String testFileB = "testFileB";
-
     final ParquetRowBuffer bufferUnderTest =
         (ParquetRowBuffer) createTestBuffer(OpenChannelRequest.OnErrorOption.CONTINUE);
 
@@ -1749,23 +1746,20 @@ public class RowBufferTest {
     final AtomicReference<ChannelData<ParquetChunkData>> firstFlushResult = new AtomicReference<>();
     final Thread t =
         getThreadThatWaitsForLockReleaseAndFlushes(
-            bufferUnderTest, testFileA, latch, firstFlushResult);
+            bufferUnderTest, latch, firstFlushResult);
     t.start();
 
-    final ChannelData<ParquetChunkData> secondFlushResult = bufferUnderTest.flush(testFileB);
-    Assert.assertEquals(testFileB, getPrimaryFileId(secondFlushResult));
+    final ChannelData<ParquetChunkData> secondFlushResult = bufferUnderTest.flush();
+    // TODO: need to verify other fields
 
     latch.countDown();
     t.join();
 
     Assert.assertNotNull(firstFlushResult.get());
-    Assert.assertEquals(testFileA, getPrimaryFileId(firstFlushResult.get()));
-    Assert.assertEquals(testFileB, getPrimaryFileId(secondFlushResult));
   }
 
   private static Thread getThreadThatWaitsForLockReleaseAndFlushes(
       final ParquetRowBuffer bufferUnderTest,
-      final String filenameToFlush,
       final CountDownLatch latch,
       final AtomicReference<ChannelData<ParquetChunkData>> flushResult) {
     return new Thread(
@@ -1775,10 +1769,10 @@ public class RowBufferTest {
           } catch (InterruptedException e) {
             fail("Thread was unexpectedly interrupted");
           }
-
+          
           final ChannelData<ParquetChunkData> flush =
               loadData(bufferUnderTest, Collections.singletonMap("colChar", "b"))
-                  .flush(filenameToFlush);
+                  .flush();
           flushResult.set(flush);
         });
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -592,7 +592,7 @@ public class SnowflakeStreamingIngestChannelTest {
     row.put("col", 1);
 
     // Get data before insert to verify that there is no row (data should be null)
-    ChannelData<?> data = channel.getData("my_snowpipe_streaming.bdec");
+    ChannelData<?> data = channel.getData();
     Assert.assertNull(data);
 
     long insertStartTimeInMs = System.currentTimeMillis();
@@ -605,7 +605,7 @@ public class SnowflakeStreamingIngestChannelTest {
     long insertEndTimeInMs = System.currentTimeMillis();
 
     // Get data again to verify the row is inserted
-    data = channel.getData("my_snowpipe_streaming.bdec");
+    data = channel.getData();
     Assert.assertEquals(3, data.getRowCount());
     Assert.assertEquals((Long) 1L, data.getRowSequencer());
     Assert.assertEquals(1, ((ChannelData<ParquetChunkData>) data).getVectors().rows.get(0).size());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtilsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtilsIT.java
@@ -27,7 +27,10 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({JWTManager.class})
-@PowerMockIgnore({"javax.net.ssl.*"}) /* Avoid ssl related exception from power mockito*/
+@PowerMockIgnore({
+  "javax.net.ssl.*",
+  "javax.security.*"
+}) /* Avoid ssl related exception from power mockito*/
 public class StreamingIngestUtilsIT {
   @Test
   public void testJWTRetries() throws Exception {


### PR DESCRIPTION
- Write file name to metadata at the place when we create the file (only works for `serializeFromJavaObjects`)
- Looks like `serializeFromParquetWriteBuffers` is not maintained to work with `primaryFileId` as the `ParquetWriter` is created during `setupSchema`, we would better remove the code as a whole if we decide to not use it, or a bigger, separated change is required.