### PR TITLE
SNOW-1659373 cleanup serializeFromParquetBuffers

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
@@ -10,8 +10,6 @@ import net.snowflake.ingest.utils.ParameterProvider;
 /** Channel's buffer relevant parameters that are set at the owning client level. */
 public class ClientBufferParameters {
 
-  private boolean enableParquetInternalBuffering;
-
   private long maxChunkSizeInBytes;
 
   private long maxAllowedRowSizeInBytes;
@@ -23,18 +21,14 @@ public class ClientBufferParameters {
   /**
    * Private constructor used for test methods
    *
-   * @param enableParquetInternalBuffering flag whether buffering in internal Parquet buffers is
-   *     enabled
    * @param maxChunkSizeInBytes maximum chunk size in bytes
    * @param maxAllowedRowSizeInBytes maximum row size in bytes
    */
   private ClientBufferParameters(
-      boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
       long maxAllowedRowSizeInBytes,
       Constants.BdecParquetCompression bdecParquetCompression,
       boolean enableNewJsonParsingLogic) {
-    this.enableParquetInternalBuffering = enableParquetInternalBuffering;
     this.maxChunkSizeInBytes = maxChunkSizeInBytes;
     this.maxAllowedRowSizeInBytes = maxAllowedRowSizeInBytes;
     this.bdecParquetCompression = bdecParquetCompression;
@@ -43,10 +37,6 @@ public class ClientBufferParameters {
 
   /** @param clientInternal reference to the client object where the relevant parameters are set */
   public ClientBufferParameters(SnowflakeStreamingIngestClientInternal clientInternal) {
-    this.enableParquetInternalBuffering =
-        clientInternal != null
-            ? clientInternal.getParameterProvider().getEnableParquetInternalBuffering()
-            : ParameterProvider.ENABLE_PARQUET_INTERNAL_BUFFERING_DEFAULT;
     this.maxChunkSizeInBytes =
         clientInternal != null
             ? clientInternal.getParameterProvider().getMaxChunkSizeInBytes()
@@ -67,28 +57,20 @@ public class ClientBufferParameters {
   }
 
   /**
-   * @param enableParquetInternalBuffering flag whether buffering in internal Parquet buffers is
-   *     enabled
    * @param maxChunkSizeInBytes maximum chunk size in bytes
    * @param maxAllowedRowSizeInBytes maximum row size in bytes
    * @return ClientBufferParameters object
    */
   public static ClientBufferParameters test_createClientBufferParameters(
-      boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
       long maxAllowedRowSizeInBytes,
       Constants.BdecParquetCompression bdecParquetCompression,
       boolean enableNewJsonParsingLogic) {
     return new ClientBufferParameters(
-        enableParquetInternalBuffering,
         maxChunkSizeInBytes,
         maxAllowedRowSizeInBytes,
         bdecParquetCompression,
         enableNewJsonParsingLogic);
-  }
-
-  public boolean getEnableParquetInternalBuffering() {
-    return enableParquetInternalBuffering;
   }
 
   public long getMaxChunkSizeInBytes() {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
@@ -8,33 +8,23 @@ import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.parquet.hadoop.BdecParquetWriter;
 
 /** Parquet data holder to buffer rows. */
 public class ParquetChunkData {
   // buffered rows serialized into Java objects. Needed for the Parquet w/o memory optimization.
   final List<List<Object>> rows;
-
-  final BdecParquetWriter parquetWriter;
-  final ByteArrayOutputStream output;
   final Map<String, String> metadata;
 
   /**
    * Construct parquet data chunk.
    *
    * @param rows buffered row data as a list
-   * @param parquetWriter buffered parquet row data
-   * @param output byte array file output
    * @param metadata chunk metadata
    */
   public ParquetChunkData(
       List<List<Object>> rows,
-      BdecParquetWriter parquetWriter,
-      ByteArrayOutputStream output,
       Map<String, String> metadata) {
     this.rows = rows;
-    this.parquetWriter = parquetWriter;
-    this.output = output;
     // create a defensive copy of the parameter map because the argument map passed here
     // may currently be shared across multiple threads.
     this.metadata = createDefensiveCopy(metadata);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetChunkData.java
@@ -4,7 +4,6 @@
 
 package net.snowflake.ingest.streaming.internal;
 
-import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,9 +20,7 @@ public class ParquetChunkData {
    * @param rows buffered row data as a list
    * @param metadata chunk metadata
    */
-  public ParquetChunkData(
-      List<List<Object>> rows,
-      Map<String, String> metadata) {
+  public ParquetChunkData(List<List<Object>> rows, Map<String, String> metadata) {
     this.rows = rows;
     // create a defensive copy of the parameter map because the argument map passed here
     // may currently be shared across multiple threads.

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -29,9 +29,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
 
   private final Constants.BdecParquetCompression bdecParquetCompression;
 
-  /**
-   * Construct parquet flusher from its schema.
-   */
+  /** Construct parquet flusher from its schema. */
   public ParquetFlusher(
       MessageType schema,
       long maxChunkSizeInBytes,
@@ -43,7 +41,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
 
   @Override
   public SerializationResult serialize(
-          List<ChannelData<ParquetChunkData>> channelsDataPerTable, String filePath)
+      List<ChannelData<ParquetChunkData>> channelsDataPerTable, String filePath)
       throws IOException {
     return serializeFromJavaObjects(channelsDataPerTable, filePath);
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -15,7 +15,6 @@ import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.SFException;
-import org.apache.parquet.hadoop.BdecParquetReader;
 import org.apache.parquet.hadoop.BdecParquetWriter;
 import org.apache.parquet.schema.MessageType;
 
@@ -26,119 +25,27 @@ import org.apache.parquet.schema.MessageType;
 public class ParquetFlusher implements Flusher<ParquetChunkData> {
   private static final Logging logger = new Logging(ParquetFlusher.class);
   private final MessageType schema;
-  private final boolean enableParquetInternalBuffering;
   private final long maxChunkSizeInBytes;
 
   private final Constants.BdecParquetCompression bdecParquetCompression;
 
   /**
-   * Construct parquet flusher from its schema and set flag that indicates whether Parquet memory
-   * optimization is enabled, i.e. rows will be buffered in internal Parquet buffer.
+   * Construct parquet flusher from its schema.
    */
   public ParquetFlusher(
       MessageType schema,
-      boolean enableParquetInternalBuffering,
       long maxChunkSizeInBytes,
       Constants.BdecParquetCompression bdecParquetCompression) {
     this.schema = schema;
-    this.enableParquetInternalBuffering = enableParquetInternalBuffering;
     this.maxChunkSizeInBytes = maxChunkSizeInBytes;
     this.bdecParquetCompression = bdecParquetCompression;
   }
 
   @Override
   public SerializationResult serialize(
-      List<ChannelData<ParquetChunkData>> channelsDataPerTable, String filePath)
+          List<ChannelData<ParquetChunkData>> channelsDataPerTable, String filePath)
       throws IOException {
-    if (enableParquetInternalBuffering) {
-      return serializeFromParquetWriteBuffers(channelsDataPerTable, filePath);
-    }
     return serializeFromJavaObjects(channelsDataPerTable, filePath);
-  }
-
-  private SerializationResult serializeFromParquetWriteBuffers(
-      List<ChannelData<ParquetChunkData>> channelsDataPerTable, String filePath)
-      throws IOException {
-    List<ChannelMetadata> channelsMetadataList = new ArrayList<>();
-    long rowCount = 0L;
-    float chunkEstimatedUncompressedSize = 0f;
-    String firstChannelFullyQualifiedTableName = null;
-    Map<String, RowBufferStats> columnEpStatsMapCombined = null;
-    BdecParquetWriter mergedChannelWriter = null;
-    ByteArrayOutputStream mergedChunkData = new ByteArrayOutputStream();
-    Pair<Long, Long> chunkMinMaxInsertTimeInMs = null;
-
-    for (ChannelData<ParquetChunkData> data : channelsDataPerTable) {
-      // Create channel metadata
-      ChannelMetadata channelMetadata =
-          ChannelMetadata.builder()
-              .setOwningChannelFromContext(data.getChannelContext())
-              .setRowSequencer(data.getRowSequencer())
-              .setOffsetToken(data.getEndOffsetToken())
-              .setStartOffsetToken(data.getStartOffsetToken())
-              .build();
-      // Add channel metadata to the metadata list
-      channelsMetadataList.add(channelMetadata);
-
-      logger.logDebug(
-          "Parquet Flusher: Start building channel={}, rowCount={}, bufferSize={} in blob={}",
-          data.getChannelContext().getFullyQualifiedName(),
-          data.getRowCount(),
-          data.getBufferSize(),
-          filePath);
-
-      if (mergedChannelWriter == null) {
-        columnEpStatsMapCombined = data.getColumnEps();
-        mergedChannelWriter = data.getVectors().parquetWriter;
-        mergedChunkData = data.getVectors().output;
-        firstChannelFullyQualifiedTableName = data.getChannelContext().getFullyQualifiedTableName();
-        chunkMinMaxInsertTimeInMs = data.getMinMaxInsertTimeInMs();
-      } else {
-        // This method assumes that channelsDataPerTable is grouped by table. We double check
-        // here and throw an error if the assumption is violated
-        if (!data.getChannelContext()
-            .getFullyQualifiedTableName()
-            .equals(firstChannelFullyQualifiedTableName)) {
-          throw new SFException(ErrorCode.INVALID_DATA_IN_CHUNK);
-        }
-
-        columnEpStatsMapCombined =
-            ChannelData.getCombinedColumnStatsMap(columnEpStatsMapCombined, data.getColumnEps());
-        data.getVectors().parquetWriter.close();
-        BdecParquetReader.readFileIntoWriter(
-            data.getVectors().output.toByteArray(), mergedChannelWriter);
-        chunkMinMaxInsertTimeInMs =
-            ChannelData.getCombinedMinMaxInsertTimeInMs(
-                chunkMinMaxInsertTimeInMs, data.getMinMaxInsertTimeInMs());
-      }
-
-      rowCount += data.getRowCount();
-      chunkEstimatedUncompressedSize += data.getBufferSize();
-
-      logger.logDebug(
-          "Parquet Flusher: Finish building channel={}, rowCount={}, bufferSize={} in blob={}",
-          data.getChannelContext().getFullyQualifiedName(),
-          data.getRowCount(),
-          data.getBufferSize(),
-          filePath);
-    }
-
-    if (mergedChannelWriter != null) {
-      mergedChannelWriter.close();
-      this.verifyRowCounts(
-          "serializeFromParquetWriteBuffers",
-          mergedChannelWriter,
-          rowCount,
-          channelsDataPerTable,
-          -1);
-    }
-    return new SerializationResult(
-        channelsMetadataList,
-        columnEpStatsMapCombined,
-        rowCount,
-        chunkEstimatedUncompressedSize,
-        mergedChunkData,
-        chunkMinMaxInsertTimeInMs);
   }
 
   private SerializationResult serializeFromJavaObjects(
@@ -167,13 +74,11 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       channelsMetadataList.add(channelMetadata);
 
       logger.logDebug(
-          "Parquet Flusher: Start building channel={}, rowCount={}, bufferSize={} in blob={},"
-              + " enableParquetMemoryOptimization={}",
+          "Parquet Flusher: Start building channel={}, rowCount={}, bufferSize={} in blob={}",
           data.getChannelContext().getFullyQualifiedName(),
           data.getRowCount(),
           data.getBufferSize(),
-          filePath,
-          enableParquetInternalBuffering);
+          filePath);
 
       if (rows == null) {
         columnEpStatsMapCombined = data.getColumnEps();
@@ -181,7 +86,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
         firstChannelFullyQualifiedTableName = data.getChannelContext().getFullyQualifiedTableName();
         chunkMinMaxInsertTimeInMs = data.getMinMaxInsertTimeInMs();
       } else {
-        // This method assumes that channelsDataPerTable is grouped by table. We double check
+        // This method assumes that channelsDataPerTable is grouped by table. We double-check
         // here and throw an error if the assumption is violated
         if (!data.getChannelContext()
             .getFullyQualifiedTableName()
@@ -202,13 +107,11 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       chunkEstimatedUncompressedSize += data.getBufferSize();
 
       logger.logDebug(
-          "Parquet Flusher: Finish building channel={}, rowCount={}, bufferSize={} in blob={},"
-              + " enableParquetMemoryOptimization={}",
+          "Parquet Flusher: Finish building channel={}, rowCount={}, bufferSize={} in blob={}",
           data.getChannelContext().getFullyQualifiedName(),
           data.getRowCount(),
           data.getBufferSize(),
-          filePath,
-          enableParquetInternalBuffering);
+          filePath);
     }
 
     Map<String, String> metadata = channelsDataPerTable.get(0).getVectors().metadata;
@@ -227,8 +130,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
     rows.forEach(parquetWriter::writeRow);
     parquetWriter.close();
 
-    this.verifyRowCounts(
-        "serializeFromJavaObjects", parquetWriter, rowCount, channelsDataPerTable, rows.size());
+    this.verifyRowCounts(parquetWriter, rowCount, channelsDataPerTable, rows.size());
 
     return new SerializationResult(
         channelsMetadataList,
@@ -243,7 +145,6 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
    * Validates that rows count in metadata matches the row count in Parquet footer and the row count
    * written by the parquet writer
    *
-   * @param serializationType Serialization type, used for logging purposes only
    * @param writer Parquet writer writing the data
    * @param channelsDataPerTable Channel data
    * @param totalMetadataRowCount Row count calculated during metadata collection
@@ -251,7 +152,6 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
    *     Used only for logging purposes if there is a mismatch.
    */
   private void verifyRowCounts(
-      String serializationType,
       BdecParquetWriter writer,
       long totalMetadataRowCount,
       List<ChannelData<ParquetChunkData>> channelsDataPerTable,
@@ -285,7 +185,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       throw new SFException(
           ErrorCode.INTERNAL_ERROR,
           String.format(
-              "[%s]The number of rows in Parquet does not match the number of rows in metadata. "
+              "The number of rows in Parquet does not match the number of rows in metadata. "
                   + "parquetTotalRowsInFooter=%d "
                   + "totalMetadataRowCount=%d "
                   + "parquetTotalRowsWritten=%d "
@@ -294,7 +194,6 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
                   + "channelsCountInMetadata=%d "
                   + "countOfSerializedJavaObjects=%d "
                   + "channelNames=%s",
-              serializationType,
               parquetTotalRowsInFooter,
               totalMetadataRowCount,
               parquetTotalRowsWritten,

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -43,11 +43,6 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
 
   /* Unflushed rows as Java objects. Needed for the Parquet w/o memory optimization. */
   private final List<List<Object>> data;
-
-  /* BDEC Parquet writer. It is used to buffer unflushed data in Parquet internal buffers instead of using Java objects */
-  private BdecParquetWriter bdecParquetWriter;
-
-  private ByteArrayOutputStream fileOutput;
   private final List<List<Object>> tempData;
 
   private MessageType schema;
@@ -111,31 +106,8 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       id++;
     }
     schema = new MessageType(PARQUET_MESSAGE_TYPE_NAME, parquetTypes);
-    createFileWriter();
     tempData.clear();
     data.clear();
-  }
-
-  /** Create BDEC file writer if Parquet memory optimization is enabled. */
-  private void createFileWriter() {
-    fileOutput = new ByteArrayOutputStream();
-    try {
-      if (clientBufferParameters.getEnableParquetInternalBuffering()) {
-        bdecParquetWriter =
-            new BdecParquetWriter(
-                fileOutput,
-                schema,
-                metadata,
-                channelFullyQualifiedName,
-                clientBufferParameters.getMaxChunkSizeInBytes(),
-                clientBufferParameters.getBdecParquetCompression());
-      } else {
-        this.bdecParquetWriter = null;
-      }
-      data.clear();
-    } catch (IOException e) {
-      throw new SFException(ErrorCode.INTERNAL_ERROR, "cannot create parquet writer", e);
-    }
   }
 
   @Override
@@ -154,11 +126,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   }
 
   void writeRow(List<Object> row) {
-    if (clientBufferParameters.getEnableParquetInternalBuffering()) {
-      bdecParquetWriter.writeRow(row);
-    } else {
       data.add(row);
-    }
   }
 
   @Override
@@ -263,12 +231,10 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   @Override
   Optional<ParquetChunkData> getSnapshot() {
     List<List<Object>> oldData = new ArrayList<>();
-    if (!clientBufferParameters.getEnableParquetInternalBuffering()) {
       data.forEach(r -> oldData.add(new ArrayList<>(r)));
-    }
     return bufferedRowCount <= 0
         ? Optional.empty()
-        : Optional.of(new ParquetChunkData(oldData, bdecParquetWriter, fileOutput, metadata));
+        : Optional.of(new ParquetChunkData(oldData, metadata));
   }
 
   /** Used only for testing. */
@@ -309,27 +275,17 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   @Override
   void reset() {
     super.reset();
-    createFileWriter();
     data.clear();
   }
 
   /** Close the row buffer by releasing its internal resources. */
   @Override
-  void closeInternal() {
-    if (bdecParquetWriter != null) {
-      try {
-        bdecParquetWriter.close();
-      } catch (IOException e) {
-        throw new SFException(ErrorCode.INTERNAL_ERROR, "Failed to close parquet writer", e);
-      }
-    }
-  }
+  void closeInternal() {}
 
   @Override
   public Flusher<ParquetChunkData> createFlusher() {
     return new ParquetFlusher(
         schema,
-        clientBufferParameters.getEnableParquetInternalBuffering(),
         clientBufferParameters.getMaxChunkSizeInBytes(),
         clientBufferParameters.getBdecParquetCompression());
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -4,8 +4,6 @@
 
 package net.snowflake.ingest.streaming.internal;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -24,7 +22,6 @@ import net.snowflake.ingest.streaming.OffsetTokenVerificationFunction;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
-import org.apache.parquet.hadoop.BdecParquetWriter;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
@@ -126,7 +123,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   }
 
   void writeRow(List<Object> row) {
-      data.add(row);
+    data.add(row);
   }
 
   @Override
@@ -231,7 +228,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   @Override
   Optional<ParquetChunkData> getSnapshot() {
     List<List<Object>> oldData = new ArrayList<>();
-      data.forEach(r -> oldData.add(new ArrayList<>(r)));
+    data.forEach(r -> oldData.add(new ArrayList<>(r)));
     return bufferedRowCount <= 0
         ? Optional.empty()
         : Optional.of(new ParquetChunkData(oldData, metadata));

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -30,8 +30,6 @@ public class ParameterProvider {
   public static final String BLOB_UPLOAD_MAX_RETRY_COUNT =
       "BLOB_UPLOAD_MAX_RETRY_COUNT".toLowerCase();
   public static final String MAX_MEMORY_LIMIT_IN_BYTES = "MAX_MEMORY_LIMIT_IN_BYTES".toLowerCase();
-  public static final String ENABLE_PARQUET_INTERNAL_BUFFERING =
-      "ENABLE_PARQUET_INTERNAL_BUFFERING".toLowerCase();
   // This should not be needed once we have the ability to track size at table/chunk level
   public static final String MAX_CHANNEL_SIZE_IN_BYTES = "MAX_CHANNEL_SIZE_IN_BYTES".toLowerCase();
   public static final String MAX_CHUNK_SIZE_IN_BYTES = "MAX_CHUNK_SIZE_IN_BYTES".toLowerCase();
@@ -78,10 +76,6 @@ public class ParameterProvider {
 
   /* Iceberg mode parameters: When streaming to Iceberg mode, different default parameters are required because it generates Parquet files instead of BDEC files. */
   public static final int MAX_CHUNKS_IN_BLOB_ICEBERG_MODE_DEFAULT = 1;
-
-  /* Parameter that enables using internal Parquet buffers for buffering of rows before serializing.
-  It reduces memory consumption compared to using Java Objects for buffering.*/
-  public static final boolean ENABLE_PARQUET_INTERNAL_BUFFERING_DEFAULT = false;
 
   public static final boolean ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT = true;
 
@@ -208,13 +202,6 @@ public class ParameterProvider {
     this.checkAndUpdate(
         MAX_MEMORY_LIMIT_IN_BYTES,
         MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT,
-        parameterOverrides,
-        props,
-        false);
-
-    this.checkAndUpdate(
-        ENABLE_PARQUET_INTERNAL_BUFFERING,
-        ENABLE_PARQUET_INTERNAL_BUFFERING_DEFAULT,
         parameterOverrides,
         props,
         false);
@@ -438,14 +425,6 @@ public class ParameterProvider {
         this.parameterMap.getOrDefault(
             MAX_MEMORY_LIMIT_IN_BYTES, MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT);
     return (val instanceof String) ? Long.parseLong(val.toString()) : (long) val;
-  }
-
-  /** @return Return whether memory optimization for Parquet is enabled. */
-  public boolean getEnableParquetInternalBuffering() {
-    Object val =
-        this.parameterMap.getOrDefault(
-            ENABLE_PARQUET_INTERNAL_BUFFERING, ENABLE_PARQUET_INTERNAL_BUFFERING_DEFAULT);
-    return (val instanceof String) ? Boolean.parseBoolean(val.toString()) : (boolean) val;
   }
 
   /** @return The max channel size in bytes */

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -35,12 +35,12 @@ public class BlobBuilderTest {
     // Construction succeeds if both data and metadata contain 1 row
     BlobBuilder.constructBlobAndMetadata(
         "a.bdec",
-        Collections.singletonList(createChannelDataPerTable(1, false)),
+        Collections.singletonList(createChannelDataPerTable(1)),
         Constants.BdecVersion.THREE,
         encrypt);
     BlobBuilder.constructBlobAndMetadata(
         "a.bdec",
-        Collections.singletonList(createChannelDataPerTable(1, true)),
+        Collections.singletonList(createChannelDataPerTable(1)),
         Constants.BdecVersion.THREE,
         encrypt);
 
@@ -48,7 +48,7 @@ public class BlobBuilderTest {
     try {
       BlobBuilder.constructBlobAndMetadata(
           "a.bdec",
-          Collections.singletonList(createChannelDataPerTable(0, false)),
+          Collections.singletonList(createChannelDataPerTable(0)),
           Constants.BdecVersion.THREE,
           encrypt);
       Assert.fail("Should not pass enableParquetInternalBuffering=false");
@@ -67,7 +67,7 @@ public class BlobBuilderTest {
     try {
       BlobBuilder.constructBlobAndMetadata(
           "a.bdec",
-          Collections.singletonList(createChannelDataPerTable(0, true)),
+          Collections.singletonList(createChannelDataPerTable(0)),
           Constants.BdecVersion.THREE,
           encrypt);
       Assert.fail("Should not pass enableParquetInternalBuffering=true");
@@ -89,14 +89,13 @@ public class BlobBuilderTest {
    * with and without internal buffering optimization)
    */
   private List<ChannelData<ParquetChunkData>> createChannelDataPerTable(
-      int metadataRowCount, boolean enableParquetInternalBuffering) throws IOException {
+      int metadataRowCount) throws IOException {
     String columnName = "C1";
     ChannelData<ParquetChunkData> channelData = Mockito.spy(new ChannelData<>());
     MessageType schema = createSchema(columnName);
     Mockito.doReturn(
             new ParquetFlusher(
                 schema,
-                enableParquetInternalBuffering,
                 100L,
                 Constants.BdecParquetCompression.GZIP))
         .when(channelData)
@@ -116,8 +115,6 @@ public class BlobBuilderTest {
     channelData.setVectors(
         new ParquetChunkData(
             Collections.singletonList(Collections.singletonList("A")),
-            bdecParquetWriter,
-            stream,
             new HashMap<>()));
     channelData.setColumnEps(new HashMap<>());
     channelData.setRowCount(metadataRowCount);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -38,11 +38,6 @@ public class BlobBuilderTest {
         Collections.singletonList(createChannelDataPerTable(1)),
         Constants.BdecVersion.THREE,
         encrypt);
-    BlobBuilder.constructBlobAndMetadata(
-        "a.bdec",
-        Collections.singletonList(createChannelDataPerTable(1)),
-        Constants.BdecVersion.THREE,
-        encrypt);
 
     // Construction fails if metadata contains 0 rows and data 1 row
     try {
@@ -51,10 +46,8 @@ public class BlobBuilderTest {
           Collections.singletonList(createChannelDataPerTable(0)),
           Constants.BdecVersion.THREE,
           encrypt);
-      Assert.fail("Should not pass enableParquetInternalBuffering=false");
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.INTERNAL_ERROR.getMessageCode(), e.getVendorCode());
-      Assert.assertTrue(e.getMessage().contains("serializeFromJavaObjects"));
       Assert.assertTrue(e.getMessage().contains("parquetTotalRowsInFooter=1"));
       Assert.assertTrue(e.getMessage().contains("totalMetadataRowCount=0"));
       Assert.assertTrue(e.getMessage().contains("parquetTotalRowsWritten=1"));
@@ -62,25 +55,6 @@ public class BlobBuilderTest {
       Assert.assertTrue(e.getMessage().contains("perBlockRowCountsInFooter=1"));
       Assert.assertTrue(e.getMessage().contains("channelsCountInMetadata=1"));
       Assert.assertTrue(e.getMessage().contains("countOfSerializedJavaObjects=1"));
-    }
-
-    try {
-      BlobBuilder.constructBlobAndMetadata(
-          "a.bdec",
-          Collections.singletonList(createChannelDataPerTable(0)),
-          Constants.BdecVersion.THREE,
-          encrypt);
-      Assert.fail("Should not pass enableParquetInternalBuffering=true");
-    } catch (SFException e) {
-      Assert.assertEquals(ErrorCode.INTERNAL_ERROR.getMessageCode(), e.getVendorCode());
-      Assert.assertTrue(e.getMessage().contains("serializeFromParquetWriteBuffers"));
-      Assert.assertTrue(e.getMessage().contains("parquetTotalRowsInFooter=1"));
-      Assert.assertTrue(e.getMessage().contains("totalMetadataRowCount=0"));
-      Assert.assertTrue(e.getMessage().contains("parquetTotalRowsWritten=1"));
-      Assert.assertTrue(e.getMessage().contains("perChannelRowCountsInMetadata=0"));
-      Assert.assertTrue(e.getMessage().contains("perBlockRowCountsInFooter=1"));
-      Assert.assertTrue(e.getMessage().contains("channelsCountInMetadata=1"));
-      Assert.assertTrue(e.getMessage().contains("countOfSerializedJavaObjects=-1"));
     }
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -62,16 +62,12 @@ public class BlobBuilderTest {
    * Creates a channel data configurable number of rows in metadata and 1 physical row (using both
    * with and without internal buffering optimization)
    */
-  private List<ChannelData<ParquetChunkData>> createChannelDataPerTable(
-      int metadataRowCount) throws IOException {
+  private List<ChannelData<ParquetChunkData>> createChannelDataPerTable(int metadataRowCount)
+      throws IOException {
     String columnName = "C1";
     ChannelData<ParquetChunkData> channelData = Mockito.spy(new ChannelData<>());
     MessageType schema = createSchema(columnName);
-    Mockito.doReturn(
-            new ParquetFlusher(
-                schema,
-                100L,
-                Constants.BdecParquetCompression.GZIP))
+    Mockito.doReturn(new ParquetFlusher(schema, 100L, Constants.BdecParquetCompression.GZIP))
         .when(channelData)
         .createFlusher();
 
@@ -88,8 +84,7 @@ public class BlobBuilderTest {
     bdecParquetWriter.writeRow(Collections.singletonList("1"));
     channelData.setVectors(
         new ParquetChunkData(
-            Collections.singletonList(Collections.singletonList("A")),
-            new HashMap<>()));
+            Collections.singletonList(Collections.singletonList("A")), new HashMap<>()));
     channelData.setColumnEps(new HashMap<>());
     channelData.setRowCount(metadataRowCount);
     channelData.setMinMaxInsertTimeInMs(new Pair<>(2L, 3L));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -129,7 +129,6 @@ public class RowBufferTest {
         rs -> {},
         initialState,
         ClientBufferParameters.test_createClientBufferParameters(
-            enableParquetMemoryOptimization,
             MAX_CHUNK_SIZE_IN_BYTES_DEFAULT,
             MAX_ALLOWED_ROW_SIZE_IN_BYTES_DEFAULT,
             Constants.BdecParquetCompression.GZIP,

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -31,15 +31,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class RowBufferTest {
-
-  private final boolean enableParquetMemoryOptimization;
   private AbstractRowBuffer<?> rowBufferOnErrorContinue;
   private AbstractRowBuffer<?> rowBufferOnErrorAbort;
   private AbstractRowBuffer<?> rowBufferOnErrorSkipBatch;
-
-  public RowBufferTest() {
-    this.enableParquetMemoryOptimization = false;
-  }
 
   @Before
   public void setupRowBuffer() {


### PR DESCRIPTION
This PR removes `ENABLE_PARQUET_INTERNAL_BUFFERING`, which was an optimization we never enabled. 