### PR TITLE
SNOW-1673203 EP info generation for new table format

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChunkMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChunkMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2021-2024 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.ingest.streaming.internal;
@@ -200,4 +200,14 @@ class ChunkMetadata {
   Long getLastInsertTimeInMs() {
     return this.lastInsertTimeInMs;
   }
+
+  //  @JsonProperty("major_vers")
+  //  Integer getMajorVersion() {
+  //    return PARQUET_MAJOR_VERSION;
+  //  }
+  //
+  //  @JsonProperty("minor_vers")
+  //  Integer getMinorVersion() {
+  //    return PARQUET_MINOR_VERSION;
+  //  }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/EpInfo.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/EpInfo.java
@@ -1,7 +1,5 @@
 package net.snowflake.ingest.streaming.internal;
 
-import static net.snowflake.ingest.utils.Constants.EP_NDV_UNKNOWN;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 import net.snowflake.ingest.utils.ErrorCode;
@@ -33,14 +31,6 @@ class EpInfo {
             String.format(
                 "Null count bigger than total row count on col=%s, nullCount=%s, rowCount=%s",
                 colName, colEp.getNullCount(), rowCount));
-      }
-
-      // Make sure the NDV should always be -1
-      if (colEp.getDistinctValues() != EP_NDV_UNKNOWN) {
-        throw new SFException(
-            ErrorCode.INTERNAL_ERROR,
-            String.format(
-                "Unexpected NDV on col=%s, value=%d", colName, colEp.getDistinctValues()));
       }
     }
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
@@ -1,14 +1,29 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal;
 
 import static net.snowflake.ingest.streaming.internal.BinaryStringUtils.truncateBytesAsHex;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Objects;
+import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.column.statistics.BooleanStatistics;
+import org.apache.parquet.column.statistics.DoubleStatistics;
+import org.apache.parquet.column.statistics.FloatStatistics;
+import org.apache.parquet.column.statistics.IntStatistics;
+import org.apache.parquet.column.statistics.LongStatistics;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 
 /** Audit register endpoint/FileColumnPropertyDTO property list. */
 class FileColumnProperties {
   private int columnOrdinal;
+  private int fieldId;
   private String minStrValue;
 
   private String maxStrValue;
@@ -84,6 +99,40 @@ class FileColumnProperties {
     this.setDistinctValues(stats.getDistinctValues());
   }
 
+  FileColumnProperties(
+      int columnOrdinal, int fieldId, Statistics<?> statistics, long ndv, long maxLength) {
+    this.setColumnOrdinal(columnOrdinal);
+    this.setFieldId(fieldId);
+    this.setNullCount(statistics.getNumNulls());
+    this.setDistinctValues(ndv);
+    this.setCollation(null);
+    this.setMaxStrNonCollated(null);
+    this.setMinStrNonCollated(null);
+
+    if (statistics instanceof BooleanStatistics) {
+      this.setMinIntValue(
+          ((BooleanStatistics) statistics).genericGetMin() ? BigInteger.ONE : BigInteger.ZERO);
+      this.setMaxIntValue(
+          ((BooleanStatistics) statistics).genericGetMax() ? BigInteger.ONE : BigInteger.ZERO);
+    } else if (statistics instanceof IntStatistics || statistics instanceof LongStatistics) {
+      this.setMinIntValue(BigInteger.valueOf(((Number) statistics.genericGetMin()).longValue()));
+      this.setMaxIntValue(BigInteger.valueOf(((Number) statistics.genericGetMax()).longValue()));
+    } else if (statistics instanceof FloatStatistics || statistics instanceof DoubleStatistics) {
+      this.setMinRealValue(new BigDecimal(statistics.genericGetMin().toString()).doubleValue());
+      this.setMaxRealValue(new BigDecimal(statistics.genericGetMax().toString()).doubleValue());
+    } else if (statistics instanceof BinaryStatistics) {
+      if (statistics.type().getLogicalTypeAnnotation()
+          instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
+        this.setMinIntValue(new BigInteger(statistics.getMinBytes()));
+        this.setMaxIntValue(new BigInteger(statistics.getMaxBytes()));
+      } else {
+        this.setMinStrValue(truncateBytesAsHex(statistics.getMinBytes(), false));
+        this.setMaxStrValue(truncateBytesAsHex(statistics.getMaxBytes(), true));
+        this.setMaxLength(maxLength);
+      }
+    }
+  }
+
   @JsonProperty("columnId")
   public int getColumnOrdinal() {
     return columnOrdinal;
@@ -91,6 +140,16 @@ class FileColumnProperties {
 
   public void setColumnOrdinal(int columnOrdinal) {
     this.columnOrdinal = columnOrdinal;
+  }
+
+  @JsonProperty("fieldId")
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  int getFieldId() {
+    return fieldId;
+  }
+
+  void setFieldId(int fieldId) {
+    this.fieldId = fieldId;
   }
 
   // Annotation required in order to have package private fields serialized
@@ -206,6 +265,7 @@ class FileColumnProperties {
   public String toString() {
     final StringBuilder sb = new StringBuilder("{");
     sb.append("\"columnOrdinal\": ").append(columnOrdinal);
+    sb.append(", \"fieldId\": ").append(fieldId);
     if (minIntValue != null) {
       sb.append(", \"minIntValue\": ").append(minIntValue);
       sb.append(", \"maxIntValue\": ").append(maxIntValue);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -603,7 +603,8 @@ class FlushService<T> {
             blobPath.fileName,
             blobData,
             bdecVersion,
-            this.owningClient.getInternalParameterProvider().getEnableChunkEncryption());
+            this.owningClient.getInternalParameterProvider().getEnableChunkEncryption(),
+            this.owningClient.getInternalParameterProvider().getIsIcebergMode());
 
     blob.blobStats.setBuildDurationMs(buildContext);
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.ingest.streaming.internal;
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import net.snowflake.ingest.utils.Pair;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
 
 /**
  * Interface to convert {@link ChannelData} buffered in {@link RowBuffer} to the underlying format
@@ -39,6 +40,9 @@ public interface Flusher<T> {
     final float chunkEstimatedUncompressedSize;
     final ByteArrayOutputStream chunkData;
     final Pair<Long, Long> chunkMinMaxInsertTimeInMs;
+    final List<BlockMetaData> blocksMetadata;
+    final Map<String, Integer> ndvStats;
+    final Map<String, Integer> maxLengthStats;
 
     public SerializationResult(
         List<ChannelMetadata> channelsMetadataList,
@@ -46,13 +50,19 @@ public interface Flusher<T> {
         long rowCount,
         float chunkEstimatedUncompressedSize,
         ByteArrayOutputStream chunkData,
-        Pair<Long, Long> chunkMinMaxInsertTimeInMs) {
+        Pair<Long, Long> chunkMinMaxInsertTimeInMs,
+        List<BlockMetaData> blocksMetadata,
+        Map<String, Integer> ndvStats,
+        Map<String, Integer> maxLengthStats) {
       this.channelsMetadataList = channelsMetadataList;
       this.columnEpStatsMapCombined = columnEpStatsMapCombined;
       this.rowCount = rowCount;
       this.chunkEstimatedUncompressedSize = chunkEstimatedUncompressedSize;
       this.chunkData = chunkData;
       this.chunkMinMaxInsertTimeInMs = chunkMinMaxInsertTimeInMs;
+      this.blocksMetadata = blocksMetadata;
+      this.ndvStats = ndvStats;
+      this.maxLengthStats = maxLengthStats;
     }
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParser.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
-import net.snowflake.ingest.utils.Utils;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
@@ -35,78 +34,70 @@ class IcebergParquetValueParser {
    *
    * @param value column value provided by user in a row
    * @param type Parquet column type
-   * @param stats column stats to update
    * @param defaultTimezone default timezone to use for timestamp parsing
    * @param insertRowsCurrIndex Row index corresponding the row to parse (w.r.t input rows in
    *     insertRows API, and not buffered row)
    * @return parsed value and byte size of Parquet internal representation
    */
   static ParquetBufferValue parseColumnValueToParquet(
-      Object value,
-      Type type,
-      RowBufferStats stats,
-      ZoneId defaultTimezone,
-      long insertRowsCurrIndex) {
-    Utils.assertNotNull("Parquet column stats", stats);
+      Object value, Type type, ZoneId defaultTimezone, long insertRowsCurrIndex) {
     float estimatedParquetSize = 0F;
     if (value != null) {
-      estimatedParquetSize += ParquetBufferValue.DEFINITION_LEVEL_ENCODING_BYTE_LEN;
-      PrimitiveType primitiveType = type.asPrimitiveType();
-      switch (primitiveType.getPrimitiveTypeName()) {
-        case BOOLEAN:
-          int intValue =
-              DataValidationUtil.validateAndParseBoolean(
-                  type.getName(), value, insertRowsCurrIndex);
-          value = intValue > 0;
-          stats.addIntValue(BigInteger.valueOf(intValue));
-          estimatedParquetSize += ParquetBufferValue.BIT_ENCODING_BYTE_LEN;
-          break;
-        case INT32:
-          int intVal = getInt32Value(value, primitiveType, insertRowsCurrIndex);
-          value = intVal;
-          stats.addIntValue(BigInteger.valueOf(intVal));
-          estimatedParquetSize += 4;
-          break;
-        case INT64:
-          long longVal = getInt64Value(value, primitiveType, defaultTimezone, insertRowsCurrIndex);
-          value = longVal;
-          stats.addIntValue(BigInteger.valueOf(longVal));
-          estimatedParquetSize += 8;
-          break;
-        case FLOAT:
-          float floatVal =
-              (float)
-                  DataValidationUtil.validateAndParseReal(
-                      type.getName(), value, insertRowsCurrIndex);
-          value = floatVal;
-          stats.addRealValue((double) floatVal);
-          estimatedParquetSize += 4;
-          break;
-        case DOUBLE:
-          double doubleVal =
-              DataValidationUtil.validateAndParseReal(type.getName(), value, insertRowsCurrIndex);
-          value = doubleVal;
-          stats.addRealValue(doubleVal);
-          estimatedParquetSize += 8;
-          break;
-        case BINARY:
-          byte[] byteVal = getBinaryValue(value, primitiveType, stats, insertRowsCurrIndex);
-          value = byteVal;
-          estimatedParquetSize +=
-              ParquetBufferValue.BYTE_ARRAY_LENGTH_ENCODING_BYTE_LEN + byteVal.length;
-          break;
-        case FIXED_LEN_BYTE_ARRAY:
-          byte[] fixedLenByteArrayVal =
-              getFixedLenByteArrayValue(value, primitiveType, stats, insertRowsCurrIndex);
-          value = fixedLenByteArrayVal;
-          estimatedParquetSize +=
-              ParquetBufferValue.BYTE_ARRAY_LENGTH_ENCODING_BYTE_LEN + fixedLenByteArrayVal.length;
-          break;
-        default:
-          throw new SFException(
-              ErrorCode.UNKNOWN_DATA_TYPE,
-              type.getLogicalTypeAnnotation(),
-              primitiveType.getPrimitiveTypeName());
+      if (type.isPrimitive()) {
+        estimatedParquetSize += ParquetBufferValue.DEFINITION_LEVEL_ENCODING_BYTE_LEN;
+        PrimitiveType primitiveType = type.asPrimitiveType();
+        switch (primitiveType.getPrimitiveTypeName()) {
+          case BOOLEAN:
+            int intValue =
+                DataValidationUtil.validateAndParseBoolean(
+                    type.getName(), value, insertRowsCurrIndex);
+            value = intValue > 0;
+            estimatedParquetSize += ParquetBufferValue.BIT_ENCODING_BYTE_LEN;
+            break;
+          case INT32:
+            value = getInt32Value(value, primitiveType, insertRowsCurrIndex);
+            estimatedParquetSize += 4;
+            break;
+          case INT64:
+            value = getInt64Value(value, primitiveType, defaultTimezone, insertRowsCurrIndex);
+            estimatedParquetSize += 8;
+            break;
+          case FLOAT:
+            value =
+                (float)
+                    DataValidationUtil.validateAndParseReal(
+                        type.getName(), value, insertRowsCurrIndex);
+            ;
+            estimatedParquetSize += 4;
+            break;
+          case DOUBLE:
+            value =
+                DataValidationUtil.validateAndParseReal(type.getName(), value, insertRowsCurrIndex);
+            estimatedParquetSize += 8;
+            break;
+          case BINARY:
+            byte[] byteVal = getBinaryValue(value, primitiveType, insertRowsCurrIndex);
+            value = byteVal;
+            estimatedParquetSize +=
+                ParquetBufferValue.BYTE_ARRAY_LENGTH_ENCODING_BYTE_LEN + byteVal.length;
+            break;
+          case FIXED_LEN_BYTE_ARRAY:
+            byte[] fixedLenByteArrayVal =
+                getFixedLenByteArrayValue(value, primitiveType, insertRowsCurrIndex);
+            value = fixedLenByteArrayVal;
+            estimatedParquetSize +=
+                ParquetBufferValue.BYTE_ARRAY_LENGTH_ENCODING_BYTE_LEN
+                    + fixedLenByteArrayVal.length;
+            break;
+          default:
+            throw new SFException(
+                ErrorCode.UNKNOWN_DATA_TYPE,
+                type.getLogicalTypeAnnotation(),
+                primitiveType.getPrimitiveTypeName());
+        }
+      } else {
+        throw new SFException(
+            ErrorCode.UNKNOWN_DATA_TYPE, type.getLogicalTypeAnnotation(), type.getName());
       }
     }
 
@@ -115,7 +106,6 @@ class IcebergParquetValueParser {
         throw new SFException(
             ErrorCode.INVALID_FORMAT_ROW, type.getName(), "Passed null to non nullable field");
       }
-      stats.incCurrentNullCount();
     }
 
     return new ParquetBufferValue(value, estimatedParquetSize);
@@ -196,12 +186,11 @@ class IcebergParquetValueParser {
    *
    * @param value value to parse
    * @param type Parquet column type
-   * @param stats column stats to update
    * @param insertRowsCurrIndex Used for logging the row of index given in insertRows API
    * @return string representation
    */
   private static byte[] getBinaryValue(
-      Object value, PrimitiveType type, RowBufferStats stats, final long insertRowsCurrIndex) {
+      Object value, PrimitiveType type, final long insertRowsCurrIndex) {
     LogicalTypeAnnotation logicalTypeAnnotation = type.getLogicalTypeAnnotation();
     if (logicalTypeAnnotation == null) {
       byte[] bytes =
@@ -210,7 +199,6 @@ class IcebergParquetValueParser {
               value,
               Optional.of(Constants.BINARY_COLUMN_MAX_SIZE),
               insertRowsCurrIndex);
-      stats.addBinaryValue(bytes);
       return bytes;
     }
     if (logicalTypeAnnotation instanceof StringLogicalTypeAnnotation) {
@@ -220,7 +208,6 @@ class IcebergParquetValueParser {
               value,
               Optional.of(Constants.VARCHAR_COLUMN_MAX_SIZE),
               insertRowsCurrIndex);
-      stats.addStrValue(string);
       return string.getBytes(StandardCharsets.UTF_8);
     }
     throw new SFException(
@@ -232,12 +219,11 @@ class IcebergParquetValueParser {
    *
    * @param value value to parse
    * @param type Parquet column type
-   * @param stats column stats to update
    * @param insertRowsCurrIndex Used for logging the row of index given in insertRows API
    * @return string representation
    */
   private static byte[] getFixedLenByteArrayValue(
-      Object value, PrimitiveType type, RowBufferStats stats, final long insertRowsCurrIndex) {
+      Object value, PrimitiveType type, final long insertRowsCurrIndex) {
     LogicalTypeAnnotation logicalTypeAnnotation = type.getLogicalTypeAnnotation();
     int length = type.getTypeLength();
     byte[] bytes = null;
@@ -245,11 +231,9 @@ class IcebergParquetValueParser {
       bytes =
           DataValidationUtil.validateAndParseBinary(
               type.getName(), value, Optional.of(length), insertRowsCurrIndex);
-      stats.addBinaryValue(bytes);
     }
     if (logicalTypeAnnotation instanceof DecimalLogicalTypeAnnotation) {
       BigInteger bigIntegerVal = getDecimalValue(value, type, insertRowsCurrIndex).unscaledValue();
-      stats.addIntValue(bigIntegerVal);
       bytes = bigIntegerVal.toByteArray();
       if (bytes.length < length) {
         byte[] newBytes = new byte[length];

--- a/src/main/java/net/snowflake/ingest/streaming/internal/InternalParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/InternalParameterProvider.java
@@ -17,4 +17,8 @@ class InternalParameterProvider {
     // mode does not need client-side encryption.
     return !isIcebergMode;
   }
+
+  boolean getIsIcebergMode() {
+    return isIcebergMode;
+  }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -174,7 +174,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       ParquetBufferValue valueWithSize =
           (clientBufferParameters.getIsIcebergMode()
               ? IcebergParquetValueParser.parseColumnValueToParquet(
-                  value, parquetColumn.type, forkedStats, defaultTimezone, insertRowsCurrIndex)
+                  value, parquetColumn.type, defaultTimezone, insertRowsCurrIndex)
               : SnowflakeParquetValueParser.parseColumnValueToParquet(
                   value,
                   column,
@@ -293,6 +293,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
     return new ParquetFlusher(
         schema,
         clientBufferParameters.getMaxChunkSizeInBytes(),
-        clientBufferParameters.getBdecParquetCompression());
+        clientBufferParameters.getBdecParquetCompression(),
+        clientBufferParameters.getIsIcebergMode());
   }
 }

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -71,6 +71,9 @@ public class Constants {
   public static final String DROP_CHANNEL_ENDPOINT = "/v1/streaming/channels/drop/";
   public static final String REGISTER_BLOB_ENDPOINT = "/v1/streaming/channels/write/blobs/";
 
+  public static final int PARQUET_MAJOR_VERSION = 1;
+  public static final int PARQUET_MINOR_VERSION = 0;
+
   public enum WriteMode {
     CLOUD_STORAGE,
     REST_API,

--- a/src/main/java/org/apache/parquet/hadoop/BdecParquetWriter.java
+++ b/src/main/java/org/apache/parquet/hadoop/BdecParquetWriter.java
@@ -7,13 +7,14 @@ package org.apache.parquet.hadoop;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.values.factory.DefaultV1ValuesWriterFactory;
 import org.apache.parquet.crypto.FileEncryptionProperties;
@@ -39,6 +40,7 @@ import org.apache.parquet.schema.Type;
 public class BdecParquetWriter implements AutoCloseable {
   private final InternalParquetRecordWriter<List<Object>> writer;
   private final CodecFactory codecFactory;
+  private final BdecWriteSupport writeSupport;
   private long rowsWritten = 0;
 
   /**
@@ -48,6 +50,7 @@ public class BdecParquetWriter implements AutoCloseable {
    * @param schema row schema
    * @param extraMetaData extra metadata
    * @param channelName name of the channel that is using the writer
+   * @param enableNdvAndMaxLengthStats whether to record NDV and MaxLength
    * @throws IOException
    */
   public BdecParquetWriter(
@@ -56,13 +59,14 @@ public class BdecParquetWriter implements AutoCloseable {
       Map<String, String> extraMetaData,
       String channelName,
       long maxChunkSizeInBytes,
-      Constants.BdecParquetCompression bdecParquetCompression)
+      Constants.BdecParquetCompression bdecParquetCompression,
+      boolean enableNdvAndMaxLengthStats)
       throws IOException {
     OutputFile file = new ByteArrayOutputFile(stream, maxChunkSizeInBytes);
     ParquetProperties encodingProps = createParquetProperties();
     Configuration conf = new Configuration();
-    WriteSupport<List<Object>> writeSupport =
-        new BdecWriteSupport(schema, extraMetaData, channelName);
+    writeSupport =
+        new BdecWriteSupport(schema, extraMetaData, channelName, enableNdvAndMaxLengthStats);
     WriteSupport.WriteContext writeContext = writeSupport.init(conf);
 
     ParquetFileWriter fileWriter =
@@ -112,6 +116,23 @@ public class BdecParquetWriter implements AutoCloseable {
       blockRowCounts.add(metadata.getRowCount());
     }
     return blockRowCounts;
+  }
+
+  public List<BlockMetaData> getBlocksMetadata() {
+    return writer.getFooter().getBlocks();
+  }
+
+  public Map<String, Integer> getMaxLengthStats() {
+    return writeSupport.maxLengthStats;
+  }
+
+  public Map<String, Integer> getNdvStats() {
+    if (!writeSupport.enableNdvAndMaxLengthStats) {
+      return null;
+    }
+    Map<String, Integer> ndvStats = new HashMap<>();
+    writeSupport.ndvStatsSet.forEach((k, v) -> ndvStats.put(k, v.size()));
+    return ndvStats;
   }
 
   public void writeRow(List<Object> row) {
@@ -246,16 +267,28 @@ public class BdecParquetWriter implements AutoCloseable {
     RecordConsumer recordConsumer;
     Map<String, String> extraMetadata;
     private final String channelName;
+    boolean enableNdvAndMaxLengthStats;
+    Map<String, HashSet<Object>> ndvStatsSet;
+    Map<String, Integer> maxLengthStats;
 
     // TODO SNOW-672156: support specifying encodings and compression
-    BdecWriteSupport(MessageType schema, Map<String, String> extraMetadata, String channelName) {
+    BdecWriteSupport(
+        MessageType schema,
+        Map<String, String> extraMetadata,
+        String channelName,
+        boolean enableNdvAndMaxLengthStats) {
       this.schema = schema;
       this.extraMetadata = extraMetadata;
       this.channelName = channelName;
+      this.enableNdvAndMaxLengthStats = enableNdvAndMaxLengthStats;
     }
 
     @Override
     public WriteContext init(Configuration config) {
+      if (enableNdvAndMaxLengthStats) {
+        ndvStatsSet = new HashMap<>();
+        maxLengthStats = new HashMap<>();
+      }
       return new WriteContext(schema, extraMetadata);
     }
 
@@ -266,7 +299,7 @@ public class BdecParquetWriter implements AutoCloseable {
 
     @Override
     public void write(List<Object> values) {
-      List<ColumnDescriptor> cols = schema.getColumns();
+      List<Type> cols = schema.getFields();
       if (values.size() != cols.size()) {
         throw new ParquetEncodingException(
             "Invalid input data in channel '"
@@ -281,20 +314,24 @@ public class BdecParquetWriter implements AutoCloseable {
                 + values);
       }
       recordConsumer.startMessage();
-      writeValues(values, schema);
+      writeValues(values, schema, "");
       recordConsumer.endMessage();
     }
 
-    private void writeValues(List<Object> values, GroupType type) {
+    private void writeValues(List<Object> values, GroupType type, String path) {
       List<Type> cols = type.getFields();
       for (int i = 0; i < cols.size(); ++i) {
         Object val = values.get(i);
         if (val != null) {
           String fieldName = cols.get(i).getName();
+          String currentPath = !path.isEmpty() ? path + "." + fieldName : fieldName;
           recordConsumer.startField(fieldName, i);
           if (cols.get(i).isPrimitive()) {
             PrimitiveType.PrimitiveTypeName typeName =
                 cols.get(i).asPrimitiveType().getPrimitiveTypeName();
+            if (enableNdvAndMaxLengthStats) {
+              ndvStatsSet.computeIfAbsent(currentPath, k -> new HashSet<>()).add(val);
+            }
             switch (typeName) {
               case BOOLEAN:
                 recordConsumer.addBoolean((boolean) val);
@@ -317,6 +354,9 @@ public class BdecParquetWriter implements AutoCloseable {
                         ? Binary.fromString((String) val)
                         : Binary.fromConstantByteArray((byte[]) val);
                 recordConsumer.addBinary(binVal);
+                if (enableNdvAndMaxLengthStats) {
+                  maxLengthStats.merge(currentPath, binVal.length(), Math::max);
+                }
                 break;
               case FIXED_LEN_BYTE_ARRAY:
                 Binary binary = Binary.fromConstantByteArray((byte[]) val);
@@ -327,7 +367,19 @@ public class BdecParquetWriter implements AutoCloseable {
                     "Unsupported column type: " + cols.get(i).asPrimitiveType());
             }
           } else {
-            throw new ParquetEncodingException("Unsupported column type: " + cols.get(i));
+            if (cols.get(i).isRepetition(Type.Repetition.REPEATED)) {
+              for (Object o : values) {
+                recordConsumer.startGroup();
+                if (o != null) {
+                  writeValues((List<Object>) o, cols.get(i).asGroupType(), currentPath);
+                }
+                recordConsumer.endGroup();
+              }
+            } else {
+              recordConsumer.startGroup();
+              writeValues((List<Object>) val, cols.get(i).asGroupType(), currentPath);
+              recordConsumer.endGroup();
+            }
           }
           recordConsumer.endField(fieldName, i);
         }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -37,7 +37,8 @@ public class BlobBuilderTest {
         "a.bdec",
         Collections.singletonList(createChannelDataPerTable(1)),
         Constants.BdecVersion.THREE,
-        encrypt);
+        encrypt,
+        !encrypt);
 
     // Construction fails if metadata contains 0 rows and data 1 row
     try {
@@ -45,7 +46,8 @@ public class BlobBuilderTest {
           "a.bdec",
           Collections.singletonList(createChannelDataPerTable(0)),
           Constants.BdecVersion.THREE,
-          encrypt);
+          encrypt,
+          !encrypt);
     } catch (SFException e) {
       Assert.assertEquals(ErrorCode.INTERNAL_ERROR.getMessageCode(), e.getVendorCode());
       Assert.assertTrue(e.getMessage().contains("parquetTotalRowsInFooter=1"));
@@ -67,7 +69,7 @@ public class BlobBuilderTest {
     String columnName = "C1";
     ChannelData<ParquetChunkData> channelData = Mockito.spy(new ChannelData<>());
     MessageType schema = createSchema(columnName);
-    Mockito.doReturn(new ParquetFlusher(schema, 100L, Constants.BdecParquetCompression.GZIP))
+    Mockito.doReturn(new ParquetFlusher(schema, 100L, Constants.BdecParquetCompression.GZIP, false))
         .when(channelData)
         .createFlusher();
 
@@ -80,7 +82,8 @@ public class BlobBuilderTest {
             new HashMap<>(),
             "CHANNEL",
             1000,
-            Constants.BdecParquetCompression.GZIP);
+            Constants.BdecParquetCompression.GZIP,
+            false);
     bdecParquetWriter.writeRow(Collections.singletonList("1"));
     channelData.setVectors(
         new ParquetChunkData(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -866,17 +866,21 @@ public class FlushServiceTest {
     Map<String, RowBufferStats> eps1 = new HashMap<>();
     Map<String, RowBufferStats> eps2 = new HashMap<>();
 
-    RowBufferStats stats1 = new RowBufferStats("COL1");
-    RowBufferStats stats2 = new RowBufferStats("COL1");
+    RowBufferStats stats1col1 = new RowBufferStats("testBuildAndUpload1");
+    RowBufferStats stats1col2 = new RowBufferStats("testBuildAndUpload2");
+    RowBufferStats stats2col1 = new RowBufferStats("testBuildAndUpload1");
+    RowBufferStats stats2col2 = new RowBufferStats("testBuildAndUpload2");
 
-    eps1.put("one", stats1);
-    eps2.put("one", stats2);
+    eps1.put("testBuildAndUpload1", stats1col1);
+    eps1.put("testBuildAndUpload2", stats1col2);
+    eps2.put("testBuildAndUpload1", stats2col1);
+    eps2.put("testBuildAndUpload2", stats2col2);
 
-    stats1.addIntValue(new BigInteger("10"));
-    stats1.addIntValue(new BigInteger("15"));
-    stats2.addIntValue(new BigInteger("11"));
-    stats2.addIntValue(new BigInteger("13"));
-    stats2.addIntValue(new BigInteger("17"));
+    stats1col1.addIntValue(new BigInteger("11"));
+    stats1col1.addIntValue(new BigInteger("22"));
+    stats1col2.addStrValue("bob");
+    stats2col1.addIntValue(null);
+    stats2col2.addStrValue("toby");
 
     channel1Data.setColumnEps(eps1);
     channel2Data.setColumnEps(eps2);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParserTest.java
@@ -8,6 +8,7 @@ import static java.time.ZoneOffset.UTC;
 import static net.snowflake.ingest.streaming.internal.ParquetBufferValue.BYTE_ARRAY_LENGTH_ENCODING_BYTE_LEN;
 import static net.snowflake.ingest.streaming.internal.ParquetBufferValue.DEFINITION_LEVEL_ENCODING_BYTE_LEN;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
@@ -19,17 +20,16 @@ import org.junit.Test;
 
 public class IcebergParquetValueParserTest {
 
+  static ObjectMapper objectMapper = new ObjectMapper();
+
   @Test
   public void parseValueBoolean() {
     Type type =
         Types.primitive(PrimitiveTypeName.BOOLEAN, Repetition.OPTIONAL).named("BOOLEAN_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("BOOLEAN_COL");
-    ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(true, type, rowBufferStats, UTC, 0);
+    ParquetBufferValue pv = IcebergParquetValueParser.parseColumnValueToParquet(true, type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(Boolean.class)
         .expectedParsedValue(true)
         .expectedSize(ParquetBufferValue.BIT_ENCODING_BYTE_LEN + DEFINITION_LEVEL_ENCODING_BYTE_LEN)
@@ -41,13 +41,10 @@ public class IcebergParquetValueParserTest {
   public void parseValueInt() {
     Type type = Types.primitive(PrimitiveTypeName.INT32, Repetition.OPTIONAL).named("INT_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("INT_COL");
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(
-            Integer.MAX_VALUE, type, rowBufferStats, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(Integer.MAX_VALUE, type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
         .expectedParsedValue(Integer.MAX_VALUE)
         .expectedSize(4.0f + DEFINITION_LEVEL_ENCODING_BYTE_LEN)
@@ -62,13 +59,11 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.decimalType(4, 9))
             .named("DECIMAL_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("DECIMAL_COL");
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            new BigDecimal("12345.6789"), type, rowBufferStats, UTC, 0);
+            new BigDecimal("12345.6789"), type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
         .expectedParsedValue(123456789)
         .expectedSize(4.0f + DEFINITION_LEVEL_ENCODING_BYTE_LEN)
@@ -83,13 +78,10 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.dateType())
             .named("DATE_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("DATE_COL");
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(
-            "2024-01-01", type, rowBufferStats, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet("2024-01-01", type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(Integer.class)
         .expectedParsedValue(19723)
         .expectedSize(4.0f + DEFINITION_LEVEL_ENCODING_BYTE_LEN)
@@ -101,13 +93,10 @@ public class IcebergParquetValueParserTest {
   public void parseValueLong() {
     Type type = Types.primitive(PrimitiveTypeName.INT64, Repetition.OPTIONAL).named("LONG_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("LONG_COL");
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(
-            Long.MAX_VALUE, type, rowBufferStats, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(Long.MAX_VALUE, type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(Long.class)
         .expectedParsedValue(Long.MAX_VALUE)
         .expectedSize(8.0f + DEFINITION_LEVEL_ENCODING_BYTE_LEN)
@@ -122,13 +111,11 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.decimalType(9, 18))
             .named("DECIMAL_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("DECIMAL_COL");
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            new BigDecimal("123456789.123456789"), type, rowBufferStats, UTC, 0);
+            new BigDecimal("123456789.123456789"), type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(Long.class)
         .expectedParsedValue(123456789123456789L)
         .expectedSize(8.0f + DEFINITION_LEVEL_ENCODING_BYTE_LEN)
@@ -143,13 +130,10 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.timeType(false, LogicalTypeAnnotation.TimeUnit.MICROS))
             .named("TIME_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("TIME_COL");
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(
-            "12:34:56.789", type, rowBufferStats, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet("12:34:56.789", type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(Long.class)
         .expectedParsedValue(45296789000L)
         .expectedSize(8.0f + DEFINITION_LEVEL_ENCODING_BYTE_LEN)
@@ -164,13 +148,11 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.MICROS))
             .named("TIMESTAMP_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("TIMESTAMP_COL");
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            "2024-01-01T12:34:56.789+08:00", type, rowBufferStats, UTC, 0);
+            "2024-01-01T12:34:56.789+08:00", type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(Long.class)
         .expectedParsedValue(1704112496789000L)
         .expectedSize(8.0f + DEFINITION_LEVEL_ENCODING_BYTE_LEN)
@@ -185,13 +167,11 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
             .named("TIMESTAMP_TZ_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("TIMESTAMP_TZ_COL");
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            "2024-01-01T12:34:56.789+08:00", type, rowBufferStats, UTC, 0);
+            "2024-01-01T12:34:56.789+08:00", type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(Long.class)
         .expectedParsedValue(1704083696789000L)
         .expectedSize(8.0f + DEFINITION_LEVEL_ENCODING_BYTE_LEN)
@@ -203,13 +183,10 @@ public class IcebergParquetValueParserTest {
   public void parseValueFloat() {
     Type type = Types.primitive(PrimitiveTypeName.FLOAT, Repetition.OPTIONAL).named("FLOAT_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("FLOAT_COL");
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(
-            Float.MAX_VALUE, type, rowBufferStats, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(Float.MAX_VALUE, type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(Float.class)
         .expectedParsedValue(Float.MAX_VALUE)
         .expectedSize(4.0f + DEFINITION_LEVEL_ENCODING_BYTE_LEN)
@@ -221,13 +198,10 @@ public class IcebergParquetValueParserTest {
   public void parseValueDouble() {
     Type type = Types.primitive(PrimitiveTypeName.DOUBLE, Repetition.OPTIONAL).named("DOUBLE_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("DOUBLE_COL");
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(
-            Double.MAX_VALUE, type, rowBufferStats, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(Double.MAX_VALUE, type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(Double.class)
         .expectedParsedValue(Double.MAX_VALUE)
         .expectedSize(8.0f + DEFINITION_LEVEL_ENCODING_BYTE_LEN)
@@ -239,13 +213,11 @@ public class IcebergParquetValueParserTest {
   public void parseValueBinary() {
     Type type = Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL).named("BINARY_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("BINARY_COL");
     byte[] value = "snowflake_to_the_moon".getBytes();
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(value, type, rowBufferStats, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(value, type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(byte[].class)
         .expectedParsedValue(value)
         .expectedSize(
@@ -261,13 +233,11 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.stringType())
             .named("BINARY_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("BINARY_COL");
     String value = "snowflake_to_the_moon";
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(value, type, rowBufferStats, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(value, type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(byte[].class)
         .expectedParsedValue(value.getBytes())
         .expectedSize(
@@ -285,13 +255,11 @@ public class IcebergParquetValueParserTest {
             .length(4)
             .named("FIXED_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("FIXED_COL");
     byte[] value = "snow".getBytes();
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(value, type, rowBufferStats, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(value, type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(byte[].class)
         .expectedParsedValue(value)
         .expectedSize(
@@ -308,13 +276,11 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.decimalType(10, 20))
             .named("FIXED_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("FIXED_COL");
     BigDecimal value = new BigDecimal("1234567890.0123456789");
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(value, type, rowBufferStats, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(value, type, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
-        .rowBufferStats(rowBufferStats)
         .expectedValueClass(byte[].class)
         .expectedParsedValue(value.unscaledValue().toByteArray())
         .expectedSize(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserAssertionBuilder.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParquetValueParserAssertionBuilder.java
@@ -7,6 +7,7 @@ package net.snowflake.ingest.streaming.internal;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.junit.Assert;
 
 /** Builder that helps to assert parsing of values to parquet types */
@@ -64,41 +65,64 @@ class ParquetValueParserAssertionBuilder {
     if (valueClass.equals(byte[].class)) {
       Assert.assertArrayEquals((byte[]) value, (byte[]) parquetBufferValue.getValue());
     } else {
-      Assert.assertEquals(value, parquetBufferValue.getValue());
+      assertValueEquals(value, parquetBufferValue.getValue());
     }
     Assert.assertEquals(size, parquetBufferValue.getSize(), 0);
-    if (minMaxStat instanceof BigInteger) {
-      Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMinIntValue());
-      Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMaxIntValue());
-      return;
-    } else if (minMaxStat instanceof byte[]) {
-      Assert.assertArrayEquals((byte[]) minMaxStat, rowBufferStats.getCurrentMinStrValue());
-      Assert.assertArrayEquals((byte[]) minMaxStat, rowBufferStats.getCurrentMaxStrValue());
-      return;
-    } else if (valueClass.equals(String.class)) {
-      // String can have null min/max stats for variant data types
-      Object min =
-          rowBufferStats.getCurrentMinStrValue() != null
-              ? new String(rowBufferStats.getCurrentMinStrValue(), StandardCharsets.UTF_8)
-              : rowBufferStats.getCurrentMinStrValue();
-      Object max =
-          rowBufferStats.getCurrentMaxStrValue() != null
-              ? new String(rowBufferStats.getCurrentMaxStrValue(), StandardCharsets.UTF_8)
-              : rowBufferStats.getCurrentMaxStrValue();
-      Assert.assertEquals(minMaxStat, min);
-      Assert.assertEquals(minMaxStat, max);
-      return;
-    } else if (minMaxStat instanceof Double || minMaxStat instanceof BigDecimal) {
-      Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMinRealValue());
-      Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMaxRealValue());
-      return;
+    if (rowBufferStats != null) {
+      if (minMaxStat instanceof BigInteger) {
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMinIntValue());
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMaxIntValue());
+        return;
+      } else if (minMaxStat instanceof byte[]) {
+        Assert.assertArrayEquals((byte[]) minMaxStat, rowBufferStats.getCurrentMinStrValue());
+        Assert.assertArrayEquals((byte[]) minMaxStat, rowBufferStats.getCurrentMaxStrValue());
+        return;
+      } else if (valueClass.equals(String.class)) {
+        // String can have null min/max stats for variant data types
+        Object min =
+            rowBufferStats.getCurrentMinStrValue() != null
+                ? new String(rowBufferStats.getCurrentMinStrValue(), StandardCharsets.UTF_8)
+                : rowBufferStats.getCurrentMinStrValue();
+        Object max =
+            rowBufferStats.getCurrentMaxStrValue() != null
+                ? new String(rowBufferStats.getCurrentMaxStrValue(), StandardCharsets.UTF_8)
+                : rowBufferStats.getCurrentMaxStrValue();
+        Assert.assertEquals(minMaxStat, min);
+        Assert.assertEquals(minMaxStat, max);
+        return;
+      } else if (minMaxStat instanceof Double || minMaxStat instanceof BigDecimal) {
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMinRealValue());
+        Assert.assertEquals(minMaxStat, rowBufferStats.getCurrentMaxRealValue());
+        return;
+      }
+      throw new IllegalArgumentException(
+          String.format("Unknown data type for min stat: %s", minMaxStat.getClass()));
     }
-    throw new IllegalArgumentException(
-        String.format("Unknown data type for min stat: %s", minMaxStat.getClass()));
   }
 
   void assertNull() {
     Assert.assertNull(parquetBufferValue.getValue());
     Assert.assertEquals(currentNullCount, rowBufferStats.getCurrentNullCount());
+  }
+
+  void assertValueEquals(Object expectedValue, Object actualValue) {
+    if (expectedValue == null) {
+      Assert.assertNull(actualValue);
+      return;
+    }
+    if (expectedValue instanceof List) {
+      Assert.assertTrue(actualValue instanceof List);
+      List<?> expectedList = (List<?>) expectedValue;
+      List<?> actualList = (List<?>) actualValue;
+      Assert.assertEquals(expectedList.size(), actualList.size());
+      for (int i = 0; i < expectedList.size(); i++) {
+        assertValueEquals(expectedList.get(i), actualList.get(i));
+      }
+    } else if (expectedValue.getClass().equals(byte[].class)) {
+      Assert.assertEquals(byte[].class, actualValue.getClass());
+      Assert.assertArrayEquals((byte[]) expectedValue, (byte[]) actualValue);
+    } else {
+      Assert.assertEquals(expectedValue, actualValue);
+    }
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -759,46 +759,51 @@ public class RowBufferTest {
     ChannelData<?> result = rowBuffer.flush();
     Map<String, RowBufferStats> columnEpStats = result.getColumnEps();
 
-    Assert.assertEquals(
-        BigInteger.valueOf(11), columnEpStats.get("colTinyInt").getCurrentMaxIntValue());
-    Assert.assertEquals(
-        BigInteger.valueOf(10), columnEpStats.get("colTinyInt").getCurrentMinIntValue());
-    Assert.assertEquals(0, columnEpStats.get("colTinyInt").getCurrentNullCount());
-    Assert.assertEquals(-1, columnEpStats.get("colTinyInt").getDistinctValues());
+    if (!isIcebergMode) {
+      Assert.assertEquals(
+          BigInteger.valueOf(11), columnEpStats.get("colTinyInt").getCurrentMaxIntValue());
+      Assert.assertEquals(
+          BigInteger.valueOf(10), columnEpStats.get("colTinyInt").getCurrentMinIntValue());
+      Assert.assertEquals(0, columnEpStats.get("colTinyInt").getCurrentNullCount());
+      Assert.assertEquals(-1, columnEpStats.get("colTinyInt").getDistinctValues());
 
-    Assert.assertEquals(
-        BigInteger.valueOf(1), columnEpStats.get("COLTINYINT").getCurrentMaxIntValue());
-    Assert.assertEquals(
-        BigInteger.valueOf(1), columnEpStats.get("COLTINYINT").getCurrentMinIntValue());
-    Assert.assertEquals(0, columnEpStats.get("COLTINYINT").getCurrentNullCount());
-    Assert.assertEquals(-1, columnEpStats.get("COLTINYINT").getDistinctValues());
+      Assert.assertEquals(
+          BigInteger.valueOf(1), columnEpStats.get("COLTINYINT").getCurrentMaxIntValue());
+      Assert.assertEquals(
+          BigInteger.valueOf(1), columnEpStats.get("COLTINYINT").getCurrentMinIntValue());
+      Assert.assertEquals(0, columnEpStats.get("COLTINYINT").getCurrentNullCount());
+      Assert.assertEquals(-1, columnEpStats.get("COLTINYINT").getDistinctValues());
 
-    Assert.assertEquals(
-        BigInteger.valueOf(3), columnEpStats.get("COLSMALLINT").getCurrentMaxIntValue());
-    Assert.assertEquals(
-        BigInteger.valueOf(2), columnEpStats.get("COLSMALLINT").getCurrentMinIntValue());
-    Assert.assertEquals(0, columnEpStats.get("COLSMALLINT").getCurrentNullCount());
-    Assert.assertEquals(-1, columnEpStats.get("COLSMALLINT").getDistinctValues());
+      Assert.assertEquals(
+          BigInteger.valueOf(3), columnEpStats.get("COLSMALLINT").getCurrentMaxIntValue());
+      Assert.assertEquals(
+          BigInteger.valueOf(2), columnEpStats.get("COLSMALLINT").getCurrentMinIntValue());
+      Assert.assertEquals(0, columnEpStats.get("COLSMALLINT").getCurrentNullCount());
+      Assert.assertEquals(-1, columnEpStats.get("COLSMALLINT").getDistinctValues());
 
-    Assert.assertEquals(BigInteger.valueOf(3), columnEpStats.get("COLINT").getCurrentMaxIntValue());
-    Assert.assertEquals(BigInteger.valueOf(3), columnEpStats.get("COLINT").getCurrentMinIntValue());
-    Assert.assertEquals(1L, columnEpStats.get("COLINT").getCurrentNullCount());
-    Assert.assertEquals(-1, columnEpStats.get("COLINT").getDistinctValues());
+      Assert.assertEquals(
+          BigInteger.valueOf(3), columnEpStats.get("COLINT").getCurrentMaxIntValue());
+      Assert.assertEquals(
+          BigInteger.valueOf(3), columnEpStats.get("COLINT").getCurrentMinIntValue());
+      Assert.assertEquals(1L, columnEpStats.get("COLINT").getCurrentNullCount());
+      Assert.assertEquals(-1, columnEpStats.get("COLINT").getDistinctValues());
 
-    Assert.assertEquals(
-        BigInteger.valueOf(40), columnEpStats.get("COLBIGINT").getCurrentMaxIntValue());
-    Assert.assertEquals(
-        BigInteger.valueOf(4), columnEpStats.get("COLBIGINT").getCurrentMinIntValue());
-    Assert.assertEquals(0, columnEpStats.get("COLBIGINT").getCurrentNullCount());
-    Assert.assertEquals(-1, columnEpStats.get("COLBIGINT").getDistinctValues());
+      Assert.assertEquals(
+          BigInteger.valueOf(40), columnEpStats.get("COLBIGINT").getCurrentMaxIntValue());
+      Assert.assertEquals(
+          BigInteger.valueOf(4), columnEpStats.get("COLBIGINT").getCurrentMinIntValue());
+      Assert.assertEquals(0, columnEpStats.get("COLBIGINT").getCurrentNullCount());
+      Assert.assertEquals(-1, columnEpStats.get("COLBIGINT").getDistinctValues());
 
-    Assert.assertArrayEquals(
-        "2".getBytes(StandardCharsets.UTF_8), columnEpStats.get("COLCHAR").getCurrentMinStrValue());
-    Assert.assertArrayEquals(
-        "alice".getBytes(StandardCharsets.UTF_8),
-        columnEpStats.get("COLCHAR").getCurrentMaxStrValue());
-    Assert.assertEquals(0, columnEpStats.get("COLCHAR").getCurrentNullCount());
-    Assert.assertEquals(-1, columnEpStats.get("COLCHAR").getDistinctValues());
+      Assert.assertArrayEquals(
+          "2".getBytes(StandardCharsets.UTF_8),
+          columnEpStats.get("COLCHAR").getCurrentMinStrValue());
+      Assert.assertArrayEquals(
+          "alice".getBytes(StandardCharsets.UTF_8),
+          columnEpStats.get("COLCHAR").getCurrentMaxStrValue());
+      Assert.assertEquals(0, columnEpStats.get("COLCHAR").getCurrentNullCount());
+      Assert.assertEquals(-1, columnEpStats.get("COLCHAR").getDistinctValues());
+    }
 
     // Confirm we reset
     ChannelData<?> resetResults = rowBuffer.flush();
@@ -869,15 +874,14 @@ public class RowBufferTest {
     ChannelData<?> result = innerBuffer.flush();
     Assert.assertEquals(3, result.getRowCount());
 
-    Assert.assertEquals(
-        BigInteger.valueOf(1621899220 * (isIcebergMode ? 1000000L : 1)),
-        result.getColumnEps().get("COLTIMESTAMPLTZ_SB8").getCurrentMinIntValue());
-    Assert.assertEquals(
-        BigInteger.valueOf(1621899221 * (isIcebergMode ? 1000000L : 1)),
-        result.getColumnEps().get("COLTIMESTAMPLTZ_SB8").getCurrentMaxIntValue());
-
-    /* Iceberg only supports microsecond precision for TIMESTAMP_LTZ */
     if (!isIcebergMode) {
+      Assert.assertEquals(
+          BigInteger.valueOf(1621899220),
+          result.getColumnEps().get("COLTIMESTAMPLTZ_SB8").getCurrentMinIntValue());
+      Assert.assertEquals(
+          BigInteger.valueOf(1621899221),
+          result.getColumnEps().get("COLTIMESTAMPLTZ_SB8").getCurrentMaxIntValue());
+
       Assert.assertEquals(
           new BigInteger("1621899220123456789"),
           result.getColumnEps().get("COLTIMESTAMPLTZ_SB16").getCurrentMinIntValue());
@@ -886,18 +890,19 @@ public class RowBufferTest {
           result.getColumnEps().get("COLTIMESTAMPLTZ_SB16").getCurrentMaxIntValue());
       Assert.assertEquals(
           1, result.getColumnEps().get("COLTIMESTAMPLTZ_SB16").getCurrentNullCount());
+
+      Assert.assertEquals(
+          new BigInteger("1621899220123456"),
+          result.getColumnEps().get("COLTIMESTAMPLTZ_SB16_SCALE6").getCurrentMinIntValue());
+      Assert.assertEquals(
+          new BigInteger("1621899220123457"),
+          result.getColumnEps().get("COLTIMESTAMPLTZ_SB16_SCALE6").getCurrentMaxIntValue());
+
+      Assert.assertEquals(
+          1, result.getColumnEps().get("COLTIMESTAMPLTZ_SB8").getCurrentNullCount());
+      Assert.assertEquals(
+          1, result.getColumnEps().get("COLTIMESTAMPLTZ_SB16_SCALE6").getCurrentNullCount());
     }
-
-    Assert.assertEquals(
-        new BigInteger("1621899220123456"),
-        result.getColumnEps().get("COLTIMESTAMPLTZ_SB16_SCALE6").getCurrentMinIntValue());
-    Assert.assertEquals(
-        new BigInteger("1621899220123457"),
-        result.getColumnEps().get("COLTIMESTAMPLTZ_SB16_SCALE6").getCurrentMaxIntValue());
-
-    Assert.assertEquals(1, result.getColumnEps().get("COLTIMESTAMPLTZ_SB8").getCurrentNullCount());
-    Assert.assertEquals(
-        1, result.getColumnEps().get("COLTIMESTAMPLTZ_SB16_SCALE6").getCurrentNullCount());
   }
 
   @Test
@@ -942,12 +947,14 @@ public class RowBufferTest {
     ChannelData<?> result = innerBuffer.flush();
     Assert.assertEquals(3, result.getRowCount());
 
-    Assert.assertEquals(
-        BigInteger.valueOf(18772), result.getColumnEps().get("COLDATE").getCurrentMinIntValue());
-    Assert.assertEquals(
-        BigInteger.valueOf(18773), result.getColumnEps().get("COLDATE").getCurrentMaxIntValue());
+    if (!isIcebergMode) {
+      Assert.assertEquals(
+          BigInteger.valueOf(18772), result.getColumnEps().get("COLDATE").getCurrentMinIntValue());
+      Assert.assertEquals(
+          BigInteger.valueOf(18773), result.getColumnEps().get("COLDATE").getCurrentMaxIntValue());
 
-    Assert.assertEquals(1, result.getColumnEps().get("COLDATE").getCurrentNullCount());
+      Assert.assertEquals(1, result.getColumnEps().get("COLDATE").getCurrentNullCount());
+    }
   }
 
   @Test
@@ -1026,23 +1033,7 @@ public class RowBufferTest {
     ChannelData<?> result = innerBuffer.flush();
     Assert.assertEquals(3, result.getRowCount());
 
-    if (isIcebergMode) {
-      Assert.assertEquals(
-          BigInteger.valueOf(10 * 60 * 60 * 1000000L),
-          result.getColumnEps().get("COLTIMESB4").getCurrentMinIntValue());
-      Assert.assertEquals(
-          BigInteger.valueOf((11 * 60 * 60 + 15 * 60) * 1000000L),
-          result.getColumnEps().get("COLTIMESB4").getCurrentMaxIntValue());
-      Assert.assertEquals(1, result.getColumnEps().get("COLTIMESB4").getCurrentNullCount());
-
-      Assert.assertEquals(
-          BigInteger.valueOf((10 * 60 * 60 * 1000L + 123) * 1000L),
-          result.getColumnEps().get("COLTIMESB8").getCurrentMinIntValue());
-      Assert.assertEquals(
-          BigInteger.valueOf((11 * 60 * 60 * 1000L + 15 * 60 * 1000 + 456) * 1000L),
-          result.getColumnEps().get("COLTIMESB8").getCurrentMaxIntValue());
-      Assert.assertEquals(1, result.getColumnEps().get("COLTIMESB8").getCurrentNullCount());
-    } else {
+    if (!isIcebergMode) {
       Assert.assertEquals(
           BigInteger.valueOf(10 * 60 * 60),
           result.getColumnEps().get("COLTIMESB4").getCurrentMinIntValue());
@@ -1274,23 +1265,27 @@ public class RowBufferTest {
     }
 
     ChannelData<?> channelData = innerBuffer.flush();
-    RowBufferStats statsCol1 = channelData.getColumnEps().get("COLVARCHAR1");
-    RowBufferStats statsCol2 = channelData.getColumnEps().get("COLVARCHAR2");
-    RowBufferStats statsCol3 = channelData.getColumnEps().get("COLBOOLEAN1");
     Assert.assertEquals(1, channelData.getRowCount());
-    Assert.assertEquals(0, statsCol1.getCurrentNullCount());
-    Assert.assertEquals(0, statsCol2.getCurrentNullCount());
-    Assert.assertEquals(0, statsCol3.getCurrentNullCount());
-    Assert.assertArrayEquals(
-        "c".getBytes(StandardCharsets.UTF_8), statsCol1.getCurrentMinStrValue());
-    Assert.assertArrayEquals(
-        "c".getBytes(StandardCharsets.UTF_8), statsCol1.getCurrentMaxStrValue());
-    Assert.assertArrayEquals(
-        "d".getBytes(StandardCharsets.UTF_8), statsCol2.getCurrentMinStrValue());
-    Assert.assertArrayEquals(
-        "d".getBytes(StandardCharsets.UTF_8), statsCol2.getCurrentMaxStrValue());
-    Assert.assertEquals(BigInteger.ONE, statsCol3.getCurrentMinIntValue());
-    Assert.assertEquals(BigInteger.ONE, statsCol3.getCurrentMaxIntValue());
+
+    if (!isIcebergMode) {
+      RowBufferStats statsCol1 = channelData.getColumnEps().get("COLVARCHAR1");
+      RowBufferStats statsCol2 = channelData.getColumnEps().get("COLVARCHAR2");
+      RowBufferStats statsCol3 = channelData.getColumnEps().get("COLBOOLEAN1");
+
+      Assert.assertEquals(0, statsCol1.getCurrentNullCount());
+      Assert.assertEquals(0, statsCol2.getCurrentNullCount());
+      Assert.assertEquals(0, statsCol3.getCurrentNullCount());
+      Assert.assertArrayEquals(
+          "c".getBytes(StandardCharsets.UTF_8), statsCol1.getCurrentMinStrValue());
+      Assert.assertArrayEquals(
+          "c".getBytes(StandardCharsets.UTF_8), statsCol1.getCurrentMaxStrValue());
+      Assert.assertArrayEquals(
+          "d".getBytes(StandardCharsets.UTF_8), statsCol2.getCurrentMinStrValue());
+      Assert.assertArrayEquals(
+          "d".getBytes(StandardCharsets.UTF_8), statsCol2.getCurrentMaxStrValue());
+      Assert.assertEquals(BigInteger.ONE, statsCol3.getCurrentMinIntValue());
+      Assert.assertEquals(BigInteger.ONE, statsCol3.getCurrentMaxIntValue());
+    }
   }
 
   @Test
@@ -1336,11 +1331,13 @@ public class RowBufferTest {
     ChannelData<?> result = innerBuffer.flush();
     Assert.assertEquals(3, result.getRowCount());
 
-    Assert.assertEquals(
-        BigInteger.valueOf(0), result.getColumnEps().get("COLBOOLEAN").getCurrentMinIntValue());
-    Assert.assertEquals(
-        BigInteger.valueOf(1), result.getColumnEps().get("COLBOOLEAN").getCurrentMaxIntValue());
-    Assert.assertEquals(1, result.getColumnEps().get("COLBOOLEAN").getCurrentNullCount());
+    if (!isIcebergMode) {
+      Assert.assertEquals(
+          BigInteger.valueOf(0), result.getColumnEps().get("COLBOOLEAN").getCurrentMinIntValue());
+      Assert.assertEquals(
+          BigInteger.valueOf(1), result.getColumnEps().get("COLBOOLEAN").getCurrentMaxIntValue());
+      Assert.assertEquals(1, result.getColumnEps().get("COLBOOLEAN").getCurrentNullCount());
+    }
   }
 
   @Test
@@ -1394,14 +1391,16 @@ public class RowBufferTest {
     ChannelData<?> result = innerBuffer.flush();
 
     Assert.assertEquals(3, result.getRowCount());
-    Assert.assertEquals(11L, result.getColumnEps().get("COLBINARY").getCurrentMaxLength());
-    Assert.assertArrayEquals(
-        "Hello World".getBytes(StandardCharsets.UTF_8),
-        result.getColumnEps().get("COLBINARY").getCurrentMinStrValue());
-    Assert.assertArrayEquals(
-        "Honk Honk".getBytes(StandardCharsets.UTF_8),
-        result.getColumnEps().get("COLBINARY").getCurrentMaxStrValue());
-    Assert.assertEquals(1, result.getColumnEps().get("COLBINARY").getCurrentNullCount());
+    if (!isIcebergMode) {
+      Assert.assertEquals(11L, result.getColumnEps().get("COLBINARY").getCurrentMaxLength());
+      Assert.assertArrayEquals(
+          "Hello World".getBytes(StandardCharsets.UTF_8),
+          result.getColumnEps().get("COLBINARY").getCurrentMinStrValue());
+      Assert.assertArrayEquals(
+          "Honk Honk".getBytes(StandardCharsets.UTF_8),
+          result.getColumnEps().get("COLBINARY").getCurrentMaxStrValue());
+      Assert.assertEquals(1, result.getColumnEps().get("COLBINARY").getCurrentNullCount());
+    }
   }
 
   @Test
@@ -1446,11 +1445,13 @@ public class RowBufferTest {
     ChannelData<?> result = innerBuffer.flush();
 
     Assert.assertEquals(3, result.getRowCount());
-    Assert.assertEquals(
-        Double.valueOf(123.456), result.getColumnEps().get("COLREAL").getCurrentMinRealValue());
-    Assert.assertEquals(
-        Double.valueOf(123.4567), result.getColumnEps().get("COLREAL").getCurrentMaxRealValue());
-    Assert.assertEquals(1, result.getColumnEps().get("COLREAL").getCurrentNullCount());
+    if (!isIcebergMode) {
+      Assert.assertEquals(
+          Double.valueOf(123.456), result.getColumnEps().get("COLREAL").getCurrentMinRealValue());
+      Assert.assertEquals(
+          Double.valueOf(123.4567), result.getColumnEps().get("COLREAL").getCurrentMaxRealValue());
+      Assert.assertEquals(1, result.getColumnEps().get("COLREAL").getCurrentNullCount());
+    }
   }
 
   @Test
@@ -1476,12 +1477,14 @@ public class RowBufferTest {
 
     Assert.assertEquals(1, innerBuffer.bufferedRowCount);
     Assert.assertEquals(0, innerBuffer.getTempRowCount());
-    Assert.assertEquals(
-        1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
-    Assert.assertEquals(
-        1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    if (!isIcebergMode) {
+      Assert.assertEquals(
+          1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
+      Assert.assertEquals(
+          1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    }
 
     Map<String, Object> row2 = new HashMap<>();
     row2.put("COLDECIMAL", 2);
@@ -1490,12 +1493,14 @@ public class RowBufferTest {
 
     Assert.assertEquals(2, innerBuffer.bufferedRowCount);
     Assert.assertEquals(0, innerBuffer.getTempRowCount());
-    Assert.assertEquals(
-        2, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
-    Assert.assertEquals(
-        1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    if (!isIcebergMode) {
+      Assert.assertEquals(
+          2, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
+      Assert.assertEquals(
+          1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    }
 
     Map<String, Object> row3 = new HashMap<>();
     row3.put("COLDECIMAL", true);
@@ -1507,24 +1512,28 @@ public class RowBufferTest {
 
     Assert.assertEquals(2, innerBuffer.bufferedRowCount);
     Assert.assertEquals(0, innerBuffer.getTempRowCount());
-    Assert.assertEquals(
-        2, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
-    Assert.assertEquals(
-        1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    if (!isIcebergMode) {
+      Assert.assertEquals(
+          2, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
+      Assert.assertEquals(
+          1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    }
 
     row3.put("COLDECIMAL", 3);
     response = innerBuffer.insertRows(Collections.singletonList(row3), "1", "3");
     Assert.assertFalse(response.hasErrors());
     Assert.assertEquals(3, innerBuffer.bufferedRowCount);
     Assert.assertEquals(0, innerBuffer.getTempRowCount());
-    Assert.assertEquals(
-        3, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
-    Assert.assertEquals(
-        1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    if (!isIcebergMode) {
+      Assert.assertEquals(
+          3, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
+      Assert.assertEquals(
+          1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    }
 
     ChannelData<?> data = innerBuffer.flush();
     Assert.assertEquals(3, data.getRowCount());
@@ -1555,12 +1564,14 @@ public class RowBufferTest {
 
     Assert.assertEquals(1, innerBuffer.bufferedRowCount);
     Assert.assertEquals(0, innerBuffer.getTempRowCount());
-    Assert.assertEquals(
-        1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
-    Assert.assertEquals(
-        1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    if (!isIcebergMode) {
+      Assert.assertEquals(
+          1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
+      Assert.assertEquals(
+          1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    }
 
     Map<String, Object> row2 = new HashMap<>();
     row2.put("COLDECIMAL", 2);
@@ -1572,33 +1583,39 @@ public class RowBufferTest {
 
     Assert.assertEquals(1, innerBuffer.bufferedRowCount);
     Assert.assertEquals(0, innerBuffer.getTempRowCount());
-    Assert.assertEquals(
-        1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
-    Assert.assertEquals(
-        1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    if (!isIcebergMode) {
+      Assert.assertEquals(
+          1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
+      Assert.assertEquals(
+          1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    }
 
     Assert.assertEquals(1, innerBuffer.bufferedRowCount);
     Assert.assertEquals(0, innerBuffer.getTempRowCount());
-    Assert.assertEquals(
-        1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
-    Assert.assertEquals(
-        1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    if (!isIcebergMode) {
+      Assert.assertEquals(
+          1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
+      Assert.assertEquals(
+          1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    }
 
     row3.put("COLDECIMAL", 3);
     response = innerBuffer.insertRows(Arrays.asList(row2, row3), "1", "3");
     Assert.assertFalse(response.hasErrors());
     Assert.assertEquals(3, innerBuffer.bufferedRowCount);
     Assert.assertEquals(0, innerBuffer.getTempRowCount());
-    Assert.assertEquals(
-        3, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
-    Assert.assertEquals(
-        1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
-    Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    if (!isIcebergMode) {
+      Assert.assertEquals(
+          3, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMaxIntValue().intValue());
+      Assert.assertEquals(
+          1, innerBuffer.statsMap.get("COLDECIMAL").getCurrentMinIntValue().intValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMaxIntValue());
+      Assert.assertNull(innerBuffer.tempStatsMap.get("COLDECIMAL").getCurrentMinIntValue());
+    }
 
     ChannelData<?> data = innerBuffer.flush();
     Assert.assertEquals(3, data.getRowCount());


### PR DESCRIPTION
This PR contains logic of ep info generation logic as the Iceberg tables requires different EP info than FDN tables. For Iceberg tables, the min/max value come from parquet footer. The NDV and maxLength of string/binary columns are computed by SDK in `bdecParquetWriter`.