### PR TITLE
SNOW-1674752 Fix vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <fasterxml.version>2.17.2</fasterxml.version>
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.3.6</hadoop.version>
-    <iceberg.version>1.3.1</iceberg.version>
+    <iceberg.version>1.5.2</iceberg.version>
     <jacoco.skip.instrument>true</jacoco.skip.instrument>
     <jacoco.version>0.8.5</jacoco.version>
     <license.processing.dependencyJarsDir>${project.build.directory}/dependency-jars</license.processing.dependencyJarsDir>
@@ -67,7 +67,7 @@
     <parquet.version>1.14.1</parquet.version>
     <powermock.version>2.0.9</powermock.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <protobuf.version>4.27.2</protobuf.version>
+    <protobuf.version>4.27.5</protobuf.version>
     <shadeBase>net.snowflake.ingest.internal</shadeBase>
     <slf4j.version>1.7.36</slf4j.version>
     <snappy.version>1.1.10.5</snappy.version>
@@ -1220,6 +1220,7 @@
                     <exclude>NOTICE</exclude>
                     <exclude>iceberg-build.properties</exclude>
                     <exclude>google/protobuf/**/*.proto</exclude>
+                    <exclude>THIRD-PARTY.txt</exclude>
                   </excludes>
                 </filter>
                 <filter>


### PR DESCRIPTION
The `com.google.protobuf:protobuf-java` and `org.apache.avro:avro` introduced in #814 failed the [Synk gate](https://app.snyk.io/org/snowflakedb-sca-scanning-public-repo/project/decdb8fe-6a6d-465d-9e89-84aa34efb781/history/59edc0f3-2ae9-407a-8e34-09de15fc5d5c). Upgrade packages to resolve it.

[JIRA](https://snowflakecomputing.atlassian.net/browse/SNOW-1674752)