### PR TITLE
Get test coverage for telemetry reporting (was missing) + Fix SnowflakeServiceClient test code to allow per-API overrides 

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -226,7 +226,9 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
               String.format("%s_%s", this.name, System.currentTimeMillis()));
 
       logger.logInfo("Using {} for authorization", this.requestBuilder.getAuthType());
+    }
 
+    if (this.requestBuilder != null) {
       // Setup client telemetries if needed
       this.setupMetricsForClient();
     }

--- a/src/test/java/net/snowflake/ingest/TestUtils.java
+++ b/src/test/java/net/snowflake/ingest/TestUtils.java
@@ -25,7 +25,9 @@ import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -102,7 +104,7 @@ public class TestUtils {
    *
    * @throws IOException if can't read profile
    */
-  private static void init() throws Exception {
+  private static void init() throws NoSuchAlgorithmException, InvalidKeySpecException, IOException {
     String testProfilePath = getTestProfilePath();
     Path path = Paths.get(testProfilePath);
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
@@ -6,9 +6,12 @@ package net.snowflake.ingest.streaming.internal;
 
 import static java.time.ZoneOffset.UTC;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
+import net.snowflake.ingest.connection.RequestBuilder;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import org.junit.Assert;
 import org.junit.Before;
@@ -39,7 +42,12 @@ public class ChannelCacheTest {
   @Before
   public void setup() {
     cache = new ChannelCache<>();
-    client = new SnowflakeStreamingIngestClientInternal<>("client", isIcebergMode);
+    CloseableHttpClient httpClient = MockSnowflakeServiceClient.createHttpClient();
+    RequestBuilder requestBuilder = MockSnowflakeServiceClient.createRequestBuilder(httpClient);
+    client =
+        new SnowflakeStreamingIngestClientInternal<>(
+            "client", null, null, httpClient, isIcebergMode, true, requestBuilder, new HashMap<>());
+
     channel1 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel1",

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -97,6 +97,7 @@ public class FlushServiceTest {
     FlushService<T> flushService;
     IStorageManager storageManager;
     InternalStage storage;
+    ExternalVolume extVolume;
     ParameterProvider parameterProvider;
     RegisterService registerService;
 
@@ -104,6 +105,7 @@ public class FlushServiceTest {
 
     TestContext() {
       storage = Mockito.mock(InternalStage.class);
+      extVolume = Mockito.mock(ExternalVolume.class);
       parameterProvider = new ParameterProvider(isIcebergMode);
       InternalParameterProvider internalParameterProvider =
           new InternalParameterProvider(isIcebergMode);
@@ -113,9 +115,12 @@ public class FlushServiceTest {
       storageManager =
           Mockito.spy(
               isIcebergMode
-                  ? new ExternalVolumeManager(true, "role", "client", null)
+                  ? new ExternalVolumeManager(
+                      true, "role", "client", MockSnowflakeServiceClient.create())
                   : new InternalStageManager(true, "role", "client", null));
-      Mockito.doReturn(storage).when(storageManager).getStorage(ArgumentMatchers.any());
+      Mockito.doReturn(isIcebergMode ? extVolume : storage)
+          .when(storageManager)
+          .getStorage(ArgumentMatchers.any());
       Mockito.when(storageManager.getClientPrefix()).thenReturn("client_prefix");
       Mockito.when(client.getParameterProvider())
           .thenAnswer((Answer<ParameterProvider>) (i) -> parameterProvider);
@@ -425,6 +430,7 @@ public class FlushServiceTest {
 
   @Test
   public void testGetFilePath() {
+    // SNOW-1490151 Iceberg testing gaps
     if (isIcebergMode) {
       // TODO: SNOW-1502887 Blob path generation for iceberg table
       return;
@@ -623,6 +629,7 @@ public class FlushServiceTest {
     FlushService<?> flushService = testContext.flushService;
 
     // Force = true flushes
+    // SNOW-1490151 Iceberg testing gaps
     if (!isIcebergMode) {
       flushService.flush(true).get();
       Mockito.verify(flushService, Mockito.atLeast(2))
@@ -674,6 +681,7 @@ public class FlushServiceTest {
 
     FlushService<?> flushService = testContext.flushService;
 
+    // SNOW-1490151 Iceberg testing gaps
     if (!isIcebergMode) {
       // Force = true flushes
       flushService.flush(true).get();
@@ -711,6 +719,7 @@ public class FlushServiceTest {
 
     FlushService<?> flushService = testContext.flushService;
 
+    // SNOW-1490151 Iceberg testing gaps
     if (!isIcebergMode) {
       // Force = true flushes
       flushService.flush(true).get();
@@ -721,6 +730,7 @@ public class FlushServiceTest {
 
   @Test
   public void testBlobSplitDueToNumberOfChunks() throws Exception {
+    // SNOW-1490151 Iceberg testing gaps
     if (isIcebergMode) {
       return;
     }
@@ -799,6 +809,7 @@ public class FlushServiceTest {
     channel3.setupSchema(Collections.singletonList(createLargeTestTextColumn("C1")));
     channel3.insertRow(Collections.singletonMap("C1", 0), "");
 
+    // SNOW-1490151 Iceberg testing gaps
     if (isIcebergMode) {
       return;
     }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
@@ -10,6 +10,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
+import net.snowflake.ingest.connection.RequestBuilder;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Utils;
@@ -50,9 +52,19 @@ public class InsertRowsBenchmarkTest {
   @Setup(Level.Trial)
   public void setUpBeforeAll() {
     // SNOW-1490151: Testing gaps
+    CloseableHttpClient httpClient = MockSnowflakeServiceClient.createHttpClient();
+    RequestBuilder requestBuilder = MockSnowflakeServiceClient.createRequestBuilder(httpClient);
     client =
-        new SnowflakeStreamingIngestClientInternal<ParquetChunkData>(
-            "client_PARQUET", isIcebergMode);
+        new SnowflakeStreamingIngestClientInternal<>(
+            "client_PARQUET",
+            null,
+            null,
+            httpClient,
+            isIcebergMode,
+            true,
+            requestBuilder,
+            new HashMap<>());
+
     channel =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel",

--- a/src/test/java/net/snowflake/ingest/streaming/internal/MockSnowflakeServiceClient.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/MockSnowflakeServiceClient.java
@@ -9,149 +9,231 @@ import static net.snowflake.ingest.utils.Constants.REGISTER_BLOB_ENDPOINT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import net.snowflake.client.jdbc.internal.apache.commons.io.IOUtils;
 import net.snowflake.client.jdbc.internal.apache.http.HttpEntity;
 import net.snowflake.client.jdbc.internal.apache.http.HttpStatus;
 import net.snowflake.client.jdbc.internal.apache.http.HttpVersion;
 import net.snowflake.client.jdbc.internal.apache.http.client.methods.CloseableHttpResponse;
+import net.snowflake.client.jdbc.internal.apache.http.client.methods.HttpPost;
 import net.snowflake.client.jdbc.internal.apache.http.client.methods.HttpUriRequest;
 import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
 import net.snowflake.client.jdbc.internal.apache.http.message.BasicStatusLine;
+import net.snowflake.client.log.SFLogger;
+import net.snowflake.client.log.SFLoggerFactory;
 import net.snowflake.ingest.TestUtils;
 import net.snowflake.ingest.connection.RequestBuilder;
+import org.apache.commons.lang3.tuple.Pair;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 public class MockSnowflakeServiceClient {
   private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final SFLogger LOGGER =
+      SFLoggerFactory.getLogger(MockSnowflakeServiceClient.class);
+
+  public static class ApiOverride {
+    private final Map<String, Function<HttpUriRequest, Pair<Integer, Map<String, Object>>>>
+        apiOverrides = new HashMap<>();
+
+    public void addMapOverride(
+        String uriPath, Function<HttpUriRequest, Pair<Integer, Map<String, Object>>> override) {
+      apiOverrides.put(uriPath.toUpperCase(), override);
+    }
+
+    public void addSerializedJsonOverride(
+        String uriPath, Function<HttpUriRequest, Pair<Integer, String>> override) {
+      addMapOverride(
+          uriPath,
+          request -> {
+            Pair<Integer, String> pair = override.apply(request);
+            try {
+              Map<String, Object> map = objectMapper.readValue(pair.getRight(), HashMap.class);
+              return Pair.of(pair.getLeft(), map);
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          });
+    }
+  }
 
   public static SnowflakeServiceClient create() {
-    RequestBuilder requestBuilder = null;
     try {
-      requestBuilder = new RequestBuilder("test_host", "test_name", TestUtils.getKeyPair());
-      return new SnowflakeServiceClient(createHttpClient(), requestBuilder);
+      CloseableHttpClient httpClient = createHttpClient(new ApiOverride());
+      RequestBuilder requestBuilder = createRequestBuilder(httpClient);
+      return new SnowflakeServiceClient(httpClient, requestBuilder);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
 
-  private static CloseableHttpClient createHttpClient() throws IOException {
-    CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
-
-    Mockito.doAnswer(
-            (Answer<CloseableHttpResponse>)
-                invocation -> {
-                  HttpUriRequest request = invocation.getArgument(0);
-                  switch (request.getURI().getPath()) {
-                    case CLIENT_CONFIGURE_ENDPOINT:
-                      Map<String, Object> clientConfigresponseMap = new HashMap<>();
-                      clientConfigresponseMap.put("prefix", "test_prefix");
-                      clientConfigresponseMap.put("status_code", 0L);
-                      clientConfigresponseMap.put("message", "OK");
-                      clientConfigresponseMap.put("stage_location", getStageLocationMap());
-                      clientConfigresponseMap.put("deployment_id", 123L);
-                      return buildStreamingIngestResponse(clientConfigresponseMap);
-                    case CHANNEL_CONFIGURE_ENDPOINT:
-                      Map<String, Object> channelConfigResponseMap = new HashMap<>();
-                      channelConfigResponseMap.put("status_code", 0L);
-                      channelConfigResponseMap.put("message", "OK");
-                      channelConfigResponseMap.put("stage_location", getStageLocationMap());
-                      return buildStreamingIngestResponse(channelConfigResponseMap);
-                    case OPEN_CHANNEL_ENDPOINT:
-                      List<Map<String, Object>> tableColumnsLists = new ArrayList<>();
-                      Map<String, Object> tableColumnMap = new HashMap<>();
-                      tableColumnMap.put("byteLength", 123L);
-                      tableColumnMap.put("length", 0L);
-                      tableColumnMap.put("logicalType", "test_logical_type");
-                      tableColumnMap.put("name", "test_column");
-                      tableColumnMap.put("nullable", true);
-                      tableColumnMap.put("precision", 0L);
-                      tableColumnMap.put("scale", 0L);
-                      tableColumnMap.put("type", "test_type");
-                      tableColumnMap.put("ordinal", 0L);
-                      tableColumnsLists.add(tableColumnMap);
-                      Map<String, Object> openChannelResponseMap = new HashMap<>();
-                      openChannelResponseMap.put("status_code", 0L);
-                      openChannelResponseMap.put("message", "OK");
-                      openChannelResponseMap.put("database", "test_db");
-                      openChannelResponseMap.put("schema", "test_schema");
-                      openChannelResponseMap.put("table", "test_table");
-                      openChannelResponseMap.put("channel", "test_channel");
-                      openChannelResponseMap.put("client_sequencer", 123L);
-                      openChannelResponseMap.put("row_sequencer", 123L);
-                      openChannelResponseMap.put("offset_token", "test_offset_token");
-                      openChannelResponseMap.put("table_columns", tableColumnsLists);
-                      openChannelResponseMap.put("encryption_key", "test_encryption_key");
-                      openChannelResponseMap.put("encryption_key_id", 123L);
-                      openChannelResponseMap.put("iceberg_location", getStageLocationMap());
-                      return buildStreamingIngestResponse(openChannelResponseMap);
-                    case DROP_CHANNEL_ENDPOINT:
-                      Map<String, Object> dropChannelResponseMap = new HashMap<>();
-                      dropChannelResponseMap.put("status_code", 0L);
-                      dropChannelResponseMap.put("message", "OK");
-                      dropChannelResponseMap.put("database", "test_db");
-                      dropChannelResponseMap.put("schema", "test_schema");
-                      dropChannelResponseMap.put("table", "test_table");
-                      dropChannelResponseMap.put("channel", "test_channel");
-                      return buildStreamingIngestResponse(dropChannelResponseMap);
-                    case CHANNEL_STATUS_ENDPOINT:
-                      List<Map<String, Object>> channelStatusList = new ArrayList<>();
-                      Map<String, Object> channelStatusMap = new HashMap<>();
-                      channelStatusMap.put("status_code", 0L);
-                      channelStatusMap.put("persisted_row_sequencer", 123L);
-                      channelStatusMap.put("persisted_client_sequencer", 123L);
-                      channelStatusMap.put("persisted_offset_token", "test_offset_token");
-                      Map<String, Object> channelStatusResponseMap = new HashMap<>();
-                      channelStatusResponseMap.put("status_code", 0L);
-                      channelStatusResponseMap.put("message", "OK");
-                      channelStatusResponseMap.put("channels", channelStatusList);
-                      return buildStreamingIngestResponse(channelStatusResponseMap);
-                    case REGISTER_BLOB_ENDPOINT:
-                      List<Map<String, Object>> channelList = new ArrayList<>();
-                      Map<String, Object> channelMap = new HashMap<>();
-                      channelMap.put("status_code", 0L);
-                      channelMap.put("message", "OK");
-                      channelMap.put("channel", "test_channel");
-                      channelMap.put("client_sequencer", 123L);
-                      channelList.add(channelMap);
-                      List<Map<String, Object>> chunkList = new ArrayList<>();
-                      Map<String, Object> chunkMap = new HashMap<>();
-                      chunkMap.put("channels", channelList);
-                      chunkMap.put("database", "test_db");
-                      chunkMap.put("schema", "test_schema");
-                      chunkMap.put("table", "test_table");
-                      chunkList.add(chunkMap);
-                      List<Map<String, Object>> blobsList = new ArrayList<>();
-                      Map<String, Object> blobMap = new HashMap<>();
-                      blobMap.put("chunks", chunkList);
-                      blobsList.add(blobMap);
-                      Map<String, Object> registerBlobResponseMap = new HashMap<>();
-                      registerBlobResponseMap.put("status_code", 0L);
-                      registerBlobResponseMap.put("message", "OK");
-                      registerBlobResponseMap.put("blobs", blobsList);
-                      return buildStreamingIngestResponse(registerBlobResponseMap);
-                    default:
-                      assert false;
-                  }
-                  return null;
-                })
-        .when(httpClient)
-        .execute(Mockito.any());
-
-    return httpClient;
+  public static RequestBuilder createRequestBuilder(CloseableHttpClient httpClient) {
+    try {
+      return new RequestBuilder(
+          "test_host",
+          "test_name",
+          TestUtils.getKeyPair(),
+          "https",
+          "snowflakecomputing.com",
+          443,
+          null,
+          null,
+          httpClient,
+          "mock_client");
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
-  private static CloseableHttpResponse buildStreamingIngestResponse(Map<String, Object> payload)
-      throws IOException {
-    CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
-    HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
+  public static CloseableHttpClient createHttpClient() {
+    return createHttpClient(new ApiOverride());
+  }
 
+  public static CloseableHttpClient createHttpClient(ApiOverride apiOverride) {
+    try {
+      CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+
+      Mockito.doAnswer(
+              (Answer<CloseableHttpResponse>)
+                  invocation -> {
+                    HttpUriRequest request = invocation.getArgument(0);
+                    if (request.getMethod().equals(HttpPost.METHOD_NAME)) {
+                      LOGGER.debug(
+                          request.toString()
+                              + IOUtils.toString(
+                                  ((HttpPost) request).getEntity().getContent(),
+                                  StandardCharsets.UTF_8));
+                    }
+
+                    String path = request.getURI().getPath();
+                    if (apiOverride.apiOverrides.containsKey(path.toUpperCase())) {
+                      Pair<Integer, Map<String, Object>> responsePayload =
+                          apiOverride.apiOverrides.get(path.toUpperCase()).apply(request);
+                      return buildStreamingIngestResponse(
+                          responsePayload.getLeft(), responsePayload.getRight());
+                    }
+                    switch (path) {
+                      case "/telemetry/send/sessionless":
+                        return buildStreamingIngestResponse(HttpStatus.SC_OK, new HashMap<>());
+                      case CLIENT_CONFIGURE_ENDPOINT:
+                        Map<String, Object> clientConfigresponseMap = new HashMap<>();
+                        clientConfigresponseMap.put("prefix", "test_prefix");
+                        clientConfigresponseMap.put("status_code", 0L);
+                        clientConfigresponseMap.put("message", "OK");
+                        clientConfigresponseMap.put("stage_location", getStageLocationMap());
+                        clientConfigresponseMap.put("deployment_id", 123L);
+                        return buildStreamingIngestResponse(
+                            HttpStatus.SC_OK, clientConfigresponseMap);
+                      case CHANNEL_CONFIGURE_ENDPOINT:
+                        Map<String, Object> channelConfigResponseMap = new HashMap<>();
+                        channelConfigResponseMap.put("status_code", 0L);
+                        channelConfigResponseMap.put("message", "OK");
+                        channelConfigResponseMap.put("stage_location", getStageLocationMap());
+                        return buildStreamingIngestResponse(
+                            HttpStatus.SC_OK, channelConfigResponseMap);
+                      case OPEN_CHANNEL_ENDPOINT:
+                        List<Map<String, Object>> tableColumnsLists = new ArrayList<>();
+                        Map<String, Object> tableColumnMap = new HashMap<>();
+                        tableColumnMap.put("byteLength", 123L);
+                        tableColumnMap.put("length", 0L);
+                        tableColumnMap.put("logicalType", "test_logical_type");
+                        tableColumnMap.put("name", "test_column");
+                        tableColumnMap.put("nullable", true);
+                        tableColumnMap.put("precision", 0L);
+                        tableColumnMap.put("scale", 0L);
+                        tableColumnMap.put("type", "test_type");
+                        tableColumnMap.put("ordinal", 0L);
+                        tableColumnsLists.add(tableColumnMap);
+                        Map<String, Object> openChannelResponseMap = new HashMap<>();
+                        openChannelResponseMap.put("status_code", 0L);
+                        openChannelResponseMap.put("message", "OK");
+                        openChannelResponseMap.put("database", "test_db");
+                        openChannelResponseMap.put("schema", "test_schema");
+                        openChannelResponseMap.put("table", "test_table");
+                        openChannelResponseMap.put("channel", "test_channel");
+                        openChannelResponseMap.put("client_sequencer", 123L);
+                        openChannelResponseMap.put("row_sequencer", 123L);
+                        openChannelResponseMap.put("offset_token", "test_offset_token");
+                        openChannelResponseMap.put("table_columns", tableColumnsLists);
+                        openChannelResponseMap.put("encryption_key", "test_encryption_key");
+                        openChannelResponseMap.put("encryption_key_id", 123L);
+                        openChannelResponseMap.put("iceberg_location", getStageLocationMap());
+                        return buildStreamingIngestResponse(
+                            HttpStatus.SC_OK, openChannelResponseMap);
+                      case DROP_CHANNEL_ENDPOINT:
+                        Map<String, Object> dropChannelResponseMap = new HashMap<>();
+                        dropChannelResponseMap.put("status_code", 0L);
+                        dropChannelResponseMap.put("message", "OK");
+                        dropChannelResponseMap.put("database", "test_db");
+                        dropChannelResponseMap.put("schema", "test_schema");
+                        dropChannelResponseMap.put("table", "test_table");
+                        dropChannelResponseMap.put("channel", "test_channel");
+                        return buildStreamingIngestResponse(
+                            HttpStatus.SC_OK, dropChannelResponseMap);
+                      case CHANNEL_STATUS_ENDPOINT:
+                        List<Map<String, Object>> channelStatusList = new ArrayList<>();
+                        Map<String, Object> channelStatusMap = new HashMap<>();
+                        channelStatusMap.put("status_code", 0L);
+                        channelStatusMap.put("persisted_row_sequencer", 123L);
+                        channelStatusMap.put("persisted_client_sequencer", 123L);
+                        channelStatusMap.put("persisted_offset_token", "test_offset_token");
+                        Map<String, Object> channelStatusResponseMap = new HashMap<>();
+                        channelStatusResponseMap.put("status_code", 0L);
+                        channelStatusResponseMap.put("message", "OK");
+                        channelStatusResponseMap.put("channels", channelStatusList);
+                        return buildStreamingIngestResponse(
+                            HttpStatus.SC_OK, channelStatusResponseMap);
+                      case REGISTER_BLOB_ENDPOINT:
+                        List<Map<String, Object>> channelList = new ArrayList<>();
+                        Map<String, Object> channelMap = new HashMap<>();
+                        channelMap.put("status_code", 0L);
+                        channelMap.put("message", "OK");
+                        channelMap.put("channel", "test_channel");
+                        channelMap.put("client_sequencer", 123L);
+                        channelList.add(channelMap);
+                        List<Map<String, Object>> chunkList = new ArrayList<>();
+                        Map<String, Object> chunkMap = new HashMap<>();
+                        chunkMap.put("channels", channelList);
+                        chunkMap.put("database", "test_db");
+                        chunkMap.put("schema", "test_schema");
+                        chunkMap.put("table", "test_table");
+                        chunkList.add(chunkMap);
+                        List<Map<String, Object>> blobsList = new ArrayList<>();
+                        Map<String, Object> blobMap = new HashMap<>();
+                        blobMap.put("chunks", chunkList);
+                        blobsList.add(blobMap);
+                        Map<String, Object> registerBlobResponseMap = new HashMap<>();
+                        registerBlobResponseMap.put("status_code", 0L);
+                        registerBlobResponseMap.put("message", "OK");
+                        registerBlobResponseMap.put("blobs", blobsList);
+                        return buildStreamingIngestResponse(
+                            HttpStatus.SC_OK, registerBlobResponseMap);
+                      default:
+                        assert false;
+                    }
+                    return null;
+                  })
+          .when(httpClient)
+          .execute(Mockito.any());
+
+      return httpClient;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static CloseableHttpResponse buildStreamingIngestResponse(
+      int statusCode, Map<String, Object> payload) throws IOException {
+    CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
     Mockito.when(response.getStatusLine())
-        .thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+        .thenReturn(
+            new BasicStatusLine(HttpVersion.HTTP_1_1, statusCode, String.valueOf(statusCode)));
+    HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
     Mockito.when(response.getEntity()).thenReturn(httpEntity);
     Mockito.when(httpEntity.getContent())
         .thenReturn(IOUtils.toInputStream(objectMapper.writeValueAsString(payload)));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
@@ -9,13 +9,18 @@ import static net.snowflake.ingest.utils.Constants.BLOB_UPLOAD_TIMEOUT_IN_SEC;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
+import net.snowflake.ingest.connection.RequestBuilder;
 import net.snowflake.ingest.utils.Pair;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,6 +34,22 @@ public class RegisterServiceTest {
   }
 
   @Parameterized.Parameter public boolean isIcebergMode;
+
+  private SnowflakeStreamingIngestClientInternal<StubChunkData> client;
+
+  @Before
+  public void setup() {
+    CloseableHttpClient httpClient = MockSnowflakeServiceClient.createHttpClient();
+    RequestBuilder requestBuilder = MockSnowflakeServiceClient.createRequestBuilder(httpClient);
+    client =
+        new SnowflakeStreamingIngestClientInternal<>(
+            "client", null, null, httpClient, isIcebergMode, true, requestBuilder, new HashMap<>());
+  }
+
+  @After
+  public void teardown() throws Exception {
+    client.close();
+  }
 
   @Test
   public void testRegisterService() throws ExecutionException, InterruptedException {
@@ -57,8 +78,6 @@ public class RegisterServiceTest {
    */
   @Test
   public void testRegisterServiceTimeoutException() throws Exception {
-    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
-        new SnowflakeStreamingIngestClientInternal<>("client", isIcebergMode);
     RegisterService<StubChunkData> rs = new RegisterService<>(client, true);
 
     Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blobFuture1 =
@@ -85,8 +104,6 @@ public class RegisterServiceTest {
   @Ignore
   @Test
   public void testRegisterServiceTimeoutException_testRetries() throws Exception {
-    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
-        new SnowflakeStreamingIngestClientInternal<>("client", isIcebergMode);
     RegisterService<StubChunkData> rs = new RegisterService<>(client, true);
 
     Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blobFuture1 =
@@ -119,8 +136,6 @@ public class RegisterServiceTest {
 
   @Test
   public void testRegisterServiceNonTimeoutException() {
-    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
-        new SnowflakeStreamingIngestClientInternal<>("client", isIcebergMode);
     RegisterService<StubChunkData> rs = new RegisterService<>(client, true);
 
     CompletableFuture<BlobMetadata> future = new CompletableFuture<>();


### PR DESCRIPTION
As part of bringing in ExternalVolume (presigned url based uploads), I decided to not add test-only code into ExtVol / ExtVolManager. This meant the following:
1. All the httpClient mock logic to return hardcoded responses now needs to handle multiple APIs (client configure AND getPresignedUrls) - this looked very similar to MockSnowflakeServiceClient logic but duplicated 10 times.
2. To fix this, introduced a per-API behavior override mechanism in MockSNowflakeServiceClient; helped me remove hundreds of lines of code that was just setting up the httpclient mock, and reduce how brittle that setup is
3. To do away with isTestMode in InternalStage / InternalStageManager, also did the following two changes:
    1. Make the snowflake service client respond to telemetry upload calls correctly when isTestMode is false
    1. Initialize the telemetry client even when isTestMode is false

Tested all affected unit test classes locally