### PR TITLE
SNOW-1708577 Parquet V2 support for new table format

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -25,6 +25,7 @@ import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.SFException;
+import org.apache.parquet.column.ParquetProperties;
 
 /**
  * The abstract implementation of the buffer in the Streaming Ingest channel that holds the
@@ -668,6 +669,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       ChannelRuntimeState channelRuntimeState,
       ClientBufferParameters clientBufferParameters,
       OffsetTokenVerificationFunction offsetTokenVerificationFunction,
+      ParquetProperties.WriterVersion parquetWriterVersion,
       TelemetryService telemetryService) {
     switch (bdecVersion) {
       case THREE:
@@ -681,6 +683,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
                 channelRuntimeState,
                 clientBufferParameters,
                 offsetTokenVerificationFunction,
+                parquetWriterVersion,
                 telemetryService);
       default:
         throw new SFException(

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
@@ -32,6 +32,7 @@ import net.snowflake.ingest.utils.Cryptor;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.Pair;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.parquet.hadoop.ParquetFileWriter;
 
 /**
  * Build a single blob file that contains file header plus data. The header will be a
@@ -68,8 +69,12 @@ class BlobBuilder {
       List<List<ChannelData<T>>> blobData,
       Constants.BdecVersion bdecVersion,
       InternalParameterProvider internalParameterProvider)
-      throws IOException, NoSuchPaddingException, NoSuchAlgorithmException,
-          InvalidAlgorithmParameterException, InvalidKeyException, IllegalBlockSizeException,
+      throws IOException,
+          NoSuchPaddingException,
+          NoSuchAlgorithmException,
+          InvalidAlgorithmParameterException,
+          InvalidKeyException,
+          IllegalBlockSizeException,
           BadPaddingException {
     List<ChunkMetadata> chunksMetadataList = new ArrayList<>();
     List<byte[]> chunksDataList = new ArrayList<>();
@@ -140,7 +145,7 @@ class BlobBuilder {
 
         if (internalParameterProvider.setIcebergSpecificFieldsInEp()) {
           chunkMetadataBuilder
-              .setMajorVersion(Constants.PARQUET_MAJOR_VERSION)
+              .setMajorVersion(ParquetFileWriter.CURRENT_VERSION)
               .setMinorVersion(Constants.PARQUET_MINOR_VERSION)
               // set createdOn in seconds
               .setCreatedOn(System.currentTimeMillis() / 1000)

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
@@ -69,12 +69,8 @@ class BlobBuilder {
       List<List<ChannelData<T>>> blobData,
       Constants.BdecVersion bdecVersion,
       InternalParameterProvider internalParameterProvider)
-      throws IOException,
-          NoSuchPaddingException,
-          NoSuchAlgorithmException,
-          InvalidAlgorithmParameterException,
-          InvalidKeyException,
-          IllegalBlockSizeException,
+      throws IOException, NoSuchPaddingException, NoSuchAlgorithmException,
+          InvalidAlgorithmParameterException, InvalidKeyException, IllegalBlockSizeException,
           BadPaddingException {
     List<ChunkMetadata> chunksMetadataList = new ArrayList<>();
     List<byte[]> chunksDataList = new ArrayList<>();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelFlushContext.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelFlushContext.java
@@ -5,6 +5,7 @@
 package net.snowflake.ingest.streaming.internal;
 
 import net.snowflake.ingest.utils.Utils;
+import org.apache.parquet.column.ParquetProperties;
 
 /**
  * Channel immutable identification and encryption attributes.
@@ -29,6 +30,8 @@ class ChannelFlushContext {
   // Data encryption key id
   private final Long encryptionKeyId;
 
+  private final ParquetProperties.WriterVersion parquetWriterVersion;
+
   ChannelFlushContext(
       String name,
       String dbName,
@@ -36,7 +39,8 @@ class ChannelFlushContext {
       String tableName,
       Long channelSequencer,
       String encryptionKey,
-      Long encryptionKeyId) {
+      Long encryptionKeyId,
+      ParquetProperties.WriterVersion parquetWriterVersion) {
     this.name = name;
     this.fullyQualifiedName =
         Utils.getFullyQualifiedChannelName(dbName, schemaName, tableName, name);
@@ -47,6 +51,7 @@ class ChannelFlushContext {
     this.channelSequencer = channelSequencer;
     this.encryptionKey = encryptionKey;
     this.encryptionKeyId = encryptionKeyId;
+    this.parquetWriterVersion = parquetWriterVersion;
   }
 
   @Override
@@ -114,5 +119,9 @@ class ChannelFlushContext {
 
   Long getEncryptionKeyId() {
     return encryptionKeyId;
+  }
+
+  ParquetProperties.WriterVersion getParquetWriterVersion() {
+    return parquetWriterVersion;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelFlushContext.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelFlushContext.java
@@ -5,7 +5,6 @@
 package net.snowflake.ingest.streaming.internal;
 
 import net.snowflake.ingest.utils.Utils;
-import org.apache.parquet.column.ParquetProperties;
 
 /**
  * Channel immutable identification and encryption attributes.
@@ -30,8 +29,6 @@ class ChannelFlushContext {
   // Data encryption key id
   private final Long encryptionKeyId;
 
-  private final ParquetProperties.WriterVersion parquetWriterVersion;
-
   ChannelFlushContext(
       String name,
       String dbName,
@@ -39,8 +36,7 @@ class ChannelFlushContext {
       String tableName,
       Long channelSequencer,
       String encryptionKey,
-      Long encryptionKeyId,
-      ParquetProperties.WriterVersion parquetWriterVersion) {
+      Long encryptionKeyId) {
     this.name = name;
     this.fullyQualifiedName =
         Utils.getFullyQualifiedChannelName(dbName, schemaName, tableName, name);
@@ -51,7 +47,6 @@ class ChannelFlushContext {
     this.channelSequencer = channelSequencer;
     this.encryptionKey = encryptionKey;
     this.encryptionKeyId = encryptionKeyId;
-    this.parquetWriterVersion = parquetWriterVersion;
   }
 
   @Override
@@ -119,9 +114,5 @@ class ChannelFlushContext {
 
   Long getEncryptionKeyId() {
     return encryptionKeyId;
-  }
-
-  ParquetProperties.WriterVersion getParquetWriterVersion() {
-    return parquetWriterVersion;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
@@ -47,9 +47,7 @@ public class ClientBufferParameters {
     this.isIcebergMode = isIcebergMode;
   }
 
-  /**
-   * @param clientInternal reference to the client object where the relevant parameters are set
-   */
+  /** @param clientInternal reference to the client object where the relevant parameters are set */
   public ClientBufferParameters(SnowflakeStreamingIngestClientInternal clientInternal) {
     this.maxChunkSizeInBytes =
         clientInternal != null

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
@@ -47,7 +47,9 @@ public class ClientBufferParameters {
     this.isIcebergMode = isIcebergMode;
   }
 
-  /** @param clientInternal reference to the client object where the relevant parameters are set */
+  /**
+   * @param clientInternal reference to the client object where the relevant parameters are set
+   */
   public ClientBufferParameters(SnowflakeStreamingIngestClientInternal clientInternal) {
     this.maxChunkSizeInBytes =
         clientInternal != null
@@ -123,5 +125,9 @@ public class ClientBufferParameters {
 
   public String getParquetMessageTypeName() {
     return isIcebergMode ? PARQUET_MESSAGE_TYPE_NAME : BDEC_PARQUET_MESSAGE_TYPE_NAME;
+  }
+
+  public boolean isEnableDictionaryEncoding() {
+    return isIcebergMode;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/OpenChannelResponse.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/OpenChannelResponse.java
@@ -6,6 +6,7 @@ package net.snowflake.ingest.streaming.internal;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import net.snowflake.ingest.utils.Constants;
 
 /** Response to the OpenChannelRequest */
 class OpenChannelResponse extends StreamingIngestResponse {
@@ -22,6 +23,7 @@ class OpenChannelResponse extends StreamingIngestResponse {
   private String encryptionKey;
   private Long encryptionKeyId;
   private FileLocationInfo icebergLocationInfo;
+  private String icebergSerializationPolicy;
 
   @JsonProperty("status_code")
   void setStatusCode(Long statusCode) {
@@ -139,5 +141,14 @@ class OpenChannelResponse extends StreamingIngestResponse {
 
   FileLocationInfo getIcebergLocationInfo() {
     return this.icebergLocationInfo;
+  }
+
+  @JsonProperty("iceberg_serialization_policy")
+  void setIcebergSerializationPolicy(String icebergSerializationPolicy) {
+    this.icebergSerializationPolicy = icebergSerializationPolicy;
+  }
+
+  Constants.IcebergSerializationPolicy getIcebergSerializationPolicy() {
+    return Constants.IcebergSerializationPolicy.fromName(this.icebergSerializationPolicy);
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/OpenChannelResponse.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/OpenChannelResponse.java
@@ -6,7 +6,6 @@ package net.snowflake.ingest.streaming.internal;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import net.snowflake.ingest.utils.Constants;
 
 /** Response to the OpenChannelRequest */
 class OpenChannelResponse extends StreamingIngestResponse {
@@ -148,7 +147,7 @@ class OpenChannelResponse extends StreamingIngestResponse {
     this.icebergSerializationPolicy = icebergSerializationPolicy;
   }
 
-  Constants.IcebergSerializationPolicy getIcebergSerializationPolicy() {
-    return Constants.IcebergSerializationPolicy.fromName(this.icebergSerializationPolicy);
+  String getIcebergSerializationPolicy() {
+    return this.icebergSerializationPolicy;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -394,6 +394,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
         schema,
         clientBufferParameters.getMaxChunkSizeInBytes(),
         clientBufferParameters.getMaxRowGroups(),
-        clientBufferParameters.getBdecParquetCompression());
+        clientBufferParameters.getBdecParquetCompression(),
+        clientBufferParameters.isEnableDictionaryEncoding());
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -26,6 +26,7 @@ import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
@@ -45,6 +46,8 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   private final List<List<Object>> data;
   private final List<List<Object>> tempData;
 
+  private final ParquetProperties.WriterVersion parquetWriterVersion;
+
   private MessageType schema;
 
   /** Construct a ParquetRowBuffer object. */
@@ -56,6 +59,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       ChannelRuntimeState channelRuntimeState,
       ClientBufferParameters clientBufferParameters,
       OffsetTokenVerificationFunction offsetTokenVerificationFunction,
+      ParquetProperties.WriterVersion parquetWriterVersion,
       TelemetryService telemetryService) {
     super(
         onErrorOption,
@@ -70,6 +74,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
     this.metadata = new HashMap<>();
     this.data = new ArrayList<>();
     this.tempData = new ArrayList<>();
+    this.parquetWriterVersion = parquetWriterVersion;
   }
 
   /**
@@ -395,6 +400,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
         clientBufferParameters.getMaxChunkSizeInBytes(),
         clientBufferParameters.getMaxRowGroups(),
         clientBufferParameters.getBdecParquetCompression(),
+        parquetWriterVersion,
         clientBufferParameters.isEnableDictionaryEncoding());
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelFactory.java
@@ -8,6 +8,7 @@ import java.time.ZoneId;
 import net.snowflake.ingest.streaming.OffsetTokenVerificationFunction;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Utils;
+import org.apache.parquet.column.ParquetProperties;
 
 /** Builds a Streaming Ingest channel for a specific Streaming Ingest client */
 class SnowflakeStreamingIngestChannelFactory {
@@ -30,6 +31,7 @@ class SnowflakeStreamingIngestChannelFactory {
     private OpenChannelRequest.OnErrorOption onErrorOption;
     private ZoneId defaultTimezone;
     private OffsetTokenVerificationFunction offsetTokenVerificationFunction;
+    private ParquetProperties.WriterVersion parquetWriterVersion;
 
     private SnowflakeStreamingIngestChannelBuilder(String name) {
       this.name = name;
@@ -98,6 +100,12 @@ class SnowflakeStreamingIngestChannelFactory {
       return this;
     }
 
+    SnowflakeStreamingIngestChannelBuilder<T> setParquetWriterVersion(
+        ParquetProperties.WriterVersion parquetWriterVersion) {
+      this.parquetWriterVersion = parquetWriterVersion;
+      return this;
+    }
+
     SnowflakeStreamingIngestChannelInternal<T> build() {
       Utils.assertStringNotNullOrEmpty("channel name", this.name);
       Utils.assertStringNotNullOrEmpty("table name", this.tableName);
@@ -124,7 +132,8 @@ class SnowflakeStreamingIngestChannelFactory {
           this.onErrorOption,
           this.defaultTimezone,
           this.owningClient.getParameterProvider().getBlobFormatVersion(),
-          this.offsetTokenVerificationFunction);
+          this.offsetTokenVerificationFunction,
+          this.parquetWriterVersion);
     }
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelFactory.java
@@ -131,7 +131,6 @@ class SnowflakeStreamingIngestChannelFactory {
           this.encryptionKeyId,
           this.onErrorOption,
           this.defaultTimezone,
-          this.owningClient.getParameterProvider().getBlobFormatVersion(),
           this.offsetTokenVerificationFunction,
           this.parquetWriterVersion);
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -386,6 +386,8 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
             .setOnErrorOption(request.getOnErrorOption())
             .setDefaultTimezone(request.getDefaultTimezone())
             .setOffsetTokenVerificationFunction(request.getOffsetTokenVerificationFunction())
+            .setParquetWriterVersion(
+                response.getIcebergSerializationPolicy().getParquetWriterVersion())
             .build();
 
     // Setup the row buffer schema

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -79,28 +79,11 @@ public class Constants {
    * otherwise v1.
    */
   public enum IcebergSerializationPolicy {
-    NON_ICEBERG,
     COMPATIBLE,
     OPTIMIZED;
 
-    public static IcebergSerializationPolicy fromName(String name) {
-      if (name == null) {
-        return NON_ICEBERG;
-      }
-      for (IcebergSerializationPolicy e : IcebergSerializationPolicy.values()) {
-        if (e.name().equalsIgnoreCase(name)) {
-          return e;
-        }
-      }
-      throw new IllegalArgumentException(
-          String.format(
-              "Unsupported ICEBERG_SERIALIZATION_POLICY = '%s', allowed values are %s",
-              name, Arrays.asList(IcebergSerializationPolicy.values())));
-    }
-
-    public ParquetProperties.WriterVersion getParquetWriterVersion() {
+    public ParquetProperties.WriterVersion toParquetWriterVersion() {
       switch (this) {
-        case NON_ICEBERG:
         case COMPATIBLE:
           return ParquetProperties.WriterVersion.PARQUET_1_0;
         case OPTIMIZED:

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -14,6 +14,7 @@ import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.SFException;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.hadoop.BdecParquetWriter;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
@@ -76,7 +77,8 @@ public class BlobBuilderTest {
                 schema,
                 100L,
                 isIceberg ? Optional.of(1) : Optional.empty(),
-                Constants.BdecParquetCompression.GZIP))
+                Constants.BdecParquetCompression.GZIP,
+                isIceberg))
         .when(channelData)
         .createFlusher();
 
@@ -90,7 +92,11 @@ public class BlobBuilderTest {
             "CHANNEL",
             1000,
             isIceberg ? Optional.of(1) : Optional.empty(),
-            Constants.BdecParquetCompression.GZIP);
+            Constants.BdecParquetCompression.GZIP,
+            isIceberg
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0,
+            isIceberg);
     bdecParquetWriter.writeRow(Collections.singletonList("1"));
     channelData.setVectors(
         new ParquetChunkData(
@@ -115,7 +121,17 @@ public class BlobBuilderTest {
                         .named("test"))
                 : new RowBufferStats(columnName, null, 1, null, null));
     channelData.setChannelContext(
-        new ChannelFlushContext("channel1", "DB", "SCHEMA", "TABLE", 1L, "enc", 1L));
+        new ChannelFlushContext(
+            "channel1",
+            "DB",
+            "SCHEMA",
+            "TABLE",
+            1L,
+            "enc",
+            1L,
+            isIceberg
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0));
     return Collections.singletonList(channelData);
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -78,6 +78,9 @@ public class BlobBuilderTest {
                 100L,
                 isIceberg ? Optional.of(1) : Optional.empty(),
                 Constants.BdecParquetCompression.GZIP,
+                isIceberg
+                    ? ParquetProperties.WriterVersion.PARQUET_2_0
+                    : ParquetProperties.WriterVersion.PARQUET_1_0,
                 isIceberg))
         .when(channelData)
         .createFlusher();
@@ -121,17 +124,7 @@ public class BlobBuilderTest {
                         .named("test"))
                 : new RowBufferStats(columnName, null, 1, null, null));
     channelData.setChannelContext(
-        new ChannelFlushContext(
-            "channel1",
-            "DB",
-            "SCHEMA",
-            "TABLE",
-            1L,
-            "enc",
-            1L,
-            isIceberg
-                ? ParquetProperties.WriterVersion.PARQUET_2_0
-                : ParquetProperties.WriterVersion.PARQUET_1_0));
+        new ChannelFlushContext("channel1", "DB", "SCHEMA", "TABLE", 1L, "enc", 1L));
     return Collections.singletonList(channelData);
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
 import net.snowflake.ingest.connection.RequestBuilder;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
+import org.apache.parquet.column.ParquetProperties;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,7 +62,11 @@ public class ChannelCacheTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel2",
@@ -75,7 +80,11 @@ public class ChannelCacheTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     channel3 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel3",
@@ -89,7 +98,11 @@ public class ChannelCacheTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     cache.addChannel(channel1);
     cache.addChannel(channel2);
     cache.addChannel(channel3);
@@ -115,7 +128,11 @@ public class ChannelCacheTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     cache.addChannel(channel);
     Assert.assertEquals(1, cache.getSize());
     Assert.assertTrue(channel == cache.entrySet().iterator().next().getValue().get(channelName));
@@ -133,7 +150,11 @@ public class ChannelCacheTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     cache.addChannel(channelDup);
     // The old channel should be invalid now
     Assert.assertTrue(!channel.isValid());
@@ -214,7 +235,11 @@ public class ChannelCacheTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     cache.removeChannelIfSequencersMatch(channel3Dup);
     // Verify that remove the same channel with a different channel sequencer is a no op
     Assert.assertEquals(1, cache.getSize());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -303,7 +303,6 @@ public class FlushServiceTest {
           encryptionKeyId,
           onErrorOption,
           defaultTimezone,
-          Constants.BdecVersion.THREE,
           null,
           isIcebergMode
               ? ParquetProperties.WriterVersion.PARQUET_2_0
@@ -1065,7 +1064,11 @@ public class FlushServiceTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            ZoneOffset.UTC);
+            ZoneOffset.UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     SnowflakeStreamingIngestChannelInternal<StubChunkData> channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
@@ -1080,7 +1083,11 @@ public class FlushServiceTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            ZoneOffset.UTC);
+            ZoneOffset.UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     channelCache.addChannel(channel1);
     channelCache.addChannel(channel2);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -52,6 +52,7 @@ import net.snowflake.ingest.utils.Cryptor;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 import org.junit.Assert;
@@ -303,7 +304,10 @@ public class FlushServiceTest {
           onErrorOption,
           defaultTimezone,
           Constants.BdecVersion.THREE,
-          null);
+          null,
+          isIcebergMode
+              ? ParquetProperties.WriterVersion.PARQUET_2_0
+              : ParquetProperties.WriterVersion.PARQUET_1_0);
     }
 
     @Override
@@ -1227,8 +1231,12 @@ public class FlushServiceTest {
 
   @Test
   public void testEncryptionDecryption()
-      throws InvalidAlgorithmParameterException, NoSuchPaddingException, IllegalBlockSizeException,
-          NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
+      throws InvalidAlgorithmParameterException,
+          NoSuchPaddingException,
+          IllegalBlockSizeException,
+          NoSuchAlgorithmException,
+          BadPaddingException,
+          InvalidKeyException {
     byte[] data = "testEncryptionDecryption".getBytes(StandardCharsets.UTF_8);
     String encryptionKey =
         Base64.getEncoder().encodeToString("encryption_key".getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -1231,12 +1231,8 @@ public class FlushServiceTest {
 
   @Test
   public void testEncryptionDecryption()
-      throws InvalidAlgorithmParameterException,
-          NoSuchPaddingException,
-          IllegalBlockSizeException,
-          NoSuchAlgorithmException,
-          BadPaddingException,
-          InvalidKeyException {
+      throws InvalidAlgorithmParameterException, NoSuchPaddingException, IllegalBlockSizeException,
+          NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
     byte[] data = "testEncryptionDecryption".getBytes(StandardCharsets.UTF_8);
     String encryptionKey =
         Base64.getEncoder().encodeToString("encryption_key".getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
@@ -15,6 +15,7 @@ import net.snowflake.ingest.connection.RequestBuilder;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Utils;
+import org.apache.parquet.column.ParquetProperties;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,7 +79,11 @@ public class InsertRowsBenchmarkTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     // Setup column fields and vectors
     ColumnMetadata col = new ColumnMetadata();
     col.setOrdinal(1);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -28,6 +28,7 @@ import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.hadoop.BdecParquetReader;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
@@ -1924,7 +1925,18 @@ public class RowBufferTest {
     bufferUnderTest.setupSchema(Collections.singletonList(colChar));
     loadData(bufferUnderTest, Collections.singletonMap("colChar", "a"));
     ChannelData<ParquetChunkData> data = bufferUnderTest.flush();
-    data.setChannelContext(new ChannelFlushContext("name", "db", "schema", "table", 1L, "key", 0L));
+    data.setChannelContext(
+        new ChannelFlushContext(
+            "name",
+            "db",
+            "schema",
+            "table",
+            1L,
+            "key",
+            0L,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0));
 
     ParquetFlusher flusher = (ParquetFlusher) bufferUnderTest.createFlusher();
     Flusher.SerializationResult result =

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -156,6 +156,9 @@ public class RowBufferTest {
             isIcebergMode ? Optional.of(1) : Optional.empty(),
             isIcebergMode),
         null,
+        isIcebergMode
+            ? ParquetProperties.WriterVersion.PARQUET_2_0
+            : ParquetProperties.WriterVersion.PARQUET_1_0,
         null);
   }
 
@@ -1925,18 +1928,7 @@ public class RowBufferTest {
     bufferUnderTest.setupSchema(Collections.singletonList(colChar));
     loadData(bufferUnderTest, Collections.singletonMap("colChar", "a"));
     ChannelData<ParquetChunkData> data = bufferUnderTest.flush();
-    data.setChannelContext(
-        new ChannelFlushContext(
-            "name",
-            "db",
-            "schema",
-            "table",
-            1L,
-            "key",
-            0L,
-            isIcebergMode
-                ? ParquetProperties.WriterVersion.PARQUET_2_0
-                : ParquetProperties.WriterVersion.PARQUET_1_0));
+    data.setChannelContext(new ChannelFlushContext("name", "db", "schema", "table", 1L, "key", 0L));
 
     ParquetFlusher flusher = (ParquetFlusher) bufferUnderTest.createFlusher();
     Flusher.SerializationResult result =

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -48,6 +48,7 @@ import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.parquet.column.ParquetProperties;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -199,7 +200,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     Assert.assertTrue(channel.isValid());
     channel.invalidate("from testChannelValid", "Invalidated by test");
@@ -247,7 +252,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     Assert.assertFalse(channel.isClosed());
     channel.markClosed();
@@ -545,7 +554,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     ColumnMetadata col = new ColumnMetadata();
     col.setOrdinal(1);
@@ -631,7 +644,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     channel.setupSchema(schema);
 
     InsertValidationResponse insertValidationResponse = channel.insertRow(row, "token-1");
@@ -655,7 +672,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.ABORT,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     channel.setupSchema(schema);
 
     try {
@@ -680,7 +701,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.SKIP_BATCH,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     channel.setupSchema(schema);
 
     insertValidationResponse = channel.insertRow(row, "token-1");
@@ -711,7 +736,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     ParameterProvider parameterProvider = new ParameterProvider(isIcebergMode);
     memoryInfoProvider.freeMemory =
@@ -755,7 +784,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("Success");
@@ -789,7 +822,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("Success");
@@ -821,7 +858,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("Success");
@@ -856,7 +897,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("Success");
@@ -887,7 +932,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -133,7 +133,7 @@ public class SnowflakeStreamingIngestClientTest {
             ZoneOffset.UTC,
             BDEC_VERSION,
             null,
-                null);
+            null);
     channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel2",
@@ -150,7 +150,7 @@ public class SnowflakeStreamingIngestClientTest {
             ZoneOffset.UTC,
             BDEC_VERSION,
             null,
-                null);
+            null);
     channel3 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel3",
@@ -167,7 +167,7 @@ public class SnowflakeStreamingIngestClientTest {
             ZoneOffset.UTC,
             BDEC_VERSION,
             null,
-                null);
+            null);
     channel4 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel4",
@@ -184,7 +184,7 @@ public class SnowflakeStreamingIngestClientTest {
             ZoneOffset.UTC,
             BDEC_VERSION,
             null,
-                null);
+            null);
   }
 
   @Test
@@ -382,7 +382,7 @@ public class SnowflakeStreamingIngestClientTest {
             ZoneOffset.UTC,
             BDEC_VERSION,
             null,
-                null);
+            null);
 
     ChannelsStatusRequest.ChannelStatusRequestDTO dto =
         new ChannelsStatusRequest.ChannelStatusRequestDTO(channel);
@@ -445,7 +445,7 @@ public class SnowflakeStreamingIngestClientTest {
             ZoneOffset.UTC,
             BDEC_VERSION,
             null,
-                null);
+            null);
 
     try {
       client.getChannelsStatus(Collections.singletonList(channel));
@@ -499,7 +499,7 @@ public class SnowflakeStreamingIngestClientTest {
             ZoneOffset.UTC,
             BDEC_VERSION,
             null,
-                null);
+            null);
 
     ChannelMetadata channelMetadata =
         ChannelMetadata.builder()
@@ -1266,7 +1266,7 @@ public class SnowflakeStreamingIngestClientTest {
             ZoneOffset.UTC,
             BDEC_VERSION,
             null,
-                null);
+            null);
 
     ChannelsStatusRequest.ChannelStatusRequestDTO dto =
         new ChannelsStatusRequest.ChannelStatusRequestDTO(channel);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -132,7 +132,8 @@ public class SnowflakeStreamingIngestClientTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
             BDEC_VERSION,
-            null);
+            null,
+                null);
     channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel2",
@@ -148,7 +149,8 @@ public class SnowflakeStreamingIngestClientTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
             BDEC_VERSION,
-            null);
+            null,
+                null);
     channel3 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel3",
@@ -164,7 +166,8 @@ public class SnowflakeStreamingIngestClientTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
             BDEC_VERSION,
-            null);
+            null,
+                null);
     channel4 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel4",
@@ -180,7 +183,8 @@ public class SnowflakeStreamingIngestClientTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
             BDEC_VERSION,
-            null);
+            null,
+                null);
   }
 
   @Test
@@ -377,7 +381,8 @@ public class SnowflakeStreamingIngestClientTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
             BDEC_VERSION,
-            null);
+            null,
+                null);
 
     ChannelsStatusRequest.ChannelStatusRequestDTO dto =
         new ChannelsStatusRequest.ChannelStatusRequestDTO(channel);
@@ -439,7 +444,8 @@ public class SnowflakeStreamingIngestClientTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
             BDEC_VERSION,
-            null);
+            null,
+                null);
 
     try {
       client.getChannelsStatus(Collections.singletonList(channel));
@@ -492,7 +498,8 @@ public class SnowflakeStreamingIngestClientTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
             BDEC_VERSION,
-            null);
+            null,
+                null);
 
     ChannelMetadata channelMetadata =
         ChannelMetadata.builder()
@@ -1258,7 +1265,8 @@ public class SnowflakeStreamingIngestClientTest {
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
             BDEC_VERSION,
-            null);
+            null,
+                null);
 
     ChannelsStatusRequest.ChannelStatusRequestDTO dto =
         new ChannelsStatusRequest.ChannelStatusRequestDTO(channel);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -61,6 +61,7 @@ import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
@@ -131,7 +132,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
     channel2 =
@@ -148,7 +148,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
     channel3 =
@@ -165,7 +164,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
     channel4 =
@@ -182,7 +180,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
   }
@@ -380,7 +377,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
 
@@ -443,7 +439,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
 
@@ -497,7 +492,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
 
@@ -1073,7 +1067,11 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     SnowflakeStreamingIngestChannelInternal<StubChunkData> channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
             channel2Name,
@@ -1087,7 +1085,11 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     client.getChannelCache().addChannel(channel1);
     client.getChannelCache().addChannel(channel2);
 
@@ -1193,7 +1195,11 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     client.getChannelCache().addChannel(channel);
 
     ChannelsStatusResponse response = new ChannelsStatusResponse();
@@ -1264,7 +1270,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractDataTypeTest {
     setUp(
         false /* isIceberg */,
         compressionAlgorithm,
-        Constants.IcebergSerializationPolicy.NON_ICEBERG);
+        Constants.IcebergSerializationPolicy.COMPATIBLE);
   }
 
   public void beforeIceberg(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -66,18 +66,51 @@ public abstract class AbstractDataTypeTest {
   protected static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Parameters(name = "{index}: {0}")
-  public static Object[] compressionAlgorithms() {
+  public static Object[] parameters() {
     return new Object[] {"GZIP", "ZSTD"};
   }
 
   @Parameter public String compressionAlgorithm;
 
-  public void before(boolean isIceberg) throws Exception {
+  public void before() throws Exception {
+    setUp(
+        false /* isIceberg */,
+        compressionAlgorithm,
+        Constants.IcebergSerializationPolicy.NON_ICEBERG);
+  }
+
+  public void beforeIceberg(
+      String compressionAlgorithm, Constants.IcebergSerializationPolicy serializationPolicy)
+      throws Exception {
+    setUp(true /* isIceberg */, compressionAlgorithm, serializationPolicy);
+  }
+
+  protected void setUp(
+      boolean isIceberg,
+      String compressionAlgorithm,
+      Constants.IcebergSerializationPolicy serializationPolicy)
+      throws Exception {
     databaseName = String.format("SDK_DATATYPE_COMPATIBILITY_IT_%s", getRandomIdentifier());
     conn = TestUtils.getConnection(true);
     conn.createStatement().execute(String.format("create or replace database %s;", databaseName));
     conn.createStatement().execute(String.format("use database %s;", databaseName));
     conn.createStatement().execute(String.format("use schema %s;", schemaName));
+
+    switch (serializationPolicy) {
+      case COMPATIBLE:
+        conn.createStatement()
+            .execute(
+                String.format(
+                    "alter schema %s set STORAGE_SERIALIZATION_POLICY = 'COMPATIBLE';",
+                    schemaName));
+        break;
+      case OPTIMIZED:
+        conn.createStatement()
+            .execute(
+                String.format(
+                    "alter schema %s set STORAGE_SERIALIZATION_POLICY = 'OPTIMIZED';", schemaName));
+        break;
+    }
 
     conn.createStatement().execute(String.format("use warehouse %s;", TestUtils.getWarehouse()));
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/BinaryIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/BinaryIT.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 public class BinaryIT extends AbstractDataTypeTest {
   @Before
   public void before() throws Exception {
-    super.before(false);
+    super.before();
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
@@ -21,7 +21,7 @@ public class DateTimeIT extends AbstractDataTypeTest {
 
   @Before
   public void setup() throws Exception {
-    super.before(false);
+    super.before();
     // Set to a random time zone not to interfere with any of the tests
     conn.createStatement().execute("alter session set timezone = 'America/New_York';");
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergDateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergDateTimeIT.java
@@ -25,8 +25,6 @@ public class IcebergDateTimeIT extends AbstractDataTypeTest {
   @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {"GZIP", Constants.IcebergSerializationPolicy.COMPATIBLE},
-      {"GZIP", Constants.IcebergSerializationPolicy.OPTIMIZED},
       {"ZSTD", Constants.IcebergSerializationPolicy.COMPATIBLE},
       {"ZSTD", Constants.IcebergSerializationPolicy.OPTIMIZED}
     };

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergDateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergDateTimeIT.java
@@ -10,18 +10,36 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runners.Parameterized;
 
 @Ignore("This test can be enabled after server side Iceberg EP support is released")
 public class IcebergDateTimeIT extends AbstractDataTypeTest {
+
+  @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {"GZIP", Constants.IcebergSerializationPolicy.COMPATIBLE},
+      {"GZIP", Constants.IcebergSerializationPolicy.OPTIMIZED},
+      {"ZSTD", Constants.IcebergSerializationPolicy.COMPATIBLE},
+      {"ZSTD", Constants.IcebergSerializationPolicy.OPTIMIZED}
+    };
+  }
+
+  @Parameterized.Parameter public static String compressionAlgorithm;
+
+  @Parameterized.Parameter(1)
+  public static Constants.IcebergSerializationPolicy icebergSerializationPolicy;
+
   @Before
   public void before() throws Exception {
-    super.before(true);
+    super.beforeIceberg(compressionAlgorithm, icebergSerializationPolicy);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergLogicalTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergLogicalTypesIT.java
@@ -1,18 +1,35 @@
 package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.util.Arrays;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runners.Parameterized;
 
 @Ignore("This test can be enabled after server side Iceberg EP support is released")
 public class IcebergLogicalTypesIT extends AbstractDataTypeTest {
+  @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {"GZIP", Constants.IcebergSerializationPolicy.COMPATIBLE},
+      {"GZIP", Constants.IcebergSerializationPolicy.OPTIMIZED},
+      {"ZSTD", Constants.IcebergSerializationPolicy.COMPATIBLE},
+      {"ZSTD", Constants.IcebergSerializationPolicy.OPTIMIZED}
+    };
+  }
+
+  @Parameterized.Parameter public static String compressionAlgorithm;
+
+  @Parameterized.Parameter(1)
+  public static Constants.IcebergSerializationPolicy icebergSerializationPolicy;
+
   @Before
   public void before() throws Exception {
-    super.before(true);
+    super.beforeIceberg(compressionAlgorithm, icebergSerializationPolicy);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergLogicalTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergLogicalTypesIT.java
@@ -15,8 +15,6 @@ public class IcebergLogicalTypesIT extends AbstractDataTypeTest {
   @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {"GZIP", Constants.IcebergSerializationPolicy.COMPATIBLE},
-      {"GZIP", Constants.IcebergSerializationPolicy.OPTIMIZED},
       {"ZSTD", Constants.IcebergSerializationPolicy.COMPATIBLE},
       {"ZSTD", Constants.IcebergSerializationPolicy.OPTIMIZED}
     };

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergNumericTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergNumericTypesIT.java
@@ -2,18 +2,35 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runners.Parameterized;
 
 @Ignore("This test can be enabled after server side Iceberg EP support is released")
 public class IcebergNumericTypesIT extends AbstractDataTypeTest {
+  @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {"GZIP", Constants.IcebergSerializationPolicy.COMPATIBLE},
+      {"GZIP", Constants.IcebergSerializationPolicy.OPTIMIZED},
+      {"ZSTD", Constants.IcebergSerializationPolicy.COMPATIBLE},
+      {"ZSTD", Constants.IcebergSerializationPolicy.OPTIMIZED}
+    };
+  }
+
+  @Parameterized.Parameter public static String compressionAlgorithm;
+
+  @Parameterized.Parameter(1)
+  public static Constants.IcebergSerializationPolicy icebergSerializationPolicy;
+
   @Before
   public void before() throws Exception {
-    super.before(true);
+    super.beforeIceberg(compressionAlgorithm, icebergSerializationPolicy);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergNumericTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergNumericTypesIT.java
@@ -16,8 +16,6 @@ public class IcebergNumericTypesIT extends AbstractDataTypeTest {
   @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {"GZIP", Constants.IcebergSerializationPolicy.COMPATIBLE},
-      {"GZIP", Constants.IcebergSerializationPolicy.OPTIMIZED},
       {"ZSTD", Constants.IcebergSerializationPolicy.COMPATIBLE},
       {"ZSTD", Constants.IcebergSerializationPolicy.OPTIMIZED}
     };

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStringIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStringIT.java
@@ -17,8 +17,6 @@ public class IcebergStringIT extends AbstractDataTypeTest {
   @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {"GZIP", Constants.IcebergSerializationPolicy.COMPATIBLE},
-      {"GZIP", Constants.IcebergSerializationPolicy.OPTIMIZED},
       {"ZSTD", Constants.IcebergSerializationPolicy.COMPATIBLE},
       {"ZSTD", Constants.IcebergSerializationPolicy.OPTIMIZED}
     };

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStringIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStringIT.java
@@ -2,6 +2,7 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.commons.lang3.StringUtils;
@@ -9,12 +10,28 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runners.Parameterized;
 
 @Ignore("This test can be enabled after server side Iceberg EP support is released")
 public class IcebergStringIT extends AbstractDataTypeTest {
+  @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {"GZIP", Constants.IcebergSerializationPolicy.COMPATIBLE},
+      {"GZIP", Constants.IcebergSerializationPolicy.OPTIMIZED},
+      {"ZSTD", Constants.IcebergSerializationPolicy.COMPATIBLE},
+      {"ZSTD", Constants.IcebergSerializationPolicy.OPTIMIZED}
+    };
+  }
+
+  @Parameterized.Parameter public static String compressionAlgorithm;
+
+  @Parameterized.Parameter(1)
+  public static Constants.IcebergSerializationPolicy icebergSerializationPolicy;
+
   @Before
   public void before() throws Exception {
-    super.before(true);
+    super.beforeIceberg(compressionAlgorithm, icebergSerializationPolicy);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
@@ -21,8 +21,6 @@ public class IcebergStructuredIT extends AbstractDataTypeTest {
   @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {"GZIP", Constants.IcebergSerializationPolicy.COMPATIBLE},
-      {"GZIP", Constants.IcebergSerializationPolicy.OPTIMIZED},
       {"ZSTD", Constants.IcebergSerializationPolicy.COMPATIBLE},
       {"ZSTD", Constants.IcebergSerializationPolicy.OPTIMIZED}
     };

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
@@ -7,18 +7,35 @@ import java.util.Map;
 import java.util.UUID;
 import net.snowflake.ingest.TestUtils;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runners.Parameterized;
 
 @Ignore("This test can be enabled after server side Iceberg EP support is released")
 public class IcebergStructuredIT extends AbstractDataTypeTest {
+  @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {"GZIP", Constants.IcebergSerializationPolicy.COMPATIBLE},
+      {"GZIP", Constants.IcebergSerializationPolicy.OPTIMIZED},
+      {"ZSTD", Constants.IcebergSerializationPolicy.COMPATIBLE},
+      {"ZSTD", Constants.IcebergSerializationPolicy.OPTIMIZED}
+    };
+  }
+
+  @Parameterized.Parameter public static String compressionAlgorithm;
+
+  @Parameterized.Parameter(1)
+  public static Constants.IcebergSerializationPolicy icebergSerializationPolicy;
+
   @Before
   public void before() throws Exception {
-    super.before(true);
+    super.beforeIceberg(compressionAlgorithm, icebergSerializationPolicy);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/LogicalTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/LogicalTypesIT.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 public class LogicalTypesIT extends AbstractDataTypeTest {
   @Before
   public void before() throws Exception {
-    super.before(false);
+    super.before();
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NullIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NullIT.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 public class NullIT extends AbstractDataTypeTest {
   @Before
   public void before() throws Exception {
-    super.before(false);
+    super.before();
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NumericTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NumericTypesIT.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 public class NumericTypesIT extends AbstractDataTypeTest {
   @Before
   public void before() throws Exception {
-    super.before(false);
+    super.before();
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
@@ -22,8 +22,9 @@ import org.junit.Test;
 public class SemiStructuredIT extends AbstractDataTypeTest {
   @Before
   public void before() throws Exception {
-    super.before(false);
+    super.before();
   }
+
   // TODO SNOW-664249: There is a few-byte mismatch between the value sent by the user and its
   // server-side representation. Validation leaves a small buffer for this difference.
   private static final int MAX_ALLOWED_LENGTH = 16 * 1024 * 1024 - 64;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
@@ -19,7 +19,7 @@ public class StringsIT extends AbstractDataTypeTest {
 
   @Before
   public void before() throws Exception {
-    super.before(false);
+    super.before();
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/it/ColumnNamesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/it/ColumnNamesIT.java
@@ -23,7 +23,7 @@ public class ColumnNamesIT extends AbstractDataTypeTest {
 
   @Before
   public void before() throws Exception {
-    super.before(false);
+    super.before();
   }
 
   @Test


### PR DESCRIPTION
This PR aims to ensure consistency with the Iceberg table scanner and registration on the server side. It includes the following changes:

1. Added support for Parquet V2 (delta encoding) when the schema's `STORAGE_SERIALIZATION_POLICY` is set to `OPTIMIZED.`
2. Enabled dictionary encoding for Iceberg mode.