### PR TITLE
Fix concurrent null-ref in External Volume Blob path Generation + track URL timeout

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/GeneratePresignedUrlsResponse.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/GeneratePresignedUrlsResponse.java
@@ -14,6 +14,15 @@ class GeneratePresignedUrlsResponse extends StreamingIngestResponse {
     @JsonProperty("url")
     public String url;
 
+    /*
+    Locally-managed expiry timestamp for this url info. We need this since everytime a new URL is
+    used for the same chunk, it requires re-serializing the chunk's metadata as the file name is
+    embedded in there (search for PRIMARY_FILE_ID_KEY for context). By tracking per-URL expiry
+    (with some buffers to account for delays) we can minimize the chances of using a URL that has
+    an expired token.
+    */
+    public long validUntilTimestamp;
+
     // default constructor for jackson deserialization
     public PresignedUrlInfo() {}
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -359,7 +359,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
         && response.getTableColumns().stream()
             .anyMatch(c -> c.getSourceIcebergDataType() == null)) {
       throw new SFException(
-          ErrorCode.INTERNAL_ERROR, "Iceberg table columns must have sourceIcebergDataType set.");
+          ErrorCode.INTERNAL_ERROR, "Iceberg table columns must have sourceIcebergDataType set");
     }
 
     logger.logInfo(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ExternalVolumeManagerTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ExternalVolumeManagerTest.java
@@ -13,11 +13,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
 import net.snowflake.ingest.utils.SFException;
 import org.junit.After;
 import org.junit.Before;
@@ -27,6 +32,7 @@ public class ExternalVolumeManagerTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private ExternalVolumeManager manager;
   private FileLocationInfo fileLocationInfo;
+  private ExecutorService executorService;
 
   @Before
   public void setup() throws JsonProcessingException {
@@ -41,7 +47,11 @@ public class ExternalVolumeManagerTest {
   }
 
   @After
-  public void teardown() {}
+  public void teardown() {
+    if (executorService != null) {
+      executorService.shutdownNow();
+    }
+  }
 
   @Test
   public void testRegister() {
@@ -59,29 +69,16 @@ public class ExternalVolumeManagerTest {
   @Test
   public void testConcurrentRegisterTable() throws Exception {
     int numThreads = 50;
-    ExecutorService executorService =
-        new ThreadPoolExecutor(
-            numThreads, numThreads, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
-    List<Callable<ExternalVolume>> tasks = new ArrayList<>();
-    final CyclicBarrier startBarrier = new CyclicBarrier(numThreads);
-    final CyclicBarrier endBarrier = new CyclicBarrier(numThreads);
-    for (int i = 0; i < numThreads; i++) {
-      tasks.add(
-          () -> {
-            startBarrier.await(30, TimeUnit.SECONDS);
-            manager.registerTable(new TableRef("db", "schema", "table"), fileLocationInfo);
-            endBarrier.await();
-            return manager.getStorage("db.schema.table");
-          });
-    }
-
-    List<Future<ExternalVolume>> allResults = executorService.invokeAll(tasks);
-    allResults.get(0).get(30, TimeUnit.SECONDS);
-
+    int timeoutInSeconds = 30;
+    List<Future<ExternalVolume>> allResults = doConcurrentTest(
+        numThreads,
+        timeoutInSeconds,
+        () -> manager.registerTable(new TableRef("db", "schema", "table"), fileLocationInfo),
+        () -> manager.getStorage("db.schema.table"));
     ExternalVolume extvol = manager.getStorage("db.schema.table");
     assertNotNull(extvol);
     for (int i = 0; i < numThreads; i++) {
-      assertSame("" + i, extvol, allResults.get(i).get(30, TimeUnit.SECONDS));
+      assertSame("" + i, extvol, allResults.get(i).get(timeoutInSeconds, TimeUnit.SECONDS));
     }
   }
 
@@ -116,6 +113,52 @@ public class ExternalVolumeManagerTest {
     assertEquals(blobPath.blobPath, "http://f1.com?token=t1");
   }
 
+  @Test
+  public void testConcurrentGenerateBlobPath() throws Exception {
+    int numThreads = 50;
+    int timeoutInSeconds = 60;
+    manager.registerTable(new TableRef("db", "schema", "table"), fileLocationInfo);
+
+    List<Future<BlobPath>> allResults = doConcurrentTest(
+        numThreads,
+        timeoutInSeconds,
+        () -> {
+          for (int i = 0; i < 1000; i++) {
+            manager.generateBlobPath("db.schema.table");
+          }
+        },
+        () -> manager.generateBlobPath("db.schema.table"));
+    for (int i = 0; i < numThreads; i++) {
+      BlobPath blobPath = allResults.get(0).get(timeoutInSeconds, TimeUnit.SECONDS);
+      assertNotNull(blobPath);
+      assertTrue(blobPath.hasToken);
+      assertTrue(blobPath.blobPath, blobPath.blobPath.contains( "http://f1.com?token=t"));
+    }
+  }
+
+  private <T> List<Future<T>> doConcurrentTest(int numThreads, int timeoutInSeconds, Runnable action, Supplier<T> getResult) throws Exception {
+    assertNull(executorService);
+
+    executorService =
+        new ThreadPoolExecutor(
+            numThreads, numThreads, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
+    List<Callable<T>> tasks = new ArrayList<>();
+    final CyclicBarrier startBarrier = new CyclicBarrier(numThreads);
+    final CyclicBarrier endBarrier = new CyclicBarrier(numThreads);
+    for (int i = 0; i < numThreads; i++) {
+      tasks.add(
+          () -> {
+            startBarrier.await(timeoutInSeconds, TimeUnit.SECONDS);
+            action.run();
+            endBarrier.await();
+            return getResult.get();
+          });
+    }
+
+    List<Future<T>> allResults = executorService.invokeAll(tasks);
+    allResults.get(0).get(timeoutInSeconds, TimeUnit.SECONDS);
+    return allResults;
+  }
   @Test
   public void testGetClientPrefix() {
     assertEquals(manager.getClientPrefix(), "test_prefix_123");

--- a/src/test/java/net/snowflake/ingest/streaming/internal/MockSnowflakeServiceClient.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/MockSnowflakeServiceClient.java
@@ -131,6 +131,7 @@ public class MockSnowflakeServiceClient {
                         return buildStreamingIngestResponse(
                             HttpStatus.SC_OK, clientConfigresponseMap);
                       case GENERATE_PRESIGNED_URLS_ENDPOINT:
+                        Thread.sleep(1);
                         Map<String, Object> generateUrlsResponseMap = new HashMap<>();
                         generateUrlsResponseMap.put("status_code", 0L);
                         generateUrlsResponseMap.put("message", "OK");
@@ -140,9 +141,9 @@ public class MockSnowflakeServiceClient {
                                 new GeneratePresignedUrlsResponse.PresignedUrlInfo(
                                     "f1", "http://f1.com?token=t1"),
                                 new GeneratePresignedUrlsResponse.PresignedUrlInfo(
-                                    "f2", "http://f2.com?token=t2"),
+                                    "f2", "http://f1.com?token=t2"),
                                 new GeneratePresignedUrlsResponse.PresignedUrlInfo(
-                                    "f3", "http://f3.com?token=t3")));
+                                    "f3", "http://f1.com?token=t3")));
                         return buildStreamingIngestResponse(
                             HttpStatus.SC_OK, generateUrlsResponseMap);
                       case OPEN_CHANNEL_ENDPOINT:


### PR DESCRIPTION
1. Only use a URL if its more than 1 minute away from expiry
2. Handle a nullref in ExternalVolume.generateUrls
3. In case of high concurrent load on the url generation semaphore, only wait to acquire when the queue is null. If this was an optimistic URL fetch there is no need to wait around or the semaphore.
4. fix comment line wrapping.
5. add concurrent test for the generateUrl changes
6. TODO add test for the "dont use urls that are about to expire in the next minute" logic