### PR TITLE
SNOW-1711460 Exclude avro dependency to fix 853

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,12 @@
         <groupId>org.apache.iceberg</groupId>
         <artifactId>iceberg-core</artifactId>
         <version>${iceberg.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.iceberg</groupId>


### PR DESCRIPTION
I think we don't need the avro dependency and can exclude it to resolve 
https://github.com/snowflakedb/snowflake-ingest-java/issues/853

An alternative is upgrading to 1.6.1 iceberg-core, which has avro version 1.12.0 but if we confirm that we don't need it, it's best to exclude
