### PR TITLE
REVERT SNOW-1711460 Exclude avro dependency to fix 853

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,12 +287,6 @@
         <groupId>org.apache.iceberg</groupId>
         <artifactId>iceberg-core</artifactId>
         <version>${iceberg.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.iceberg</groupId>


### PR DESCRIPTION
Revert due to usage in kafka connector.

Waiting for newer release of iceberg-core before we can address https://github.com/snowflakedb/snowflake-ingest-java/issues/853
As the latest iceberg-core version does not include an upgrade avro dependency 