### PR TITLE
SNOW-1727532 Set number of values for repeated fields

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.ingest.streaming.internal;
@@ -642,13 +642,17 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
    *
    * @param rowCount: count of rows in the given buffer
    * @param colStats: map of column name to RowBufferStats
-   * @param setAllDefaultValues: whether to set default values for all null fields the EPs
-   *     irrespective of the data type of this column
+   * @param setAllDefaultValues: whether to set default values for all null min/max field in the EPs
+   * @param enableDistinctValuesCount: whether to include valid NDV in the EPs irrespective of the
+   *     data type of this column
    * @return the EPs built from column stats
    */
   static EpInfo buildEpInfoFromStats(
-      long rowCount, Map<String, RowBufferStats> colStats, boolean setAllDefaultValues) {
-    EpInfo epInfo = new EpInfo(rowCount, new HashMap<>());
+      long rowCount,
+      Map<String, RowBufferStats> colStats,
+      boolean setAllDefaultValues,
+      boolean enableDistinctValuesCount) {
+    EpInfo epInfo = new EpInfo(rowCount, new HashMap<>(), enableDistinctValuesCount);
     for (Map.Entry<String, RowBufferStats> colStat : colStats.entrySet()) {
       RowBufferStats stat = colStat.getValue();
       FileColumnProperties dto = new FileColumnProperties(stat, setAllDefaultValues);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelData.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2021-2024 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.ingest.streaming.internal;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChunkMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChunkMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2021-2024 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.ingest.streaming.internal;
@@ -26,6 +26,7 @@ class ChunkMetadata {
   private Integer majorVersion;
   private Integer minorVersion;
   private Long createdOn;
+  private Long metadataSize;
   private Long extendedMetadataSize;
 
   static Builder builder() {
@@ -51,6 +52,7 @@ class ChunkMetadata {
     private Integer majorVersion;
     private Integer minorVersion;
     private Long createdOn;
+    private Long metadataSize;
     private Long extendedMetadataSize;
 
     Builder setOwningTableFromChannelContext(ChannelFlushContext channelFlushContext) {
@@ -121,6 +123,11 @@ class ChunkMetadata {
 
     Builder setCreatedOn(Long createdOn) {
       this.createdOn = createdOn;
+      return this;
+    }
+
+    Builder setMetadataSize(Long metadataSize) {
+      this.metadataSize = metadataSize;
       return this;
     }
 
@@ -256,6 +263,12 @@ class ChunkMetadata {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   Long getCreatedOn() {
     return this.createdOn;
+  }
+
+  @JsonProperty("metadata_size")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  Long getMetadataSize() {
+    return this.metadataSize;
   }
 
   @JsonProperty("ext_metadata_size")

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChunkMetadata.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChunkMetadata.java
@@ -172,6 +172,7 @@ class ChunkMetadata {
     this.majorVersion = builder.majorVersion;
     this.minorVersion = builder.minorVersion;
     this.createdOn = builder.createdOn;
+    this.metadataSize = builder.metadataSize;
     this.extendedMetadataSize = builder.extendedMetadataSize;
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
@@ -73,14 +73,14 @@ public class ClientBufferParameters {
         clientInternal != null
             ? clientInternal.getParameterProvider().isEnableNewJsonParsingLogic()
             : ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT;
-    this.maxRowGroups =
-        isIcebergMode
-            ? Optional.of(InternalParameterProvider.MAX_ROW_GROUP_COUNT_ICEBERG_MODE_DEFAULT)
-            : Optional.empty();
     this.isIcebergMode =
         clientInternal != null
             ? clientInternal.isIcebergMode()
             : ParameterProvider.IS_ICEBERG_MODE_DEFAULT;
+    this.maxRowGroups =
+        isIcebergMode
+            ? Optional.of(InternalParameterProvider.MAX_ROW_GROUP_COUNT_ICEBERG_MODE_DEFAULT)
+            : Optional.empty();
     this.enableDistinctValuesCount =
         clientInternal != null
             ? clientInternal.getInternalParameterProvider().isEnableDistinctValuesCount()
@@ -150,7 +150,7 @@ public class ClientBufferParameters {
   }
 
   public boolean isEnableValuesCount() {
-    return enableDistinctValuesCount;
+    return enableValuesCount;
   }
 
   public boolean isEnableDictionaryEncoding() {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ClientBufferParameters.java
@@ -25,6 +25,10 @@ public class ClientBufferParameters {
 
   private boolean isIcebergMode;
 
+  private boolean enableDistinctValuesCount;
+
+  private boolean enableValuesCount;
+
   /**
    * Private constructor used for test methods
    *
@@ -38,13 +42,17 @@ public class ClientBufferParameters {
       Constants.BdecParquetCompression bdecParquetCompression,
       boolean enableNewJsonParsingLogic,
       Optional<Integer> maxRowGroups,
-      boolean isIcebergMode) {
+      boolean isIcebergMode,
+      boolean enableDistinctValuesCount,
+      boolean enableValuesCount) {
     this.maxChunkSizeInBytes = maxChunkSizeInBytes;
     this.maxAllowedRowSizeInBytes = maxAllowedRowSizeInBytes;
     this.bdecParquetCompression = bdecParquetCompression;
     this.enableNewJsonParsingLogic = enableNewJsonParsingLogic;
     this.maxRowGroups = maxRowGroups;
     this.isIcebergMode = isIcebergMode;
+    this.enableDistinctValuesCount = enableDistinctValuesCount;
+    this.enableValuesCount = enableValuesCount;
   }
 
   /** @param clientInternal reference to the client object where the relevant parameters are set */
@@ -65,14 +73,22 @@ public class ClientBufferParameters {
         clientInternal != null
             ? clientInternal.getParameterProvider().isEnableNewJsonParsingLogic()
             : ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT;
-    this.isIcebergMode =
-        clientInternal != null
-            ? clientInternal.isIcebergMode()
-            : ParameterProvider.IS_ICEBERG_MODE_DEFAULT;
     this.maxRowGroups =
         isIcebergMode
             ? Optional.of(InternalParameterProvider.MAX_ROW_GROUP_COUNT_ICEBERG_MODE_DEFAULT)
             : Optional.empty();
+    this.isIcebergMode =
+        clientInternal != null
+            ? clientInternal.isIcebergMode()
+            : ParameterProvider.IS_ICEBERG_MODE_DEFAULT;
+    this.enableDistinctValuesCount =
+        clientInternal != null
+            ? clientInternal.getInternalParameterProvider().isEnableDistinctValuesCount()
+            : InternalParameterProvider.ENABLE_DISTINCT_VALUES_COUNT_DEFAULT;
+    this.enableValuesCount =
+        clientInternal != null
+            ? clientInternal.getInternalParameterProvider().isEnableValuesCount()
+            : InternalParameterProvider.ENABLE_VALUES_COUNT_DEFAULT;
   }
 
   /**
@@ -87,14 +103,18 @@ public class ClientBufferParameters {
       Constants.BdecParquetCompression bdecParquetCompression,
       boolean enableNewJsonParsingLogic,
       Optional<Integer> maxRowGroups,
-      boolean isIcebergMode) {
+      boolean isIcebergMode,
+      boolean enableDistinctValuesCount,
+      boolean enableValuesCount) {
     return new ClientBufferParameters(
         maxChunkSizeInBytes,
         maxAllowedRowSizeInBytes,
         bdecParquetCompression,
         enableNewJsonParsingLogic,
         maxRowGroups,
-        isIcebergMode);
+        isIcebergMode,
+        enableDistinctValuesCount,
+        enableValuesCount);
   }
 
   public long getMaxChunkSizeInBytes() {
@@ -123,6 +143,14 @@ public class ClientBufferParameters {
 
   public String getParquetMessageTypeName() {
     return isIcebergMode ? PARQUET_MESSAGE_TYPE_NAME : BDEC_PARQUET_MESSAGE_TYPE_NAME;
+  }
+
+  public boolean isEnableDistinctValuesCount() {
+    return enableDistinctValuesCount;
+  }
+
+  public boolean isEnableValuesCount() {
+    return enableDistinctValuesCount;
   }
 
   public boolean isEnableDictionaryEncoding() {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/EpInfo.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/EpInfo.java
@@ -13,12 +13,18 @@ class EpInfo {
 
   private Map<String, FileColumnProperties> columnEps;
 
+  private boolean enableDistinctValuesCount;
+
   /** Default constructor, needed for Jackson */
   EpInfo() {}
 
-  EpInfo(long rowCount, Map<String, FileColumnProperties> columnEps) {
+  EpInfo(
+      long rowCount,
+      Map<String, FileColumnProperties> columnEps,
+      boolean enableDistinctValuesCount) {
     this.rowCount = rowCount;
     this.columnEps = columnEps;
+    this.enableDistinctValuesCount = enableDistinctValuesCount;
   }
 
   /** Some basic verification logic to make sure the EP info is correct */
@@ -35,8 +41,8 @@ class EpInfo {
                 colName, colEp.getNullCount(), rowCount));
       }
 
-      // Make sure the NDV should always be -1
-      if (colEp.getDistinctValues() != EP_NDV_UNKNOWN) {
+      // Make sure the NDV should always be -1 when the NDV set to default
+      if (!enableDistinctValuesCount && colEp.getDistinctValues() != EP_NDV_UNKNOWN) {
         throw new SFException(
             ErrorCode.INTERNAL_ERROR,
             String.format(

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
@@ -5,6 +5,7 @@
 package net.snowflake.ingest.streaming.internal;
 
 import static net.snowflake.ingest.streaming.internal.BinaryStringUtils.truncateBytesAsHex;
+import static net.snowflake.ingest.utils.Constants.EP_NV_UNKNOWN;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -45,7 +46,7 @@ class FileColumnProperties {
   private long nullCount;
 
   // for elements in repeated columns
-  private long numberOfValues;
+  private Long numberOfValues;
 
   // for binary or string columns
   private long maxLength;
@@ -113,7 +114,10 @@ class FileColumnProperties {
     this.setMinStrNonCollated(null);
     this.setNullCount(stats.getCurrentNullCount());
     this.setDistinctValues(stats.getDistinctValues());
-    this.setNumberOfValues(stats.getNumberOfValues());
+
+    if (stats.getNumberOfValues() != EP_NV_UNKNOWN) {
+      this.setNumberOfValues(stats.getNumberOfValues());
+    }
   }
 
   private void setIntValues(RowBufferStats stats) {
@@ -289,12 +293,12 @@ class FileColumnProperties {
   }
 
   @JsonProperty("numberOfValues")
-  @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = IgnoreMinusOneFilter.class)
-  long getNumberOfValues() {
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  Long getNumberOfValues() {
     return numberOfValues;
   }
 
-  void setNumberOfValues(long numberOfValues) {
+  void setNumberOfValues(Long numberOfValues) {
     this.numberOfValues = numberOfValues;
   }
 
@@ -320,6 +324,7 @@ class FileColumnProperties {
     }
     sb.append(", \"distinctValues\": ").append(distinctValues);
     sb.append(", \"nullCount\": ").append(nullCount);
+    sb.append(", \"numberOfValues\": ").append(numberOfValues);
     return sb.append('}').toString();
   }
 
@@ -359,15 +364,5 @@ class FileColumnProperties {
         distinctValues,
         nullCount,
         maxLength);
-  }
-
-  static class IgnoreMinusOneFilter {
-    @Override
-    public boolean equals(Object obj) {
-      if (obj instanceof Long) {
-        return (Long) obj == -1;
-      }
-      return false;
-    }
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
@@ -44,6 +44,9 @@ class FileColumnProperties {
 
   private long nullCount;
 
+  // for elements in repeated columns
+  private Long numberOfValues;
+
   // for binary or string columns
   private long maxLength;
 
@@ -110,6 +113,7 @@ class FileColumnProperties {
     this.setMinStrNonCollated(null);
     this.setNullCount(stats.getCurrentNullCount());
     this.setDistinctValues(stats.getDistinctValues());
+    this.setNumberOfValues(stats.getNumberOfValues());
   }
 
   private void setIntValues(RowBufferStats stats) {
@@ -282,6 +286,16 @@ class FileColumnProperties {
 
   void setMaxStrNonCollated(String maxStrNonCollated) {
     this.maxStrNonCollated = maxStrNonCollated;
+  }
+
+  @JsonProperty("numberOfValues")
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  Long getNumberOfValues() {
+    return numberOfValues;
+  }
+
+  void setNumberOfValues(Long numberOfValues) {
+    this.numberOfValues = numberOfValues;
   }
 
   @Override

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileColumnProperties.java
@@ -45,7 +45,7 @@ class FileColumnProperties {
   private long nullCount;
 
   // for elements in repeated columns
-  private Long numberOfValues;
+  private long numberOfValues;
 
   // for binary or string columns
   private long maxLength;
@@ -289,12 +289,12 @@ class FileColumnProperties {
   }
 
   @JsonProperty("numberOfValues")
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-  Long getNumberOfValues() {
+  @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = IgnoreMinusOneFilter.class)
+  long getNumberOfValues() {
     return numberOfValues;
   }
 
-  void setNumberOfValues(Long numberOfValues) {
+  void setNumberOfValues(long numberOfValues) {
     this.numberOfValues = numberOfValues;
   }
 
@@ -359,5 +359,15 @@ class FileColumnProperties {
         distinctValues,
         nullCount,
         maxLength);
+  }
+
+  static class IgnoreMinusOneFilter {
+    @Override
+    public boolean equals(Object obj) {
+      if (obj instanceof Long) {
+        return (Long) obj == -1;
+      }
+      return false;
+    }
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -597,11 +597,13 @@ class FlushService<T> {
           InvalidKeyException {
     Timer.Context buildContext = Utils.createTimerContext(this.owningClient.buildLatency);
 
-    InternalParameterProvider paramProvider = this.owningClient.getInternalParameterProvider();
     // Construct the blob along with the metadata of the blob
     BlobBuilder.Blob blob =
         BlobBuilder.constructBlobAndMetadata(
-            blobPath.fileName, blobData, bdecVersion, paramProvider);
+            blobPath.fileName,
+            blobData,
+            bdecVersion,
+            this.owningClient.getInternalParameterProvider());
 
     blob.blobStats.setBuildDurationMs(buildContext);
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
@@ -36,6 +36,7 @@ public interface Flusher<T> {
     final float chunkEstimatedUncompressedSize;
     final ByteArrayOutputStream chunkData;
     final Pair<Long, Long> chunkMinMaxInsertTimeInMs;
+    final long extendedMetadataSize;
 
     public SerializationResult(
         List<ChannelMetadata> channelsMetadataList,
@@ -43,13 +44,15 @@ public interface Flusher<T> {
         long rowCount,
         float chunkEstimatedUncompressedSize,
         ByteArrayOutputStream chunkData,
-        Pair<Long, Long> chunkMinMaxInsertTimeInMs) {
+        Pair<Long, Long> chunkMinMaxInsertTimeInMs,
+        long extendedMetadataSize) {
       this.channelsMetadataList = channelsMetadataList;
       this.columnEpStatsMapCombined = columnEpStatsMapCombined;
       this.rowCount = rowCount;
       this.chunkEstimatedUncompressedSize = chunkEstimatedUncompressedSize;
       this.chunkData = chunkData;
       this.chunkMinMaxInsertTimeInMs = chunkMinMaxInsertTimeInMs;
+      this.extendedMetadataSize = extendedMetadataSize;
     }
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/InternalParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/InternalParameterProvider.java
@@ -7,6 +7,8 @@ package net.snowflake.ingest.streaming.internal;
 /** A class to provide non-configurable constants depends on Iceberg or non-Iceberg mode */
 class InternalParameterProvider {
   public static final Integer MAX_ROW_GROUP_COUNT_ICEBERG_MODE_DEFAULT = 1;
+  public static final boolean ENABLE_DISTINCT_VALUES_COUNT_DEFAULT = false;
+  public static final boolean ENABLE_VALUES_COUNT_DEFAULT = false;
 
   private final boolean isIcebergMode;
 
@@ -31,6 +33,17 @@ class InternalParameterProvider {
   boolean setIcebergSpecificFieldsInEp() {
     // When in Iceberg mode, we need to explicitly populate the major and minor version of parquet
     // in the EP metadata, createdOn, and extendedMetadataSize.
+    return isIcebergMode;
+  }
+
+  boolean isEnableDistinctValuesCount() {
+    // When in Iceberg mode, we enabled distinct values count in EP metadata.
+    return isIcebergMode;
+  }
+
+  boolean isEnableValuesCount() {
+    // When in Iceberg mode, we enabled values count in EP metadata for repeated group (e.g. map,
+    // list).
     return isIcebergMode;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -17,7 +17,7 @@ import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.column.ParquetProperties;
-import org.apache.parquet.hadoop.BdecParquetWriter;
+import org.apache.parquet.hadoop.SnowflakeParquetWriter;
 import org.apache.parquet.schema.MessageType;
 
 /**
@@ -66,7 +66,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
     String firstChannelFullyQualifiedTableName = null;
     Map<String, RowBufferStats> columnEpStatsMapCombined = null;
     List<List<Object>> rows = null;
-    BdecParquetWriter parquetWriter;
+    SnowflakeParquetWriter parquetWriter;
     ByteArrayOutputStream mergedData = new ByteArrayOutputStream();
     Pair<Long, Long> chunkMinMaxInsertTimeInMs = null;
 
@@ -129,7 +129,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
     // http://go/streams-on-replicated-mixed-tables
     metadata.put(Constants.PRIMARY_FILE_ID_KEY, StreamingIngestUtils.getShortname(filePath));
     parquetWriter =
-        new BdecParquetWriter(
+        new SnowflakeParquetWriter(
             mergedData,
             schema,
             metadata,
@@ -150,7 +150,8 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
         rowCount,
         chunkEstimatedUncompressedSize,
         mergedData,
-        chunkMinMaxInsertTimeInMs);
+        chunkMinMaxInsertTimeInMs,
+        parquetWriter.getExtendedMetadataSize());
   }
 
   /**
@@ -164,7 +165,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
    *     Used only for logging purposes if there is a mismatch.
    */
   private void verifyRowCounts(
-      BdecParquetWriter writer,
+      SnowflakeParquetWriter writer,
       long totalMetadataRowCount,
       List<ChannelData<ParquetChunkData>> channelsDataPerTable,
       long javaSerializationTotalRowCount) {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -358,18 +358,16 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
         if (subColumnFinder == null) {
           throw new SFException(ErrorCode.INTERNAL_ERROR, "SubColumnFinder is not initialized.");
         }
-        subColumnFinder
-            .getSubColumns(columnName)
-            .forEach(
-                subColumn -> {
-                  RowBufferStats stats = statsMap.get(subColumn);
-                  if (stats == null) {
-                    throw new SFException(
-                        ErrorCode.INTERNAL_ERROR,
-                        String.format("Column %s not found in stats map.", subColumn));
-                  }
-                  statsMap.get(subColumn).incCurrentNullCount();
-                });
+
+        for (String subColumn : subColumnFinder.getSubColumns(columnName)) {
+          RowBufferStats stats = statsMap.get(subColumn);
+          if (stats == null) {
+            throw new SFException(
+                ErrorCode.INTERNAL_ERROR,
+                String.format("Column %s not found in stats map.", subColumn));
+          }
+          stats.incCurrentNullCount();
+        }
       } else {
         statsMap.get(columnName).incCurrentNullCount();
       }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -114,8 +114,8 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
                 column.getOrdinal(),
                 null /* fieldId */,
                 parquetType.isPrimitive() ? parquetType.asPrimitiveType() : null,
-                clientBufferParameters.isEnableDistinctValuesCount(),
-                clientBufferParameters.isEnableValuesCount()));
+                false /* enableDistinctValuesCount */,
+                false /* enableValuesCount */));
 
         if (onErrorOption == OpenChannelRequest.OnErrorOption.ABORT
             || onErrorOption == OpenChannelRequest.OnErrorOption.SKIP_BATCH) {
@@ -131,8 +131,8 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
                   column.getOrdinal(),
                   null /* fieldId */,
                   parquetType.isPrimitive() ? parquetType.asPrimitiveType() : null,
-                  clientBufferParameters.isEnableDistinctValuesCount(),
-                  clientBufferParameters.isEnableValuesCount()));
+                  false /* enableDistinctValuesCount */,
+                  false /* enableValuesCount */));
         }
       }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -38,8 +38,6 @@ import org.apache.parquet.schema.Type;
  */
 public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
 
-  private final Map<String, ParquetColumn> fieldIndex;
-
   /* map that contains metadata like typeinfo for columns and other information needed by the server scanner */
   private final Map<String, String> metadata;
 
@@ -72,7 +70,6 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
         clientBufferParameters,
         offsetTokenVerificationFunction,
         telemetryService);
-    this.fieldIndex = new HashMap<>();
     this.metadata = new HashMap<>();
     this.data = new ArrayList<>();
     this.tempData = new ArrayList<>();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -5,6 +5,7 @@
 package net.snowflake.ingest.streaming.internal;
 
 import static net.snowflake.ingest.utils.Constants.EP_NDV_UNKNOWN;
+import static net.snowflake.ingest.utils.Constants.EP_NV_UNKNOWN;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -48,7 +49,7 @@ class RowBufferStats {
   private final boolean enableDistinctValuesCount;
   private Set<Object> distinctValues;
   private final boolean enableValuesCount;
-  private Long numberOfValues;
+  private long numberOfValues;
 
   RowBufferStats(
       String columnDisplayName,
@@ -310,9 +311,8 @@ class RowBufferStats {
     return enableDistinctValuesCount ? distinctValues.size() : EP_NDV_UNKNOWN;
   }
 
-  // TODO: change default to -1 after Oct 17
-  Long getNumberOfValues() {
-    return enableValuesCount ? numberOfValues : null;
+  long getNumberOfValues() {
+    return enableValuesCount ? numberOfValues : EP_NV_UNKNOWN;
   }
 
   String getCollationDefinitionString() {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -121,22 +121,22 @@ class RowBufferStats {
 
   // TODO performance test this vs in place update
   static RowBufferStats getCombinedStats(RowBufferStats left, RowBufferStats right) {
-    if (!Objects.equals(left.getCollationDefinitionString(), right.collationDefinitionString)) {
+    if (!Objects.equals(left.getCollationDefinitionString(), right.collationDefinitionString)
+        || left.enableDistinctValuesCount != right.enableDistinctValuesCount
+        || left.enableValuesCount != right.enableValuesCount) {
       throw new SFException(
           ErrorCode.INVALID_COLLATION_STRING,
-          "Tried to combine stats for different collations",
+          "Tried to combine stats for different"
+              + " collations/enableDistinctValuesCount/enableValuesCount",
           String.format(
-              "left=%s, right=%s",
-              left.getCollationDefinitionString(), right.getCollationDefinitionString()));
-    }
-
-    if (left.enableDistinctValuesCount != right.enableDistinctValuesCount) {
-      throw new SFException(
-          ErrorCode.INTERNAL_ERROR,
-          "Tried to combine stats for different distinct value settings",
-          String.format(
-              "left=%s, right=%s",
-              left.enableDistinctValuesCount, right.enableDistinctValuesCount));
+              "left={collations=%s, enableDistinctValuesCount=%s, enableValuesCount=%s}, "
+                  + "right={collations=%s, enableDistinctValuesCount=%s, enableValuesCount=%s}",
+              left.getCollationDefinitionString(),
+              left.enableDistinctValuesCount,
+              left.enableValuesCount,
+              right.getCollationDefinitionString(),
+              right.enableDistinctValuesCount,
+              right.enableValuesCount));
     }
 
     RowBufferStats combined =

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -62,6 +62,7 @@ public class Constants {
   public static final int MAX_STREAMING_INGEST_API_CHANNEL_RETRY = 3;
   public static final int STREAMING_INGEST_TELEMETRY_UPLOAD_INTERVAL_IN_SEC = 10;
   public static final long EP_NDV_UNKNOWN = -1L;
+  public static final long EP_NV_UNKNOWN = -1L;
   public static final int MAX_OAUTH_REFRESH_TOKEN_RETRY = 3;
   public static final int BINARY_COLUMN_MAX_SIZE = 8 * 1024 * 1024;
   public static final int VARCHAR_COLUMN_MAX_SIZE = 16 * 1024 * 1024;
@@ -72,6 +73,7 @@ public class Constants {
   public static final String DROP_CHANNEL_ENDPOINT = "/v1/streaming/channels/drop/";
   public static final String REGISTER_BLOB_ENDPOINT = "/v1/streaming/channels/write/blobs/";
 
+  public static final int PARQUET_MAJOR_VERSION = 1;
   public static final int PARQUET_MINOR_VERSION = 0;
 
   /**

--- a/src/main/java/net/snowflake/ingest/utils/IcebergDataTypeParser.java
+++ b/src/main/java/net/snowflake/ingest/utils/IcebergDataTypeParser.java
@@ -26,14 +26,14 @@ import org.apache.iceberg.util.JsonUtil;
  * /IcebergDataTypeParser.java
  */
 public class IcebergDataTypeParser {
+  public static final String ELEMENT = "element";
+  public static final String KEY = "key";
+  public static final String VALUE = "value";
   private static final String TYPE = "type";
   private static final String STRUCT = "struct";
   private static final String LIST = "list";
   private static final String MAP = "map";
   private static final String FIELDS = "fields";
-  private static final String ELEMENT = "element";
-  private static final String KEY = "key";
-  private static final String VALUE = "value";
   private static final String DOC = "doc";
   private static final String NAME = "name";
   private static final String ID = "id";

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -157,73 +157,85 @@ public class ParameterProvider {
         BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT,
         parameterOverrides,
         props,
-        false);
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
         INSERT_THROTTLE_INTERVAL_IN_MILLIS,
         INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT,
         parameterOverrides,
         props,
-        false);
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
         INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE,
         INSERT_THROTTLE_THRESHOLD_IN_PERCENTAGE_DEFAULT,
         parameterOverrides,
         props,
-        false);
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
         INSERT_THROTTLE_THRESHOLD_IN_BYTES,
         INSERT_THROTTLE_THRESHOLD_IN_BYTES_DEFAULT,
         parameterOverrides,
         props,
-        false);
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
         ENABLE_SNOWPIPE_STREAMING_METRICS,
         SNOWPIPE_STREAMING_METRICS_DEFAULT,
         parameterOverrides,
         props,
-        false);
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
-        BLOB_FORMAT_VERSION, BLOB_FORMAT_VERSION_DEFAULT, parameterOverrides, props, false);
+        BLOB_FORMAT_VERSION,
+        BLOB_FORMAT_VERSION_DEFAULT,
+        parameterOverrides,
+        props,
+        false /* enforceDefault */);
     getBlobFormatVersion(); // to verify parsing the configured value
 
     this.checkAndUpdate(
-        IO_TIME_CPU_RATIO, IO_TIME_CPU_RATIO_DEFAULT, parameterOverrides, props, false);
+        IO_TIME_CPU_RATIO,
+        IO_TIME_CPU_RATIO_DEFAULT,
+        parameterOverrides,
+        props,
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
         BLOB_UPLOAD_MAX_RETRY_COUNT,
         BLOB_UPLOAD_MAX_RETRY_COUNT_DEFAULT,
         parameterOverrides,
         props,
-        false);
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
         MAX_MEMORY_LIMIT_IN_BYTES,
         MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT,
         parameterOverrides,
         props,
-        false);
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
         MAX_CHANNEL_SIZE_IN_BYTES,
         MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT,
         parameterOverrides,
         props,
-        false);
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
-        MAX_CHUNK_SIZE_IN_BYTES, MAX_CHUNK_SIZE_IN_BYTES_DEFAULT, parameterOverrides, props, false);
+        MAX_CHUNK_SIZE_IN_BYTES,
+        MAX_CHUNK_SIZE_IN_BYTES_DEFAULT,
+        parameterOverrides,
+        props,
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
         MAX_CLIENT_LAG,
         isIcebergMode ? MAX_CLIENT_LAG_ICEBERG_MODE_DEFAULT : MAX_CLIENT_LAG_DEFAULT,
         parameterOverrides,
         props,
-        false);
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
         MAX_CHUNKS_IN_BLOB,
@@ -237,21 +249,21 @@ public class ParameterProvider {
         MAX_CHUNKS_IN_REGISTRATION_REQUEST_DEFAULT,
         parameterOverrides,
         props,
-        false);
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
         BDEC_PARQUET_COMPRESSION_ALGORITHM,
         BDEC_PARQUET_COMPRESSION_ALGORITHM_DEFAULT,
         parameterOverrides,
         props,
-        false);
+        false /* enforceDefault */);
 
     this.checkAndUpdate(
         ENABLE_NEW_JSON_PARSING_LOGIC,
         ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT,
         parameterOverrides,
         props,
-        false);
+        false /* enforceDefault */);
 
     if (getMaxChunksInBlob() > getMaxChunksInRegistrationRequest()) {
       throw new IllegalArgumentException(

--- a/src/main/java/net/snowflake/ingest/utils/SubColumnFinder.java
+++ b/src/main/java/net/snowflake/ingest/utils/SubColumnFinder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.utils;
+
+import static net.snowflake.ingest.utils.Utils.concatDotPath;
+import static net.snowflake.ingest.utils.Utils.isNullOrEmpty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
+
+/** Helper class to find all leaf sub-columns in an immutable schema given a dot path. */
+public class SubColumnFinder {
+  static class SubtreeInterval {
+    final int startTag;
+    final int endTag;
+
+    SubtreeInterval(int startTag, int endTag) {
+      this.startTag = startTag;
+      this.endTag = endTag;
+    }
+  }
+
+  private final List<String> list;
+  private final Map<String, SubtreeInterval> accessMap;
+
+  public SubColumnFinder(MessageType schema) {
+    accessMap = new HashMap<>();
+    list = new ArrayList<>();
+    build(schema, null);
+  }
+
+  public List<String> getSubColumns(String dotPath) {
+    if (!accessMap.containsKey(dotPath)) {
+      throw new IllegalArgumentException(String.format("Column %s not found in schema", dotPath));
+    }
+    SubtreeInterval interval = accessMap.get(dotPath);
+    return Collections.unmodifiableList(list.subList(interval.startTag, interval.endTag));
+  }
+
+  private void build(Type node, String dotPath) {
+    if (dotPath == null) {
+      /* Ignore root node type name (bdec or schema) */
+      dotPath = "";
+    } else if (dotPath.isEmpty()) {
+      dotPath = node.getName();
+    } else {
+      dotPath = concatDotPath(dotPath, node.getName());
+    }
+
+    int startTag = list.size();
+    if (!node.isPrimitive()) {
+      for (Type child : node.asGroupType().getFields()) {
+        build(child, dotPath);
+      }
+    } else {
+      list.add(dotPath);
+    }
+    if (!isNullOrEmpty(dotPath)) {
+      accessMap.put(dotPath, new SubtreeInterval(startTag, list.size()));
+    }
+  }
+}

--- a/src/main/java/net/snowflake/ingest/utils/Utils.java
+++ b/src/main/java/net/snowflake/ingest/utils/Utils.java
@@ -449,13 +449,13 @@ public class Utils {
           String.format("Invalid parquet file. File too small, file length=%s.", bytes.length));
     }
 
-    if (!ParquetFileWriter.MAGIC_STR.equals(
-        new String(bytes, magicOffset, ParquetFileWriter.MAGIC.length))) {
+    String fileMagic = new String(bytes, magicOffset, ParquetFileWriter.MAGIC.length);
+    if (!ParquetFileWriter.MAGIC_STR.equals(fileMagic)
+        && !ParquetFileWriter.EF_MAGIC_STR.equals(fileMagic)) {
       throw new IllegalArgumentException(
           String.format(
-              "Invalid parquet file. Bad parquet magic, expected=%s, actual=%s.",
-              ParquetFileWriter.MAGIC_STR,
-              new String(bytes, magicOffset, ParquetFileWriter.MAGIC.length)));
+              "Invalid parquet file. Bad parquet magic, expected=[%s | %s], actual=%s.",
+              ParquetFileWriter.MAGIC_STR, ParquetFileWriter.EF_MAGIC_STR, fileMagic));
     }
 
     return BytesUtils.readIntLittleEndian(bytes, footerSizeOffset);

--- a/src/main/java/net/snowflake/ingest/utils/Utils.java
+++ b/src/main/java/net/snowflake/ingest/utils/Utils.java
@@ -8,6 +8,7 @@ import static net.snowflake.ingest.utils.Constants.USER;
 
 import com.codahale.metrics.Timer;
 import io.netty.util.internal.PlatformDependent;
+import java.io.IOException;
 import java.io.StringReader;
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ManagementFactory;
@@ -29,6 +30,8 @@ import java.util.Map;
 import java.util.Properties;
 import net.snowflake.client.core.SFSessionProperty;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
@@ -429,5 +432,32 @@ public class Utils {
       sb.append(p);
     }
     return sb.toString();
+  }
+
+  /**
+   * Get the footer size (metadata size) of a parquet file
+   *
+   * @param bytes the serialized parquet file
+   * @return the footer size
+   */
+  public static long getParquetFooterSize(byte[] bytes) throws IOException {
+    final int magicOffset = bytes.length - ParquetFileWriter.MAGIC.length;
+    final int footerSizeOffset = magicOffset - Integer.BYTES;
+
+    if (footerSizeOffset < 0) {
+      throw new IllegalArgumentException(
+          String.format("Invalid parquet file. File too small, file length=%s.", bytes.length));
+    }
+
+    if (!ParquetFileWriter.MAGIC_STR.equals(
+        new String(bytes, magicOffset, ParquetFileWriter.MAGIC.length))) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Invalid parquet file. Bad parquet magic, expected=%s, actual=%s.",
+              ParquetFileWriter.MAGIC_STR,
+              new String(bytes, magicOffset, ParquetFileWriter.MAGIC.length)));
+    }
+
+    return BytesUtils.readIntLittleEndian(bytes, footerSizeOffset);
   }
 }

--- a/src/main/java/net/snowflake/ingest/utils/Utils.java
+++ b/src/main/java/net/snowflake/ingest/utils/Utils.java
@@ -8,7 +8,6 @@ import static net.snowflake.ingest.utils.Constants.USER;
 
 import com.codahale.metrics.Timer;
 import io.netty.util.internal.PlatformDependent;
-import java.io.IOException;
 import java.io.StringReader;
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ManagementFactory;
@@ -30,8 +29,6 @@ import java.util.Map;
 import java.util.Properties;
 import net.snowflake.client.core.SFSessionProperty;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.parquet.bytes.BytesUtils;
-import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
@@ -432,25 +429,5 @@ public class Utils {
       sb.append(p);
     }
     return sb.toString();
-  }
-
-  /**
-   * Get the extended metadata size (footer size) from a parquet file
-   *
-   * @param bytes the serialized parquet file
-   * @param length the length of the byte array without padding
-   * @return the extended metadata size
-   */
-  public static int getExtendedMetadataSize(byte[] bytes, int length) throws IOException {
-    final int magicOffset = length - ParquetFileWriter.MAGIC.length;
-    final int footerSizeOffset = magicOffset - Integer.BYTES;
-    if (bytes.length < length
-        || footerSizeOffset < 0
-        || !ParquetFileWriter.MAGIC_STR.equals(
-            new String(bytes, magicOffset, ParquetFileWriter.MAGIC.length))) {
-      throw new IllegalArgumentException("Invalid parquet file");
-    }
-
-    return BytesUtils.readIntLittleEndian(bytes, footerSizeOffset);
   }
 }

--- a/src/main/java/net/snowflake/ingest/utils/Utils.java
+++ b/src/main/java/net/snowflake/ingest/utils/Utils.java
@@ -8,6 +8,7 @@ import static net.snowflake.ingest.utils.Constants.USER;
 
 import com.codahale.metrics.Timer;
 import io.netty.util.internal.PlatformDependent;
+import java.io.IOException;
 import java.io.StringReader;
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ManagementFactory;
@@ -29,6 +30,8 @@ import java.util.Map;
 import java.util.Properties;
 import net.snowflake.client.core.SFSessionProperty;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
@@ -412,7 +415,7 @@ public class Utils {
     return String.format("%s.%s.%s.%s", dbName, schemaName, tableName, channelName);
   }
 
-  /*
+  /**
    * Get concat dot path, check if any path is empty or null
    *
    * @param path the path
@@ -429,5 +432,25 @@ public class Utils {
       sb.append(p);
     }
     return sb.toString();
+  }
+
+  /**
+   * Get the extended metadata size (footer size) from a parquet file
+   *
+   * @param bytes the serialized parquet file
+   * @param length the length of the byte array without padding
+   * @return the extended metadata size
+   */
+  public static int getExtendedMetadataSize(byte[] bytes, int length) throws IOException {
+    final int magicOffset = length - ParquetFileWriter.MAGIC.length;
+    final int footerSizeOffset = magicOffset - Integer.BYTES;
+    if (bytes.length < length
+        || footerSizeOffset < 0
+        || !ParquetFileWriter.MAGIC_STR.equals(
+            new String(bytes, magicOffset, ParquetFileWriter.MAGIC.length))) {
+      throw new IllegalArgumentException("Invalid parquet file");
+    }
+
+    return BytesUtils.readIntLittleEndian(bytes, footerSizeOffset);
   }
 }

--- a/src/main/java/org/apache/parquet/hadoop/BdecParquetReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/BdecParquetReader.java
@@ -4,6 +4,7 @@
 
 package org.apache.parquet.hadoop;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
@@ -92,10 +93,11 @@ public class BdecParquetReader implements AutoCloseable {
     }
   }
 
-  private static class BdecInputFile implements InputFile {
+  @VisibleForTesting
+  public static class BdecInputFile implements InputFile {
     private final byte[] data;
 
-    private BdecInputFile(byte[] data) {
+    public BdecInputFile(byte[] data) {
       this.data = data;
     }
 

--- a/src/main/java/org/apache/parquet/hadoop/BdecParquetReader.java
+++ b/src/main/java/org/apache/parquet/hadoop/BdecParquetReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Snowflake Computing Inc. All rights reserved.
  */
 
 package org.apache.parquet.hadoop;
@@ -82,7 +82,7 @@ public class BdecParquetReader implements AutoCloseable {
    * @param data input data to be read first and then written with outputWriter
    * @param outputWriter output parquet writer
    */
-  public static void readFileIntoWriter(byte[] data, BdecParquetWriter outputWriter) {
+  public static void readFileIntoWriter(byte[] data, SnowflakeParquetWriter outputWriter) {
     try (BdecParquetReader reader = new BdecParquetReader(data)) {
       for (List<Object> record = reader.read(); record != null; record = reader.read()) {
         outputWriter.writeRow(record);

--- a/src/main/java/org/apache/parquet/hadoop/SnowflakeParquetWriter.java
+++ b/src/main/java/org/apache/parquet/hadoop/SnowflakeParquetWriter.java
@@ -152,7 +152,7 @@ public class SnowflakeParquetWriter implements AutoCloseable {
                 + (column.getOffsetIndexReference() != null
                     ? column.getOffsetIndexReference().getLength()
                     : 0)
-                + column.getBloomFilterLength();
+                + (column.getBloomFilterLength() == -1 ? 0 : column.getBloomFilterLength());
       }
     }
     return extendedMetadataSize;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -15,7 +15,7 @@ import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.column.ParquetProperties;
-import org.apache.parquet.hadoop.BdecParquetWriter;
+import org.apache.parquet.hadoop.SnowflakeParquetWriter;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
@@ -87,8 +87,8 @@ public class BlobBuilderTest {
 
     channelData.setRowSequencer(1L);
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
-    BdecParquetWriter bdecParquetWriter =
-        new BdecParquetWriter(
+    SnowflakeParquetWriter snowflakeParquetWriter =
+        new SnowflakeParquetWriter(
             stream,
             schema,
             new HashMap<>(),
@@ -100,7 +100,7 @@ public class BlobBuilderTest {
                 ? ParquetProperties.WriterVersion.PARQUET_2_0
                 : ParquetProperties.WriterVersion.PARQUET_1_0,
             isIceberg);
-    bdecParquetWriter.writeRow(Collections.singletonList("1"));
+    snowflakeParquetWriter.writeRow(Collections.singletonList("1"));
     channelData.setVectors(
         new ParquetChunkData(
             Collections.singletonList(Collections.singletonList("A")), new HashMap<>()));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -121,8 +121,10 @@ public class BlobBuilderTest {
                     Types.optional(PrimitiveType.PrimitiveTypeName.BINARY)
                         .as(LogicalTypeAnnotation.stringType())
                         .id(1)
-                        .named("test"))
-                : new RowBufferStats(columnName, null, 1, null, null));
+                        .named("test"),
+                    isIceberg,
+                    isIceberg)
+                : new RowBufferStats(columnName, null, 1, null, null, false, false));
     channelData.setChannelContext(
         new ChannelFlushContext("channel1", "DB", "SCHEMA", "TABLE", 1L, "enc", 1L));
     return Collections.singletonList(channelData);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -4,6 +4,7 @@
 
 package net.snowflake.ingest.streaming.internal;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collections;
@@ -15,11 +16,20 @@ import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.SnowflakeParquetWriter;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.DelegatingSeekableInputStream;
+import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,6 +71,51 @@ public class BlobBuilderTest {
       Assert.assertTrue(e.getMessage().contains("channelsCountInMetadata=1"));
       Assert.assertTrue(e.getMessage().contains("countOfSerializedJavaObjects=1"));
     }
+  }
+
+  @Test
+  public void testMetadataAndExtendedMetadataSize() throws Exception {
+    if (!isIceberg) {
+      return;
+    }
+
+    BlobBuilder.Blob blob =
+        BlobBuilder.constructBlobAndMetadata(
+            "a.parquet",
+            Collections.singletonList(createChannelDataPerTable(1)),
+            Constants.BdecVersion.THREE,
+            new InternalParameterProvider(isIceberg));
+
+    InputFile blobInputFile = new InMemoryInputFile(blob.blobBytes);
+    ParquetFileReader reader = ParquetFileReader.open(blobInputFile);
+    ParquetMetadata footer = reader.getFooter();
+
+    int extendedMetadataSize = 0;
+    long extendedMetadaOffset = 0;
+    for (BlockMetaData block : footer.getBlocks()) {
+      for (ColumnChunkMetaData column : block.getColumns()) {
+        extendedMetadataSize +=
+            (column.getColumnIndexReference() != null
+                    ? column.getColumnIndexReference().getLength()
+                    : 0)
+                + (column.getOffsetIndexReference() != null
+                    ? column.getOffsetIndexReference().getLength()
+                    : 0)
+                + (column.getBloomFilterLength() == -1 ? 0 : column.getBloomFilterLength());
+        extendedMetadaOffset =
+            Math.max(column.getFirstDataPageOffset() + column.getTotalSize(), extendedMetadaOffset);
+      }
+    }
+    Assertions.assertThat(blob.chunksMetadataList.size()).isEqualTo(1);
+    Assertions.assertThat(blob.chunksMetadataList.get(0).getExtendedMetadataSize())
+        .isEqualTo(extendedMetadataSize);
+    Assertions.assertThat(blob.chunksMetadataList.get(0).getMetadataSize())
+        .isEqualTo(
+            blob.blobBytes.length
+                - extendedMetadaOffset
+                - extendedMetadataSize
+                - ParquetFileWriter.MAGIC.length
+                - Integer.BYTES);
   }
 
   /**
@@ -133,7 +188,7 @@ public class BlobBuilderTest {
   private static MessageType createSchema(String columnName) {
     ParquetTypeInfo c1 =
         ParquetTypeGenerator.generateColumnParquetTypeInfo(createTestTextColumn(columnName), 1);
-    return new MessageType("bdec", Collections.singletonList(c1.getParquetType()));
+    return new MessageType("InMemory", Collections.singletonList(c1.getParquetType()));
   }
 
   private static ColumnMetadata createTestTextColumn(String name) {
@@ -147,5 +202,56 @@ public class BlobBuilderTest {
     colChar.setLength(11);
     colChar.setScale(0);
     return colChar;
+  }
+
+  static class InMemoryInputFile implements InputFile {
+    private final byte[] data;
+
+    public InMemoryInputFile(byte[] data) {
+      this.data = data;
+    }
+
+    @Override
+    public long getLength() {
+      return data.length;
+    }
+
+    @Override
+    public SeekableInputStream newStream() {
+      return new InMemorySeekableInputStream(new InMemoryByteArrayInputStream(data));
+    }
+  }
+
+  private static class InMemorySeekableInputStream extends DelegatingSeekableInputStream {
+    private final InMemoryByteArrayInputStream stream;
+
+    public InMemorySeekableInputStream(InMemoryByteArrayInputStream stream) {
+      super(stream);
+      this.stream = stream;
+    }
+
+    @Override
+    public long getPos() {
+      return stream.getPos();
+    }
+
+    @Override
+    public void seek(long newPos) {
+      stream.seek(newPos);
+    }
+  }
+
+  private static class InMemoryByteArrayInputStream extends ByteArrayInputStream {
+    public InMemoryByteArrayInputStream(byte[] buf) {
+      super(buf);
+    }
+
+    long getPos() {
+      return pos;
+    }
+
+    void seek(long newPos) {
+      pos = (int) newPos;
+    }
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelDataTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelDataTest.java
@@ -125,13 +125,8 @@ public class ChannelDataTest {
     Assert.assertNull(oneCombined.getCurrentMinRealValue());
     Assert.assertNull(oneCombined.getCurrentMaxRealValue());
 
-    if (enableNDVAndNV) {
-      Assert.assertEquals(5, oneCombined.getDistinctValues());
-      Assert.assertEquals(5, oneCombined.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, oneCombined.getDistinctValues());
-      Assert.assertNull(oneCombined.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 5 : -1, oneCombined.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 5 : -1, oneCombined.getNumberOfValues());
 
     Assert.assertArrayEquals(
         "10".getBytes(StandardCharsets.UTF_8), twoCombined.getCurrentMinStrValue());
@@ -142,12 +137,7 @@ public class ChannelDataTest {
     Assert.assertNull(twoCombined.getCurrentMinRealValue());
     Assert.assertNull(twoCombined.getCurrentMaxRealValue());
 
-    if (enableNDVAndNV) {
-      Assert.assertEquals(5, twoCombined.getDistinctValues());
-      Assert.assertEquals(5, twoCombined.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, twoCombined.getDistinctValues());
-      Assert.assertNull(twoCombined.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 5 : -1, oneCombined.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 5 : -1, oneCombined.getNumberOfValues());
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelDataTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelDataTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal;
 
 import java.math.BigInteger;
@@ -8,13 +12,22 @@ import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class ChannelDataTest {
+  @Parameterized.Parameters(name = "enableNDVAndNV: {0}")
+  public static Object[] enableNDVAndNV() {
+    return new Object[] {false, true};
+  }
+
+  @Parameterized.Parameter public boolean enableNDVAndNV;
 
   @Test
   public void testGetCombinedColumnStatsMapNulls() {
     Map<String, RowBufferStats> left = new HashMap<>();
-    RowBufferStats leftStats1 = new RowBufferStats("COL1");
+    RowBufferStats leftStats1 = new RowBufferStats("COL1", enableNDVAndNV, enableNDVAndNV);
     left.put("one", leftStats1);
     leftStats1.addIntValue(new BigInteger("10"));
 
@@ -43,12 +56,12 @@ public class ChannelDataTest {
   @Test
   public void testGetCombinedColumnStatsMapMissingColumn() {
     Map<String, RowBufferStats> left = new HashMap<>();
-    RowBufferStats leftStats1 = new RowBufferStats("COL1");
+    RowBufferStats leftStats1 = new RowBufferStats("COL1", enableNDVAndNV, enableNDVAndNV);
     left.put("one", leftStats1);
     leftStats1.addIntValue(new BigInteger("10"));
 
     Map<String, RowBufferStats> right = new HashMap<>();
-    RowBufferStats rightStats1 = new RowBufferStats("COL1");
+    RowBufferStats rightStats1 = new RowBufferStats("COL1", enableNDVAndNV, enableNDVAndNV);
     right.put("foo", rightStats1);
     rightStats1.addIntValue(new BigInteger("11"));
 
@@ -78,10 +91,10 @@ public class ChannelDataTest {
     Map<String, RowBufferStats> left = new HashMap<>();
     Map<String, RowBufferStats> right = new HashMap<>();
 
-    RowBufferStats leftStats1 = new RowBufferStats("COL1");
-    RowBufferStats rightStats1 = new RowBufferStats("COL1");
-    RowBufferStats leftStats2 = new RowBufferStats("COL1");
-    RowBufferStats rightStats2 = new RowBufferStats("COL1");
+    RowBufferStats leftStats1 = new RowBufferStats("COL1", enableNDVAndNV, enableNDVAndNV);
+    RowBufferStats rightStats1 = new RowBufferStats("COL1", enableNDVAndNV, enableNDVAndNV);
+    RowBufferStats leftStats2 = new RowBufferStats("COL1", enableNDVAndNV, enableNDVAndNV);
+    RowBufferStats rightStats2 = new RowBufferStats("COL1", enableNDVAndNV, enableNDVAndNV);
 
     left.put("one", leftStats1);
     left.put("two", leftStats2);
@@ -107,20 +120,34 @@ public class ChannelDataTest {
 
     Assert.assertEquals(new BigInteger("10"), oneCombined.getCurrentMinIntValue());
     Assert.assertEquals(new BigInteger("17"), oneCombined.getCurrentMaxIntValue());
-    Assert.assertEquals(-1, oneCombined.getDistinctValues());
     Assert.assertNull(oneCombined.getCurrentMinStrValue());
     Assert.assertNull(oneCombined.getCurrentMaxStrValue());
     Assert.assertNull(oneCombined.getCurrentMinRealValue());
     Assert.assertNull(oneCombined.getCurrentMaxRealValue());
 
+    if (enableNDVAndNV) {
+      Assert.assertEquals(5, oneCombined.getDistinctValues());
+      Assert.assertEquals(5, oneCombined.getNumberOfValues().longValue());
+    } else {
+      Assert.assertEquals(-1, oneCombined.getDistinctValues());
+      Assert.assertNull(oneCombined.getNumberOfValues());
+    }
+
     Assert.assertArrayEquals(
         "10".getBytes(StandardCharsets.UTF_8), twoCombined.getCurrentMinStrValue());
     Assert.assertArrayEquals(
         "17".getBytes(StandardCharsets.UTF_8), twoCombined.getCurrentMaxStrValue());
-    Assert.assertEquals(-1, twoCombined.getDistinctValues());
     Assert.assertNull(twoCombined.getCurrentMinIntValue());
     Assert.assertNull(twoCombined.getCurrentMaxIntValue());
     Assert.assertNull(twoCombined.getCurrentMinRealValue());
     Assert.assertNull(twoCombined.getCurrentMaxRealValue());
+
+    if (enableNDVAndNV) {
+      Assert.assertEquals(5, twoCombined.getDistinctValues());
+      Assert.assertEquals(5, twoCombined.getNumberOfValues().longValue());
+    } else {
+      Assert.assertEquals(-1, twoCombined.getDistinctValues());
+      Assert.assertNull(twoCombined.getNumberOfValues());
+    }
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FileColumnPropertiesTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FileColumnPropertiesTest.java
@@ -32,8 +32,10 @@ public class FileColumnPropertiesTest {
                 Types.optional(PrimitiveType.PrimitiveTypeName.BINARY)
                     .as(LogicalTypeAnnotation.stringType())
                     .id(1)
-                    .named("test"))
-            : new RowBufferStats("COL", null, 1, null, null);
+                    .named("test"),
+                isIceberg,
+                isIceberg)
+            : new RowBufferStats("COL", null, 1, null, null, false, false);
     stats.addStrValue("bcd");
     stats.addStrValue("abcde");
     FileColumnProperties props = new FileColumnProperties(stats, !isIceberg);
@@ -55,8 +57,10 @@ public class FileColumnPropertiesTest {
                 Types.optional(PrimitiveType.PrimitiveTypeName.BINARY)
                     .as(LogicalTypeAnnotation.stringType())
                     .id(1)
-                    .named("test"))
-            : new RowBufferStats("COL", null, 1, null, null);
+                    .named("test"),
+                isIceberg,
+                isIceberg)
+            : new RowBufferStats("COL", null, 1, null, null, false, false);
     stats.addStrValue("aßßßßßßßßßßßßßßßß");
     Assert.assertEquals(33, stats.getCurrentMinStrValue().length);
     props = new FileColumnProperties(stats, !isIceberg);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -884,10 +884,16 @@ public class FlushServiceTest {
 
     RowBufferStats stats1 =
         new RowBufferStats(
-            "COL1", Types.optional(PrimitiveType.PrimitiveTypeName.INT32).id(1).named("COL1"));
+            "COL1",
+            Types.optional(PrimitiveType.PrimitiveTypeName.INT32).id(1).named("COL1"),
+            isIcebergMode,
+            isIcebergMode);
     RowBufferStats stats2 =
         new RowBufferStats(
-            "COL1", Types.optional(PrimitiveType.PrimitiveTypeName.INT32).id(1).named("COL1"));
+            "COL1",
+            Types.optional(PrimitiveType.PrimitiveTypeName.INT32).id(1).named("COL1"),
+            isIcebergMode,
+            isIcebergMode);
 
     eps1.put("one", stats1);
     eps2.put("one", stats2);
@@ -919,7 +925,7 @@ public class FlushServiceTest {
 
     EpInfo expectedChunkEpInfo =
         AbstractRowBuffer.buildEpInfoFromStats(
-            3, ChannelData.getCombinedColumnStatsMap(eps1, eps2), !isIcebergMode);
+            3, ChannelData.getCombinedColumnStatsMap(eps1, eps2), !isIcebergMode, isIcebergMode);
 
     ChannelMetadata expectedChannel1Metadata =
         ChannelMetadata.builder()
@@ -1049,8 +1055,11 @@ public class FlushServiceTest {
         Mockito.mock(SnowflakeStreamingIngestClientInternal.class);
     ParameterProvider parameterProvider = new ParameterProvider(isIcebergMode);
     ChannelCache<StubChunkData> channelCache = new ChannelCache<>();
+    InternalParameterProvider internalParameterProvider =
+        new InternalParameterProvider(isIcebergMode);
     Mockito.when(client.getChannelCache()).thenReturn(channelCache);
     Mockito.when(client.getParameterProvider()).thenReturn(parameterProvider);
+    Mockito.when(client.getInternalParameterProvider()).thenReturn(internalParameterProvider);
     SnowflakeStreamingIngestChannelInternal<StubChunkData> channel1 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel1",
@@ -1134,13 +1143,16 @@ public class FlushServiceTest {
 
     RowBufferStats stats1 =
         new RowBufferStats(
-            "COL1", Types.optional(PrimitiveType.PrimitiveTypeName.INT32).id(1).named("COL1"));
+            "COL1",
+            Types.optional(PrimitiveType.PrimitiveTypeName.INT32).id(1).named("COL1"),
+            isIcebergMode,
+            isIcebergMode);
 
     eps1.put("one", stats1);
 
     stats1.addIntValue(new BigInteger("10"));
     stats1.addIntValue(new BigInteger("15"));
-    EpInfo epInfo = AbstractRowBuffer.buildEpInfoFromStats(2, eps1, !isIcebergMode);
+    EpInfo epInfo = AbstractRowBuffer.buildEpInfoFromStats(2, eps1, !isIcebergMode, isIcebergMode);
 
     ChannelMetadata channelMetadata =
         ChannelMetadata.builder()

--- a/src/test/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParserTest.java
@@ -21,32 +21,46 @@ import java.util.List;
 import java.util.Map;
 import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.SFException;
+import net.snowflake.ingest.utils.SubColumnFinder;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Type.Repetition;
 import org.apache.parquet.schema.Types;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class IcebergParquetValueParserTest {
 
-  static ObjectMapper objectMapper = new ObjectMapper();
+  static ObjectMapper objectMapper;
+  static SubColumnFinder mockSubColumnFinder;
+
+  @Before
+  public void setUp() {
+    objectMapper = new ObjectMapper();
+    mockSubColumnFinder = Mockito.mock(SubColumnFinder.class);
+    Mockito.when(mockSubColumnFinder.getSubColumns(Mockito.anyString()))
+        .thenReturn(Collections.emptyList());
+  }
 
   @Test
   public void parseValueBoolean() {
     Type type =
         Types.primitive(PrimitiveTypeName.BOOLEAN, Repetition.OPTIONAL).named("BOOLEAN_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("BOOLEAN_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("BOOLEAN_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
             put("BOOLEAN_COL", rowBufferStats);
           }
         };
+
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(true, type, rowBufferStatsMap, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(
+            true, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -61,7 +75,7 @@ public class IcebergParquetValueParserTest {
   public void parseValueInt() {
     Type type = Types.primitive(PrimitiveTypeName.INT32, Repetition.OPTIONAL).named("INT_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("INT_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("INT_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -70,7 +84,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            Integer.MAX_VALUE, type, rowBufferStatsMap, UTC, 0);
+            Integer.MAX_VALUE, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -88,7 +102,7 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.decimalType(4, 9))
             .named("DECIMAL_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("DECIMAL_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("DECIMAL_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -97,7 +111,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            new BigDecimal("12345.6789"), type, rowBufferStatsMap, UTC, 0);
+            new BigDecimal("12345.6789"), type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -115,7 +129,7 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.dateType())
             .named("DATE_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("DATE_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("DATE_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -124,7 +138,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            "2024-01-01", type, rowBufferStatsMap, UTC, 0);
+            "2024-01-01", type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -139,7 +153,7 @@ public class IcebergParquetValueParserTest {
   public void parseValueLong() {
     Type type = Types.primitive(PrimitiveTypeName.INT64, Repetition.OPTIONAL).named("LONG_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("LONG_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("LONG_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -148,7 +162,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            Long.MAX_VALUE, type, rowBufferStatsMap, UTC, 0);
+            Long.MAX_VALUE, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -166,7 +180,7 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.decimalType(9, 18))
             .named("DECIMAL_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("DECIMAL_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("DECIMAL_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -175,7 +189,12 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            new BigDecimal("123456789.123456789"), type, rowBufferStatsMap, UTC, 0);
+            new BigDecimal("123456789.123456789"),
+            type,
+            rowBufferStatsMap,
+            mockSubColumnFinder,
+            UTC,
+            0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -193,7 +212,7 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.timeType(false, LogicalTypeAnnotation.TimeUnit.MICROS))
             .named("TIME_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("TIME_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("TIME_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -202,7 +221,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            "12:34:56.789", type, rowBufferStatsMap, UTC, 0);
+            "12:34:56.789", type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -220,7 +239,7 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.MICROS))
             .named("TIMESTAMP_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("TIMESTAMP_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("TIMESTAMP_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -229,7 +248,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            "2024-01-01T12:34:56.789+08:00", type, rowBufferStatsMap, UTC, 0);
+            "2024-01-01T12:34:56.789+08:00", type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -247,7 +266,7 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
             .named("TIMESTAMP_TZ_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("TIMESTAMP_TZ_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("TIMESTAMP_TZ_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -256,7 +275,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            "2024-01-01T12:34:56.789+08:00", type, rowBufferStatsMap, UTC, 0);
+            "2024-01-01T12:34:56.789+08:00", type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -271,7 +290,7 @@ public class IcebergParquetValueParserTest {
   public void parseValueFloat() {
     Type type = Types.primitive(PrimitiveTypeName.FLOAT, Repetition.OPTIONAL).named("FLOAT_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("FLOAT_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("FLOAT_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -280,7 +299,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            Float.MAX_VALUE, type, rowBufferStatsMap, UTC, 0);
+            Float.MAX_VALUE, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -295,7 +314,7 @@ public class IcebergParquetValueParserTest {
   public void parseValueDouble() {
     Type type = Types.primitive(PrimitiveTypeName.DOUBLE, Repetition.OPTIONAL).named("DOUBLE_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("DOUBLE_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("DOUBLE_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -304,7 +323,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            Double.MAX_VALUE, type, rowBufferStatsMap, UTC, 0);
+            Double.MAX_VALUE, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -319,7 +338,7 @@ public class IcebergParquetValueParserTest {
   public void parseValueBinary() {
     Type type = Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL).named("BINARY_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("BINARY_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("BINARY_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -328,7 +347,8 @@ public class IcebergParquetValueParserTest {
         };
     byte[] value = "snowflake_to_the_moon".getBytes();
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(value, type, rowBufferStatsMap, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(
+            value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -347,7 +367,7 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.stringType())
             .named("BINARY_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("BINARY_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("BINARY_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -356,7 +376,8 @@ public class IcebergParquetValueParserTest {
         };
     String value = "snowflake_to_the_moon";
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(value, type, rowBufferStatsMap, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(
+            value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -377,7 +398,7 @@ public class IcebergParquetValueParserTest {
             .length(4)
             .named("FIXED_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("FIXED_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("FIXED_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -386,7 +407,8 @@ public class IcebergParquetValueParserTest {
         };
     byte[] value = "snow".getBytes();
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(value, type, rowBufferStatsMap, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(
+            value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -406,7 +428,7 @@ public class IcebergParquetValueParserTest {
             .as(LogicalTypeAnnotation.decimalType(10, 20))
             .named("FIXED_COL");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("FIXED_COL");
+    RowBufferStats rowBufferStats = new RowBufferStats("FIXED_COL", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -415,7 +437,8 @@ public class IcebergParquetValueParserTest {
         };
     BigDecimal value = new BigDecimal("1234567890.0123456789");
     ParquetBufferValue pv =
-        IcebergParquetValueParser.parseColumnValueToParquet(value, type, rowBufferStatsMap, UTC, 0);
+        IcebergParquetValueParser.parseColumnValueToParquet(
+            value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -433,7 +456,7 @@ public class IcebergParquetValueParserTest {
         Types.optionalList()
             .element(Types.optional(PrimitiveTypeName.INT32).named("element"))
             .named("LIST_COL");
-    RowBufferStats rowBufferStats = new RowBufferStats("LIST_COL.list.element");
+    RowBufferStats rowBufferStats = new RowBufferStats("LIST_COL.list.element", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -441,10 +464,11 @@ public class IcebergParquetValueParserTest {
           }
         };
 
-    IcebergParquetValueParser.parseColumnValueToParquet(null, list, rowBufferStatsMap, UTC, 0);
+    IcebergParquetValueParser.parseColumnValueToParquet(
+        null, list, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            Arrays.asList(1, 2, 3, 4, 5), list, rowBufferStatsMap, UTC, 0);
+            Arrays.asList(1, 2, 3, 4, 5), list, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .rowBufferStats(rowBufferStats)
         .parquetBufferValue(pv)
@@ -467,10 +491,10 @@ public class IcebergParquetValueParserTest {
         SFException.class,
         () ->
             IcebergParquetValueParser.parseColumnValueToParquet(
-                null, requiredList, rowBufferStatsMap, UTC, 0));
+                null, requiredList, rowBufferStatsMap, mockSubColumnFinder, UTC, 0));
     pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            new ArrayList<>(), requiredList, rowBufferStatsMap, UTC, 0);
+            new ArrayList<>(), requiredList, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .rowBufferStats(rowBufferStats)
         .parquetBufferValue(pv)
@@ -490,7 +514,12 @@ public class IcebergParquetValueParserTest {
         SFException.class,
         () ->
             IcebergParquetValueParser.parseColumnValueToParquet(
-                Collections.singletonList(null), requiredElements, rowBufferStatsMap, UTC, 0));
+                Collections.singletonList(null),
+                requiredElements,
+                rowBufferStatsMap,
+                mockSubColumnFinder,
+                UTC,
+                0));
   }
 
   @Test
@@ -500,8 +529,8 @@ public class IcebergParquetValueParserTest {
             .key(Types.required(PrimitiveTypeName.INT32).named("key"))
             .value(Types.optional(PrimitiveTypeName.INT32).named("value"))
             .named("MAP_COL");
-    RowBufferStats rowBufferKeyStats = new RowBufferStats("MAP_COL.key_value.key");
-    RowBufferStats rowBufferValueStats = new RowBufferStats("MAP_COL.key_value.value");
+    RowBufferStats rowBufferKeyStats = new RowBufferStats("MAP_COL.key_value.key", true, true);
+    RowBufferStats rowBufferValueStats = new RowBufferStats("MAP_COL.key_value.value", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -509,7 +538,8 @@ public class IcebergParquetValueParserTest {
             put("MAP_COL.key_value.value", rowBufferValueStats);
           }
         };
-    IcebergParquetValueParser.parseColumnValueToParquet(null, map, rowBufferStatsMap, UTC, 0);
+    IcebergParquetValueParser.parseColumnValueToParquet(
+        null, map, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
             new java.util.HashMap<Integer, Integer>() {
@@ -520,6 +550,7 @@ public class IcebergParquetValueParserTest {
             },
             map,
             rowBufferStatsMap,
+            mockSubColumnFinder,
             UTC,
             0);
     ParquetValueParserAssertionBuilder.newBuilder()
@@ -546,10 +577,15 @@ public class IcebergParquetValueParserTest {
         SFException.class,
         () ->
             IcebergParquetValueParser.parseColumnValueToParquet(
-                null, requiredMap, rowBufferStatsMap, UTC, 0));
+                null, requiredMap, rowBufferStatsMap, mockSubColumnFinder, UTC, 0));
     pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            new java.util.HashMap<Integer, Integer>(), requiredMap, rowBufferStatsMap, UTC, 0);
+            new java.util.HashMap<Integer, Integer>(),
+            requiredMap,
+            rowBufferStatsMap,
+            mockSubColumnFinder,
+            UTC,
+            0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .rowBufferStats(rowBufferKeyStats)
         .parquetBufferValue(pv)
@@ -577,6 +613,7 @@ public class IcebergParquetValueParserTest {
                 },
                 requiredValues,
                 rowBufferStatsMap,
+                mockSubColumnFinder,
                 UTC,
                 0));
   }
@@ -592,8 +629,8 @@ public class IcebergParquetValueParserTest {
                     .named("b"))
             .named("STRUCT_COL");
 
-    RowBufferStats rowBufferAStats = new RowBufferStats("STRUCT_COL.a");
-    RowBufferStats rowBufferBStats = new RowBufferStats("STRUCT_COL.b");
+    RowBufferStats rowBufferAStats = new RowBufferStats("STRUCT_COL.a", true, true);
+    RowBufferStats rowBufferBStats = new RowBufferStats("STRUCT_COL.b", true, true);
     Map<String, RowBufferStats> rowBufferStatsMap =
         new HashMap<String, RowBufferStats>() {
           {
@@ -602,7 +639,8 @@ public class IcebergParquetValueParserTest {
           }
         };
 
-    IcebergParquetValueParser.parseColumnValueToParquet(null, struct, rowBufferStatsMap, UTC, 0);
+    IcebergParquetValueParser.parseColumnValueToParquet(
+        null, struct, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
     Assert.assertThrows(
         SFException.class,
         () ->
@@ -614,6 +652,7 @@ public class IcebergParquetValueParserTest {
                 },
                 struct,
                 rowBufferStatsMap,
+                mockSubColumnFinder,
                 UTC,
                 0));
     Assert.assertThrows(
@@ -627,6 +666,7 @@ public class IcebergParquetValueParserTest {
                 },
                 struct,
                 rowBufferStatsMap,
+                mockSubColumnFinder,
                 UTC,
                 0));
     ParquetBufferValue pv =
@@ -640,6 +680,7 @@ public class IcebergParquetValueParserTest {
                 }),
             struct,
             rowBufferStatsMap,
+            mockSubColumnFinder,
             UTC,
             0);
     ParquetValueParserAssertionBuilder.newBuilder()
@@ -664,10 +705,15 @@ public class IcebergParquetValueParserTest {
         SFException.class,
         () ->
             IcebergParquetValueParser.parseColumnValueToParquet(
-                null, requiredStruct, rowBufferStatsMap, UTC, 0));
+                null, requiredStruct, rowBufferStatsMap, mockSubColumnFinder, UTC, 0));
     pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            new java.util.HashMap<String, Object>(), requiredStruct, rowBufferStatsMap, UTC, 0);
+            new java.util.HashMap<String, Object>(),
+            requiredStruct,
+            rowBufferStatsMap,
+            mockSubColumnFinder,
+            UTC,
+            0);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .expectedValueClass(ArrayList.class)
@@ -688,7 +734,7 @@ public class IcebergParquetValueParserTest {
       List<?> reference = (List<?>) res.getSecond();
       ParquetBufferValue pv =
           IcebergParquetValueParser.parseColumnValueToParquet(
-              value, type, rowBufferStatsMap, UTC, 0);
+              value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
       ParquetValueParserAssertionBuilder.newBuilder()
           .parquetBufferValue(pv)
           .expectedValueClass(ArrayList.class)
@@ -703,7 +749,7 @@ public class IcebergParquetValueParserTest {
   private static Type generateNestedTypeAndStats(
       int depth, String name, Map<String, RowBufferStats> rowBufferStatsMap, String path) {
     if (depth == 0) {
-      rowBufferStatsMap.put(path, new RowBufferStats(path));
+      rowBufferStatsMap.put(path, new RowBufferStats(path, true, true));
       return Types.optional(PrimitiveTypeName.INT32).named(name);
     }
     switch (depth % 3) {
@@ -718,7 +764,8 @@ public class IcebergParquetValueParserTest {
             .addField(generateNestedTypeAndStats(depth - 1, "a", rowBufferStatsMap, path + ".a"))
             .named(name);
       case 0:
-        rowBufferStatsMap.put(path + ".key_value.key", new RowBufferStats(path + ".key_value.key"));
+        rowBufferStatsMap.put(
+            path + ".key_value.key", new RowBufferStats(path + ".key_value.key", true, true));
         return Types.optionalMap()
             .key(Types.required(PrimitiveTypeName.INT32).named("key"))
             .value(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
@@ -32,14 +32,8 @@ public class RowBufferStatsTest {
     Assert.assertNull(stats.getCurrentMinIntValue());
     Assert.assertNull(stats.getCurrentMaxIntValue());
     Assert.assertEquals(0, stats.getCurrentNullCount());
-
-    if (enableNDVAndNV) {
-      Assert.assertEquals(0, stats.getDistinctValues());
-      Assert.assertEquals(0, stats.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, stats.getDistinctValues());
-      Assert.assertNull(stats.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 0 : -1, stats.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 0 : -1, stats.getNumberOfValues());
   }
 
   @Test
@@ -49,25 +43,15 @@ public class RowBufferStatsTest {
     stats.addStrValue("bob");
     Assert.assertArrayEquals("bob".getBytes(StandardCharsets.UTF_8), stats.getCurrentMinStrValue());
     Assert.assertArrayEquals("bob".getBytes(StandardCharsets.UTF_8), stats.getCurrentMaxStrValue());
-    if (enableNDVAndNV) {
-      Assert.assertEquals(1, stats.getDistinctValues());
-      Assert.assertEquals(1, stats.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, stats.getDistinctValues());
-      Assert.assertNull(stats.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 1 : -1, stats.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 1 : -1, stats.getNumberOfValues());
 
     stats.addStrValue("charlie");
     Assert.assertArrayEquals("bob".getBytes(StandardCharsets.UTF_8), stats.getCurrentMinStrValue());
     Assert.assertArrayEquals(
         "charlie".getBytes(StandardCharsets.UTF_8), stats.getCurrentMaxStrValue());
-    if (enableNDVAndNV) {
-      Assert.assertEquals(2, stats.getDistinctValues());
-      Assert.assertEquals(2, stats.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, stats.getDistinctValues());
-      Assert.assertNull(stats.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 2 : -1, stats.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 2 : -1, stats.getNumberOfValues());
 
     stats.addStrValue("alice");
     Assert.assertArrayEquals(
@@ -75,13 +59,8 @@ public class RowBufferStatsTest {
     Assert.assertArrayEquals(
         "charlie".getBytes(StandardCharsets.UTF_8), stats.getCurrentMaxStrValue());
 
-    if (enableNDVAndNV) {
-      Assert.assertEquals(3, stats.getDistinctValues());
-      Assert.assertEquals(3, stats.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, stats.getDistinctValues());
-      Assert.assertNull(stats.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 3 : -1, stats.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 3 : -1, stats.getNumberOfValues());
 
     Assert.assertNull(stats.getCurrentMinRealValue());
     Assert.assertNull(stats.getCurrentMaxRealValue());
@@ -99,37 +78,22 @@ public class RowBufferStatsTest {
     Assert.assertEquals(BigInteger.valueOf((5)), stats.getCurrentMinIntValue());
     Assert.assertEquals(BigInteger.valueOf((5)), stats.getCurrentMaxIntValue());
 
-    if (enableNDVAndNV) {
-      Assert.assertEquals(1, stats.getDistinctValues());
-      Assert.assertEquals(1, stats.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, stats.getDistinctValues());
-      Assert.assertNull(stats.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 1 : -1, stats.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 1 : -1, stats.getNumberOfValues());
 
     stats.addIntValue(BigInteger.valueOf(6));
     Assert.assertEquals(BigInteger.valueOf((5)), stats.getCurrentMinIntValue());
     Assert.assertEquals(BigInteger.valueOf((6)), stats.getCurrentMaxIntValue());
 
-    if (enableNDVAndNV) {
-      Assert.assertEquals(2, stats.getDistinctValues());
-      Assert.assertEquals(2, stats.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, stats.getDistinctValues());
-      Assert.assertNull(stats.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 2 : -1, stats.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 2 : -1, stats.getNumberOfValues());
 
     stats.addIntValue(BigInteger.valueOf(4));
     Assert.assertEquals(BigInteger.valueOf((4)), stats.getCurrentMinIntValue());
     Assert.assertEquals(BigInteger.valueOf((6)), stats.getCurrentMaxIntValue());
 
-    if (enableNDVAndNV) {
-      Assert.assertEquals(3, stats.getDistinctValues());
-      Assert.assertEquals(3, stats.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, stats.getDistinctValues());
-      Assert.assertNull(stats.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 3 : -1, stats.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 3 : -1, stats.getNumberOfValues());
 
     Assert.assertNull(stats.getCurrentMinRealValue());
     Assert.assertNull(stats.getCurrentMaxRealValue());
@@ -147,37 +111,22 @@ public class RowBufferStatsTest {
     Assert.assertEquals(Double.valueOf(1), stats.getCurrentMinRealValue());
     Assert.assertEquals(Double.valueOf(1), stats.getCurrentMaxRealValue());
 
-    if (enableNDVAndNV) {
-      Assert.assertEquals(1, stats.getDistinctValues());
-      Assert.assertEquals(1, stats.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, stats.getDistinctValues());
-      Assert.assertNull(stats.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 1 : -1, stats.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 1 : -1, stats.getNumberOfValues());
 
     stats.addRealValue(1.5);
     Assert.assertEquals(Double.valueOf(1), stats.getCurrentMinRealValue());
     Assert.assertEquals(Double.valueOf(1.5), stats.getCurrentMaxRealValue());
 
-    if (enableNDVAndNV) {
-      Assert.assertEquals(2, stats.getDistinctValues());
-      Assert.assertEquals(2, stats.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, stats.getDistinctValues());
-      Assert.assertNull(stats.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 2 : -1, stats.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 2 : -1, stats.getNumberOfValues());
 
     stats.addRealValue(.8);
     Assert.assertEquals(Double.valueOf(.8), stats.getCurrentMinRealValue());
     Assert.assertEquals(Double.valueOf(1.5), stats.getCurrentMaxRealValue());
 
-    if (enableNDVAndNV) {
-      Assert.assertEquals(3, stats.getDistinctValues());
-      Assert.assertEquals(3, stats.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, stats.getDistinctValues());
-      Assert.assertNull(stats.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 3 : -1, stats.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 3 : -1, stats.getNumberOfValues());
 
     Assert.assertNull(stats.getCurrentMinIntValue());
     Assert.assertNull(stats.getCurrentMaxIntValue());
@@ -230,14 +179,8 @@ public class RowBufferStatsTest {
     RowBufferStats result = RowBufferStats.getCombinedStats(one, two);
     Assert.assertEquals(BigInteger.valueOf(1), result.getCurrentMinIntValue());
     Assert.assertEquals(BigInteger.valueOf(8), result.getCurrentMaxIntValue());
-
-    if (enableNDVAndNV) {
-      Assert.assertEquals(7, result.getDistinctValues());
-      Assert.assertEquals(8, result.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, result.getDistinctValues());
-      Assert.assertNull(result.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 7 : -1, result.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 8 : -1, result.getNumberOfValues());
 
     Assert.assertEquals(2, result.getCurrentNullCount());
     Assert.assertNull(result.getCurrentMinStrValue());
@@ -262,14 +205,8 @@ public class RowBufferStatsTest {
     result = RowBufferStats.getCombinedStats(one, two);
     Assert.assertEquals(Double.valueOf(1), result.getCurrentMinRealValue());
     Assert.assertEquals(Double.valueOf(8), result.getCurrentMaxRealValue());
-
-    if (enableNDVAndNV) {
-      Assert.assertEquals(7, result.getDistinctValues());
-      Assert.assertEquals(8, result.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, result.getDistinctValues());
-      Assert.assertNull(result.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 7 : -1, result.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 8 : -1, result.getNumberOfValues());
 
     Assert.assertEquals(0, result.getCurrentNullCount());
     Assert.assertNull(result.getCollationDefinitionString());
@@ -301,14 +238,8 @@ public class RowBufferStatsTest {
     Assert.assertArrayEquals("g".getBytes(StandardCharsets.UTF_8), result.getCurrentMaxStrValue());
     Assert.assertEquals(2, result.getCurrentNullCount());
     Assert.assertEquals(5, result.getCurrentMaxLength());
-
-    if (enableNDVAndNV) {
-      Assert.assertEquals(7, result.getDistinctValues());
-      Assert.assertEquals(8, result.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, result.getDistinctValues());
-      Assert.assertNull(result.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 7 : -1, result.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 8 : -1, result.getNumberOfValues());
 
     Assert.assertNull(result.getCurrentMinRealValue());
     Assert.assertNull(result.getCurrentMaxRealValue());
@@ -332,14 +263,8 @@ public class RowBufferStatsTest {
     RowBufferStats result = RowBufferStats.getCombinedStats(one, two);
     Assert.assertEquals(BigInteger.valueOf(2), result.getCurrentMinIntValue());
     Assert.assertEquals(BigInteger.valueOf(8), result.getCurrentMaxIntValue());
-
-    if (enableNDVAndNV) {
-      Assert.assertEquals(4, result.getDistinctValues());
-      Assert.assertEquals(4, result.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, result.getDistinctValues());
-      Assert.assertNull(result.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 4 : -1, result.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 4 : -1, result.getNumberOfValues());
 
     Assert.assertEquals(2, result.getCurrentNullCount());
 
@@ -359,13 +284,8 @@ public class RowBufferStatsTest {
     result = RowBufferStats.getCombinedStats(one, two);
     Assert.assertEquals(Double.valueOf(2), result.getCurrentMinRealValue());
     Assert.assertEquals(Double.valueOf(8), result.getCurrentMaxRealValue());
-    if (enableNDVAndNV) {
-      Assert.assertEquals(4, result.getDistinctValues());
-      Assert.assertEquals(4, result.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, result.getDistinctValues());
-      Assert.assertNull(result.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 4 : -1, result.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 4 : -1, result.getNumberOfValues());
     Assert.assertEquals(0, result.getCurrentNullCount());
 
     Assert.assertNull(result.getCurrentMinStrValue());
@@ -388,13 +308,8 @@ public class RowBufferStatsTest {
         "alpha".getBytes(StandardCharsets.UTF_8), result.getCurrentMinStrValue());
     Assert.assertArrayEquals("g".getBytes(StandardCharsets.UTF_8), result.getCurrentMaxStrValue());
 
-    if (enableNDVAndNV) {
-      Assert.assertEquals(4, result.getDistinctValues());
-      Assert.assertEquals(4, result.getNumberOfValues().longValue());
-    } else {
-      Assert.assertEquals(-1, result.getDistinctValues());
-      Assert.assertNull(result.getNumberOfValues());
-    }
+    Assert.assertEquals(enableNDVAndNV ? 4 : -1, result.getDistinctValues());
+    Assert.assertEquals(enableNDVAndNV ? 4 : -1, result.getNumberOfValues());
     Assert.assertEquals(1, result.getCurrentNullCount());
 
     Assert.assertNull(result.getCurrentMinRealValue());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -46,7 +46,7 @@ import org.junit.runners.Parameterized;
 public class RowBufferTest {
   @Parameterized.Parameters(name = "isIcebergMode: {0}")
   public static Object[] isIcebergMode() {
-    return new Object[] {true};
+    return new Object[] {false, true};
   }
 
   @Parameterized.Parameter public static boolean isIcebergMode;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeParquetValueParserTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal;
 
 import static java.time.ZoneOffset.UTC;
@@ -29,7 +33,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             12,
@@ -61,7 +65,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             1234,
@@ -93,7 +97,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             123456789,
@@ -125,7 +129,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             123456789987654321L,
@@ -157,7 +161,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             new BigDecimal("91234567899876543219876543211234567891"),
@@ -191,7 +195,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             new BigDecimal("12345.54321"),
@@ -221,7 +225,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             12345.54321d,
@@ -251,7 +255,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             true,
@@ -281,7 +285,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             "1234abcd".getBytes(),
@@ -326,7 +330,7 @@ public class SnowflakeParquetValueParserTest {
     String var =
         "{\"key1\":-879869596,\"key2\":\"value2\",\"key3\":null,"
             + "\"key4\":{\"key41\":0.032437,\"key42\":\"value42\",\"key43\":null}}";
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             var,
@@ -376,7 +380,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             var,
@@ -417,7 +421,7 @@ public class SnowflakeParquetValueParserTest {
     input.put("b", "2");
     input.put("c", "3");
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             input,
@@ -455,7 +459,7 @@ public class SnowflakeParquetValueParserTest {
 
     String text = "This is a sample text! Length is bigger than 32 bytes :)";
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             text,
@@ -492,7 +496,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     SFException exception =
         Assert.assertThrows(
             SFException.class,
@@ -520,7 +524,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             "2013-04-28T20:57:01.000",
@@ -551,7 +555,7 @@ public class SnowflakeParquetValueParserTest {
             .scale(9) // nanos
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             "2022-09-18T22:05:07.123456789",
@@ -583,7 +587,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             "2021-01-01",
@@ -614,7 +618,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             "01:00:00",
@@ -645,7 +649,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     ParquetBufferValue pv =
         SnowflakeParquetValueParser.parseColumnValueToParquet(
             "01:00:00.123",
@@ -676,7 +680,7 @@ public class SnowflakeParquetValueParserTest {
             .nullable(true)
             .build();
 
-    RowBufferStats rowBufferStats = new RowBufferStats("COL1");
+    RowBufferStats rowBufferStats = new RowBufferStats("COL1", false, false);
     SFException exception =
         Assert.assertThrows(
             SFException.class,

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -506,8 +506,12 @@ public class SnowflakeStreamingIngestClientTest {
     columnEps.put(
         "column",
         new RowBufferStats(
-            "COL1", Types.optional(PrimitiveType.PrimitiveTypeName.INT32).id(1).named("COL1")));
-    EpInfo epInfo = AbstractRowBuffer.buildEpInfoFromStats(1, columnEps, !isIcebergMode);
+            "COL1",
+            Types.optional(PrimitiveType.PrimitiveTypeName.INT32).id(1).named("COL1"),
+            isIcebergMode,
+            isIcebergMode));
+    EpInfo epInfo =
+        AbstractRowBuffer.buildEpInfoFromStats(1, columnEps, !isIcebergMode, isIcebergMode);
 
     ChunkMetadata chunkMetadata =
         ChunkMetadata.builder()
@@ -558,8 +562,12 @@ public class SnowflakeStreamingIngestClientTest {
     columnEps.put(
         "column",
         new RowBufferStats(
-            "COL1", Types.optional(PrimitiveType.PrimitiveTypeName.INT32).id(1).named("COL1")));
-    EpInfo epInfo = AbstractRowBuffer.buildEpInfoFromStats(1, columnEps, !isIcebergMode);
+            "COL1",
+            Types.optional(PrimitiveType.PrimitiveTypeName.INT32).id(1).named("COL1"),
+            isIcebergMode,
+            isIcebergMode));
+    EpInfo epInfo =
+        AbstractRowBuffer.buildEpInfoFromStats(1, columnEps, !isIcebergMode, isIcebergMode);
 
     ChannelMetadata channelMetadata1 =
         ChannelMetadata.builder()

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal.datatypes;
 
 import static net.snowflake.ingest.utils.Constants.ROLE;
@@ -96,20 +100,23 @@ public abstract class AbstractDataTypeTest {
     conn.createStatement().execute(String.format("use database %s;", databaseName));
     conn.createStatement().execute(String.format("use schema %s;", schemaName));
 
-    switch (serializationPolicy) {
-      case COMPATIBLE:
-        conn.createStatement()
-            .execute(
-                String.format(
-                    "alter schema %s set STORAGE_SERIALIZATION_POLICY = 'COMPATIBLE';",
-                    schemaName));
-        break;
-      case OPTIMIZED:
-        conn.createStatement()
-            .execute(
-                String.format(
-                    "alter schema %s set STORAGE_SERIALIZATION_POLICY = 'OPTIMIZED';", schemaName));
-        break;
+    if (isIceberg) {
+      switch (serializationPolicy) {
+        case COMPATIBLE:
+          conn.createStatement()
+              .execute(
+                  String.format(
+                      "alter schema %s set STORAGE_SERIALIZATION_POLICY = 'COMPATIBLE';",
+                      schemaName));
+          break;
+        case OPTIMIZED:
+          conn.createStatement()
+              .execute(
+                  String.format(
+                      "alter schema %s set STORAGE_SERIALIZATION_POLICY = 'OPTIMIZED';",
+                      schemaName));
+          break;
+      }
     }
 
     conn.createStatement().execute(String.format("use warehouse %s;", TestUtils.getWarehouse()));
@@ -163,7 +170,7 @@ public abstract class AbstractDataTypeTest {
   protected String createIcebergTable(String dataType) throws SQLException {
     String tableName = getRandomIdentifier();
     String baseLocation =
-        String.format("%s/%s/%s", databaseName, dataType.replace(" ", "_"), tableName);
+        String.format("SDK_IT/%s/%s/%s", databaseName, dataType.replace(" ", "_"), tableName);
     conn.createStatement()
         .execute(
             String.format(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergNumericTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergNumericTypesIT.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal.datatypes;
 
 import java.math.BigDecimal;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.streaming.internal.datatypes;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -77,14 +81,20 @@ public class IcebergStructuredIT extends AbstractDataTypeTest {
         .extracting(SFException::getVendorCode)
         .isEqualTo(ErrorCode.INVALID_FORMAT_ROW.getMessageCode());
 
-    /* Null struct, map list. TODO: SNOW-1727532 Should be fixed with null values EP calculation. */
+    /* Null struct, map list. */
     Assertions.assertThatThrownBy(
             () -> assertStructuredDataType("object(a int, b string, c boolean) not null", null))
-        .isInstanceOf(NullPointerException.class);
+        .isInstanceOf(SFException.class)
+        .extracting("vendorCode")
+        .isEqualTo(ErrorCode.INVALID_FORMAT_ROW.getMessageCode());
     Assertions.assertThatThrownBy(() -> assertStructuredDataType("map(string, int) not null", null))
-        .isInstanceOf(NullPointerException.class);
+        .isInstanceOf(SFException.class)
+        .extracting("vendorCode")
+        .isEqualTo(ErrorCode.INVALID_FORMAT_ROW.getMessageCode());
     Assertions.assertThatThrownBy(() -> assertStructuredDataType("array(int) not null", null))
-        .isInstanceOf(NullPointerException.class);
+        .isInstanceOf(SFException.class)
+        .extracting("vendorCode")
+        .isEqualTo(ErrorCode.INVALID_FORMAT_ROW.getMessageCode());
 
     /* Nested data types. Should be fixed. Fixed in server side. */
     Assertions.assertThatThrownBy(

--- a/src/test/java/net/snowflake/ingest/utils/SubColumnFinderTest.java
+++ b/src/test/java/net/snowflake/ingest/utils/SubColumnFinderTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.utils;
+
+import static net.snowflake.ingest.utils.Utils.concatDotPath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.junit.Test;
+
+public class SubColumnFinderTest {
+
+  @Test
+  public void testFlatSchema() {
+    MessageType schema =
+        MessageTypeParser.parseMessageType(
+            "message schema {\n"
+                + "  optional boolean BOOLEAN_COL = 1;\n"
+                + "  optional int32 INT_COL = 2;\n"
+                + "  optional int64 LONG_COL = 3;\n"
+                + "  optional float FLOAT_COL = 4;\n"
+                + "  optional double DOUBLE_COL = 5;\n"
+                + "  optional int64 DECIMAL_COL (DECIMAL(10,5)) = 6;\n"
+                + "  optional binary STRING_COL (STRING) = 7;\n"
+                + "  optional fixed_len_byte_array(10) FIXED_COL = 8;\n"
+                + "  optional binary BINARY_COL = 9;\n"
+                + "  optional int32 DATE_COL (DATE) = 10;\n"
+                + "  optional int64 TIME_COL (TIME(MICROS,false)) = 11;\n"
+                + "  optional int64 TIMESTAMP_NTZ_COL (TIMESTAMP(MICROS,false)) = 12;\n"
+                + "  optional int64 TIMESTAMP_LTZ_COL (TIMESTAMP(MICROS,true)) = 13;\n"
+                + "}\n");
+    assertFindSubColumns(schema);
+  }
+
+  @Test
+  public void testNestedSchema() {
+    MessageType schema =
+        MessageTypeParser.parseMessageType(
+            "message schema {\n"
+                + "  optional group LIST_COL (LIST) = 1 {\n"
+                + "    repeated group list {\n"
+                + "      optional group element = 4 {\n"
+                + "        optional group map_col (MAP) = 5 {\n"
+                + "          repeated group key_value {\n"
+                + "            required binary key (STRING) = 6;\n"
+                + "            optional group value (LIST) = 7 {\n"
+                + "              repeated group list {\n"
+                + "                optional group element = 8 {\n"
+                + "                  optional int32 int_col = 9;\n"
+                + "                  optional boolean boolean_col = 10;\n"
+                + "                  optional group map_col (MAP) = 11 {\n"
+                + "                    repeated group key_value {\n"
+                + "                      required int32 key = 12;\n"
+                + "                      optional int32 value = 13;\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                }\n"
+                + "              }\n"
+                + "            }\n"
+                + "          }\n"
+                + "        }\n"
+                + "        optional group obj_col = 14 {\n"
+                + "          optional group list_col (LIST) = 15 {\n"
+                + "            repeated group list {\n"
+                + "              optional int32 element = 16;\n"
+                + "            }\n"
+                + "          }\n"
+                + "          optional group map_col (MAP) = 17 {\n"
+                + "            repeated group key_value {\n"
+                + "              required binary key (STRING) = 18;\n"
+                + "              optional binary value (STRING) = 19;\n"
+                + "            }\n"
+                + "          }\n"
+                + "        }\n"
+                + "        optional int32 int_col = 20;\n"
+                + "        optional float float_col = 21;\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "  optional group OBJ_COL = 2 {\n"
+                + "    optional group obj_col = 22 {\n"
+                + "      optional group map_col (MAP) = 23 {\n"
+                + "        repeated group key_value {\n"
+                + "          required int32 key = 24;\n"
+                + "          optional int32 value = 25;\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "  optional double DOUBLE_COL = 3;\n"
+                + "}");
+    assertFindSubColumns(schema);
+  }
+
+  private void assertFindSubColumns(MessageType schema) {
+    SubColumnFinder subColumnFinder = new SubColumnFinder(schema);
+    for (String dotPath : getAllPossibleDotPath(schema)) {
+      assertThat(subColumnFinder.getSubColumns(dotPath))
+          .usingRecursiveComparison()
+          .ignoringCollectionOrder()
+          .isEqualTo(findSubColumn(schema, dotPath));
+    }
+  }
+
+  private Iterable<String> getAllPossibleDotPath(MessageType schema) {
+    Set<String> dotPaths = new HashSet<>();
+    for (ColumnDescriptor column : schema.getColumns()) {
+      String[] path = column.getPath();
+      if (path.length == 0) {
+        continue;
+      }
+      String dotPath = path[0];
+      dotPaths.add(dotPath);
+      for (int i = 1; i < path.length; i++) {
+        dotPath = concatDotPath(dotPath, path[i]);
+        dotPaths.add(dotPath);
+      }
+    }
+    return dotPaths;
+  }
+
+  private List<String> findSubColumn(MessageType schema, String dotPath) {
+    return schema.getColumns().stream()
+        .map(ColumnDescriptor::getPath)
+        .map(Utils::concatDotPath)
+        .filter(
+            s ->
+                s.startsWith(dotPath)
+                    && (s.length() == dotPath.length() || s.charAt(dotPath.length()) == '.'))
+        .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
This PR includes following change:
1. Set `numberOfValues` for repeated fields (e.g. map, list) and used it in EP file registration.
2. Increment null count for all sub-columns of a null column.
4. Use hash for approximate NDV for string and bytes.
5. Fix NPE when inserting null to a structured column, throwing SF custom exception instead.
6. Added `extendedMetadataSize` and `metadataSize` fields for EP registration.
7. Address comments of #851 