### PR TITLE
(Stacked PR) Code review changes for Parquet V2

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -25,6 +25,7 @@ import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Logging;
 import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.SFException;
+import org.apache.parquet.column.ParquetProperties;
 
 /**
  * The abstract implementation of the buffer in the Streaming Ingest channel that holds the
@@ -668,6 +669,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       ChannelRuntimeState channelRuntimeState,
       ClientBufferParameters clientBufferParameters,
       OffsetTokenVerificationFunction offsetTokenVerificationFunction,
+      ParquetProperties.WriterVersion parquetWriterVersion,
       TelemetryService telemetryService) {
     switch (bdecVersion) {
       case THREE:
@@ -681,6 +683,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
                 channelRuntimeState,
                 clientBufferParameters,
                 offsetTokenVerificationFunction,
+                parquetWriterVersion,
                 telemetryService);
       default:
         throw new SFException(

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelFlushContext.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelFlushContext.java
@@ -5,7 +5,6 @@
 package net.snowflake.ingest.streaming.internal;
 
 import net.snowflake.ingest.utils.Utils;
-import org.apache.parquet.column.ParquetProperties;
 
 /**
  * Channel immutable identification and encryption attributes.
@@ -30,8 +29,6 @@ class ChannelFlushContext {
   // Data encryption key id
   private final Long encryptionKeyId;
 
-  private final ParquetProperties.WriterVersion parquetWriterVersion;
-
   ChannelFlushContext(
       String name,
       String dbName,
@@ -39,8 +36,7 @@ class ChannelFlushContext {
       String tableName,
       Long channelSequencer,
       String encryptionKey,
-      Long encryptionKeyId,
-      ParquetProperties.WriterVersion parquetWriterVersion) {
+      Long encryptionKeyId) {
     this.name = name;
     this.fullyQualifiedName =
         Utils.getFullyQualifiedChannelName(dbName, schemaName, tableName, name);
@@ -51,7 +47,6 @@ class ChannelFlushContext {
     this.channelSequencer = channelSequencer;
     this.encryptionKey = encryptionKey;
     this.encryptionKeyId = encryptionKeyId;
-    this.parquetWriterVersion = parquetWriterVersion;
   }
 
   @Override
@@ -119,9 +114,5 @@ class ChannelFlushContext {
 
   Long getEncryptionKeyId() {
     return encryptionKeyId;
-  }
-
-  ParquetProperties.WriterVersion getParquetWriterVersion() {
-    return parquetWriterVersion;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/OpenChannelResponse.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/OpenChannelResponse.java
@@ -6,7 +6,6 @@ package net.snowflake.ingest.streaming.internal;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import net.snowflake.ingest.utils.Constants;
 
 /** Response to the OpenChannelRequest */
 class OpenChannelResponse extends StreamingIngestResponse {
@@ -148,7 +147,7 @@ class OpenChannelResponse extends StreamingIngestResponse {
     this.icebergSerializationPolicy = icebergSerializationPolicy;
   }
 
-  Constants.IcebergSerializationPolicy getIcebergSerializationPolicy() {
-    return Constants.IcebergSerializationPolicy.fromName(this.icebergSerializationPolicy);
+  String getIcebergSerializationPolicy() {
+    return this.icebergSerializationPolicy;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -26,6 +26,7 @@ import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
@@ -45,6 +46,8 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   private final List<List<Object>> data;
   private final List<List<Object>> tempData;
 
+  private final ParquetProperties.WriterVersion parquetWriterVersion;
+
   private MessageType schema;
 
   /** Construct a ParquetRowBuffer object. */
@@ -56,6 +59,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       ChannelRuntimeState channelRuntimeState,
       ClientBufferParameters clientBufferParameters,
       OffsetTokenVerificationFunction offsetTokenVerificationFunction,
+      ParquetProperties.WriterVersion parquetWriterVersion,
       TelemetryService telemetryService) {
     super(
         onErrorOption,
@@ -70,6 +74,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
     this.metadata = new HashMap<>();
     this.data = new ArrayList<>();
     this.tempData = new ArrayList<>();
+    this.parquetWriterVersion = parquetWriterVersion;
   }
 
   /**
@@ -395,6 +400,7 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
         clientBufferParameters.getMaxChunkSizeInBytes(),
         clientBufferParameters.getMaxRowGroups(),
         clientBufferParameters.getBdecParquetCompression(),
+        parquetWriterVersion,
         clientBufferParameters.isEnableDictionaryEncoding());
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelFactory.java
@@ -131,7 +131,6 @@ class SnowflakeStreamingIngestChannelFactory {
           this.encryptionKeyId,
           this.onErrorOption,
           this.defaultTimezone,
-          this.owningClient.getParameterProvider().getBlobFormatVersion(),
           this.offsetTokenVerificationFunction,
           this.parquetWriterVersion);
     }

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -79,28 +79,11 @@ public class Constants {
    * otherwise v1.
    */
   public enum IcebergSerializationPolicy {
-    NON_ICEBERG,
     COMPATIBLE,
     OPTIMIZED;
 
-    public static IcebergSerializationPolicy fromName(String name) {
-      if (name == null) {
-        return NON_ICEBERG;
-      }
-      for (IcebergSerializationPolicy e : IcebergSerializationPolicy.values()) {
-        if (e.name().equalsIgnoreCase(name)) {
-          return e;
-        }
-      }
-      throw new IllegalArgumentException(
-          String.format(
-              "Unsupported ICEBERG_SERIALIZATION_POLICY = '%s', allowed values are %s",
-              name, Arrays.asList(IcebergSerializationPolicy.values())));
-    }
-
-    public ParquetProperties.WriterVersion getParquetWriterVersion() {
+    public ParquetProperties.WriterVersion toParquetWriterVersion() {
       switch (this) {
-        case NON_ICEBERG:
         case COMPATIBLE:
           return ParquetProperties.WriterVersion.PARQUET_1_0;
         case OPTIMIZED:

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -78,6 +78,9 @@ public class BlobBuilderTest {
                 100L,
                 isIceberg ? Optional.of(1) : Optional.empty(),
                 Constants.BdecParquetCompression.GZIP,
+                isIceberg
+                    ? ParquetProperties.WriterVersion.PARQUET_2_0
+                    : ParquetProperties.WriterVersion.PARQUET_1_0,
                 isIceberg))
         .when(channelData)
         .createFlusher();
@@ -121,17 +124,7 @@ public class BlobBuilderTest {
                         .named("test"))
                 : new RowBufferStats(columnName, null, 1, null, null));
     channelData.setChannelContext(
-        new ChannelFlushContext(
-            "channel1",
-            "DB",
-            "SCHEMA",
-            "TABLE",
-            1L,
-            "enc",
-            1L,
-            isIceberg
-                ? ParquetProperties.WriterVersion.PARQUET_2_0
-                : ParquetProperties.WriterVersion.PARQUET_1_0));
+        new ChannelFlushContext("channel1", "DB", "SCHEMA", "TABLE", 1L, "enc", 1L));
     return Collections.singletonList(channelData);
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
 import net.snowflake.ingest.connection.RequestBuilder;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
+import org.apache.parquet.column.ParquetProperties;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,7 +62,11 @@ public class ChannelCacheTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel2",
@@ -75,7 +80,11 @@ public class ChannelCacheTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     channel3 =
         new SnowflakeStreamingIngestChannelInternal<>(
             "channel3",
@@ -89,7 +98,11 @@ public class ChannelCacheTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     cache.addChannel(channel1);
     cache.addChannel(channel2);
     cache.addChannel(channel3);
@@ -115,7 +128,11 @@ public class ChannelCacheTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     cache.addChannel(channel);
     Assert.assertEquals(1, cache.getSize());
     Assert.assertTrue(channel == cache.entrySet().iterator().next().getValue().get(channelName));
@@ -133,7 +150,11 @@ public class ChannelCacheTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     cache.addChannel(channelDup);
     // The old channel should be invalid now
     Assert.assertTrue(!channel.isValid());
@@ -214,7 +235,11 @@ public class ChannelCacheTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     cache.removeChannelIfSequencersMatch(channel3Dup);
     // Verify that remove the same channel with a different channel sequencer is a no op
     Assert.assertEquals(1, cache.getSize());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -303,7 +303,6 @@ public class FlushServiceTest {
           encryptionKeyId,
           onErrorOption,
           defaultTimezone,
-          Constants.BdecVersion.THREE,
           null,
           isIcebergMode
               ? ParquetProperties.WriterVersion.PARQUET_2_0
@@ -1065,7 +1064,11 @@ public class FlushServiceTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            ZoneOffset.UTC);
+            ZoneOffset.UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     SnowflakeStreamingIngestChannelInternal<StubChunkData> channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
@@ -1080,7 +1083,11 @@ public class FlushServiceTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            ZoneOffset.UTC);
+            ZoneOffset.UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     channelCache.addChannel(channel1);
     channelCache.addChannel(channel2);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
@@ -15,6 +15,7 @@ import net.snowflake.ingest.connection.RequestBuilder;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Utils;
+import org.apache.parquet.column.ParquetProperties;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,7 +79,11 @@ public class InsertRowsBenchmarkTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     // Setup column fields and vectors
     ColumnMetadata col = new ColumnMetadata();
     col.setOrdinal(1);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -156,6 +156,9 @@ public class RowBufferTest {
             isIcebergMode ? Optional.of(1) : Optional.empty(),
             isIcebergMode),
         null,
+        isIcebergMode
+            ? ParquetProperties.WriterVersion.PARQUET_2_0
+            : ParquetProperties.WriterVersion.PARQUET_1_0,
         null);
   }
 
@@ -1925,18 +1928,7 @@ public class RowBufferTest {
     bufferUnderTest.setupSchema(Collections.singletonList(colChar));
     loadData(bufferUnderTest, Collections.singletonMap("colChar", "a"));
     ChannelData<ParquetChunkData> data = bufferUnderTest.flush();
-    data.setChannelContext(
-        new ChannelFlushContext(
-            "name",
-            "db",
-            "schema",
-            "table",
-            1L,
-            "key",
-            0L,
-            isIcebergMode
-                ? ParquetProperties.WriterVersion.PARQUET_2_0
-                : ParquetProperties.WriterVersion.PARQUET_1_0));
+    data.setChannelContext(new ChannelFlushContext("name", "db", "schema", "table", 1L, "key", 0L));
 
     ParquetFlusher flusher = (ParquetFlusher) bufferUnderTest.createFlusher();
     Flusher.SerializationResult result =

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -48,6 +48,7 @@ import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.parquet.column.ParquetProperties;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -199,7 +200,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     Assert.assertTrue(channel.isValid());
     channel.invalidate("from testChannelValid", "Invalidated by test");
@@ -247,7 +252,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     Assert.assertFalse(channel.isClosed());
     channel.markClosed();
@@ -545,7 +554,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     ColumnMetadata col = new ColumnMetadata();
     col.setOrdinal(1);
@@ -631,7 +644,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     channel.setupSchema(schema);
 
     InsertValidationResponse insertValidationResponse = channel.insertRow(row, "token-1");
@@ -655,7 +672,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.ABORT,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     channel.setupSchema(schema);
 
     try {
@@ -680,7 +701,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.SKIP_BATCH,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     channel.setupSchema(schema);
 
     insertValidationResponse = channel.insertRow(row, "token-1");
@@ -711,7 +736,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     ParameterProvider parameterProvider = new ParameterProvider(isIcebergMode);
     memoryInfoProvider.freeMemory =
@@ -755,7 +784,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("Success");
@@ -789,7 +822,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("Success");
@@ -821,7 +858,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("Success");
@@ -856,7 +897,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);
     response.setMessage("Success");
@@ -887,7 +932,11 @@ public class SnowflakeStreamingIngestChannelTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
 
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(0L);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -61,6 +61,7 @@ import net.snowflake.ingest.utils.SFException;
 import net.snowflake.ingest.utils.SnowflakeURL;
 import net.snowflake.ingest.utils.Utils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
@@ -131,7 +132,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
     channel2 =
@@ -148,7 +148,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
     channel3 =
@@ -165,7 +164,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
     channel4 =
@@ -182,7 +180,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
   }
@@ -380,7 +377,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
 
@@ -443,7 +439,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
 
@@ -497,7 +492,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
 
@@ -1073,7 +1067,11 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     SnowflakeStreamingIngestChannelInternal<StubChunkData> channel2 =
         new SnowflakeStreamingIngestChannelInternal<>(
             channel2Name,
@@ -1087,7 +1085,11 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     client.getChannelCache().addChannel(channel1);
     client.getChannelCache().addChannel(channel2);
 
@@ -1193,7 +1195,11 @@ public class SnowflakeStreamingIngestClientTest {
             "key",
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
-            UTC);
+            UTC,
+            null /* offsetTokenVerificationFunction */,
+            isIcebergMode
+                ? ParquetProperties.WriterVersion.PARQUET_2_0
+                : ParquetProperties.WriterVersion.PARQUET_1_0);
     client.getChannelCache().addChannel(channel);
 
     ChannelsStatusResponse response = new ChannelsStatusResponse();
@@ -1264,7 +1270,6 @@ public class SnowflakeStreamingIngestClientTest {
             1234L,
             OpenChannelRequest.OnErrorOption.CONTINUE,
             ZoneOffset.UTC,
-            BDEC_VERSION,
             null,
             null);
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractDataTypeTest {
     setUp(
         false /* isIceberg */,
         compressionAlgorithm,
-        Constants.IcebergSerializationPolicy.NON_ICEBERG);
+        Constants.IcebergSerializationPolicy.COMPATIBLE);
   }
 
   public void beforeIceberg(


### PR DESCRIPTION
Took the liberty of sending out a PR instead of describing what I had in mind textually.
1. Remove logic from OpenChannelResponse contract class
2. Move writerVersion defaulting to channel construction callsite in clientInternal (from channel ctor), instead of passing writerVersion=null into the channel.
3. Pass around writerVersion via RowBuffer into Flusher, instead of via the per-chunk flushContext.
4. Remove a test-only overload of ChannelInternal
5. Remove an unnecessary parameter on ChannelInternal ctor (bdecVersion)
6. Remove SerializationPolicy.NON_ICEBERG, remove the custom SerPolicy.fromName method and use Enum.valueOf that java already has

Once the merge gates are green, will merge this into the V2 PR.