### PR TITLE
[SNOW-1711460] Upgrade to latest iceberg version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <protobuf.version>4.27.5</protobuf.version>
     <shadeBase>net.snowflake.ingest.internal</shadeBase>
-    <slf4j.version>1.7.36</slf4j.version>
+    <slf4j.version>2.0.16</slf4j.version>
     <snappy.version>1.1.10.5</snappy.version>
     <snowjdbc.version>3.18.0</snowjdbc.version>
     <yetus.version>0.13.0</yetus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <fasterxml.version>2.17.2</fasterxml.version>
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.4.0</hadoop.version>
-    <iceberg.version>1.5.2</iceberg.version>
+    <iceberg.version>1.6.1</iceberg.version>
     <jacoco.skip.instrument>true</jacoco.skip.instrument>
     <jacoco.version>0.8.5</jacoco.version>
     <license.processing.dependencyJarsDir>${project.build.directory}/dependency-jars</license.processing.dependencyJarsDir>

--- a/pom.xml
+++ b/pom.xml
@@ -42,13 +42,13 @@
     <codehaus.version>1.9.13</codehaus.version>
     <commonscodec.version>1.15</commonscodec.version>
     <commonscollections.version>3.2.2</commonscollections.version>
-    <commonscompress.version>1.26.0</commonscompress.version>
+    <commonscompress.version>1.26.2</commonscompress.version>
     <commonsconfiguration2.version>2.10.1</commonsconfiguration2.version>
     <commonsio.version>2.15.1</commonsio.version>
     <commonslang3.version>3.14.0</commonslang3.version>
     <commonslogging.version>1.3.3</commonslogging.version>
     <commonstext.version>1.11.0</commonstext.version>
-    <fasterxml.version>2.17.2</fasterxml.version>
+    <fasterxml.version>2.18.1</fasterxml.version>
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.4.0</hadoop.version>
     <iceberg.version>1.7.0</iceberg.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,11 @@
   <properties>
     <bouncycastle.version>1.78.1</bouncycastle.version>
     <codehaus.version>1.9.13</codehaus.version>
-    <commonscodec.version>1.15</commonscodec.version>
+    <commonscodec.version>1.17.1</commonscodec.version>
     <commonscollections.version>3.2.2</commonscollections.version>
     <commonscompress.version>1.26.2</commonscompress.version>
     <commonsconfiguration2.version>2.10.1</commonsconfiguration2.version>
-    <commonsio.version>2.15.1</commonsio.version>
+    <commonsio.version>2.16.1</commonsio.version>
     <commonslang3.version>3.14.0</commonslang3.version>
     <commonslogging.version>1.3.3</commonslogging.version>
     <commonstext.version>1.11.0</commonstext.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <fasterxml.version>2.17.2</fasterxml.version>
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.4.0</hadoop.version>
-    <iceberg.version>1.6.1</iceberg.version>
+    <iceberg.version>1.7.0</iceberg.version>
     <jacoco.skip.instrument>true</jacoco.skip.instrument>
     <jacoco.version>0.8.5</jacoco.version>
     <license.processing.dependencyJarsDir>${project.build.directory}/dependency-jars</license.processing.dependencyJarsDir>

--- a/pom.xml
+++ b/pom.xml
@@ -758,7 +758,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -841,7 +841,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
+        <version>3.8.1</version>
         <inherited>true</inherited>
         <configuration>
           <source>1.8</source>

--- a/scripts/process_licenses.py
+++ b/scripts/process_licenses.py
@@ -64,6 +64,7 @@ ADDITIONAL_LICENSES_MAP = {
     "com.thoughtworks.paranamer:paranamer": BSD_2_CLAUSE_LICENSE,
     "org.roaringbitmap:RoaringBitmap": APACHE_LICENSE,
     "org.roaringbitmap:shims": APACHE_LICENSE,
+    "dev.failsafe:failsafe": APACHE_LICENSE,
 }
 
 


### PR DESCRIPTION
Upgrading to latest version to ensure tests and releases are using a more recent version to ensure the next upgrade to 1.6.2 has minimal changes.

This still does not fix the synk issue until 1.6.2 is released