### PR TITLE
SNOW-1748333 Fix Iceberg decimal type schema parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,11 +155,6 @@
         <version>${commonslang3.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-text</artifactId>
-        <version>${commonstext.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>
@@ -384,6 +379,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>${commonstext.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-core</artifactId>
         <version>${hadoop.version}</version>
@@ -542,6 +543,10 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -86,7 +86,9 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
   public void setupSchema(List<ColumnMetadata> columns) {
     fieldIndex.clear();
     metadata.clear();
-    metadata.put("sfVer", "1,1");
+    if (!clientBufferParameters.getIsIcebergMode()) {
+      metadata.put("sfVer", "1,1");
+    }
     List<Type> parquetTypes = new ArrayList<>();
     int id = 1;
 

--- a/src/main/java/net/snowflake/ingest/utils/IcebergDataTypeParser.java
+++ b/src/main/java/net/snowflake/ingest/utils/IcebergDataTypeParser.java
@@ -4,14 +4,6 @@
 
 package net.snowflake.ingest.utils;
 
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,11 +12,10 @@ import com.google.common.collect.Lists;
 import java.util.Iterator;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.apache.iceberg.parquet.TypeToMessageType;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.LogicalTypeAnnotation;
 
 /**
  * This class is used to Iceberg data type (include primitive types and nested types) serialization
@@ -32,9 +23,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
  *
  * <p>This code is modified from
  * GlobalServices/modules/data-lake/datalake-api/src/main/java/com/snowflake/metadata/iceberg
- * /IcebergDataTypeParser.java and <a
- * href="https://github.com/apache/iceberg/blob/main/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java">
- * TypeToMessageType.java</a>
+ * /IcebergDataTypeParser.java
  */
 public class IcebergDataTypeParser {
   private static final String TYPE = "type";
@@ -55,25 +44,11 @@ public class IcebergDataTypeParser {
   private static final String ELEMENT_REQUIRED = "element-required";
   private static final String VALUE_REQUIRED = "value-required";
 
-  private static final LogicalTypeAnnotation STRING = LogicalTypeAnnotation.stringType();
-  private static final LogicalTypeAnnotation DATE = LogicalTypeAnnotation.dateType();
-  private static final LogicalTypeAnnotation TIME_MICROS =
-      LogicalTypeAnnotation.timeType(
-          false /* not adjusted to UTC */, LogicalTypeAnnotation.TimeUnit.MICROS);
-  private static final LogicalTypeAnnotation TIMESTAMP_MICROS =
-      LogicalTypeAnnotation.timestampType(
-          false /* not adjusted to UTC */, LogicalTypeAnnotation.TimeUnit.MICROS);
-  private static final LogicalTypeAnnotation TIMESTAMPTZ_MICROS =
-      LogicalTypeAnnotation.timestampType(
-          true /* adjusted to UTC */, LogicalTypeAnnotation.TimeUnit.MICROS);
-
-  private static final int DECIMAL_INT32_MAX_DIGITS = 9;
-  private static final int DECIMAL_INT64_MAX_DIGITS = 18;
-  private static final int DECIMAL_MAX_DIGITS = 38;
-  private static final int DECIMAL_MAX_BYTES = 16;
-
   /** Object mapper for this class */
   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** Util class that contains the mapping between Iceberg data type and Parquet data type */
+  private static final TypeToMessageType typeToMessageType = new TypeToMessageType();
 
   /**
    * Get Iceberg data type information by deserialization.
@@ -91,15 +66,15 @@ public class IcebergDataTypeParser {
       String name) {
     Type icebergType = deserializeIcebergType(icebergDataType);
     if (icebergType.isPrimitiveType()) {
-      return primitive(icebergType.asPrimitiveType(), repetition, id, name);
+      return typeToMessageType.primitive(icebergType.asPrimitiveType(), repetition, id, name);
     } else {
       switch (icebergType.typeId()) {
         case LIST:
-          return list(icebergType.asListType(), repetition, id, name);
+          return typeToMessageType.list(icebergType.asListType(), repetition, id, name);
         case MAP:
-          return map(icebergType.asMapType(), repetition, id, name);
+          return typeToMessageType.map(icebergType.asMapType(), repetition, id, name);
         case STRUCT:
-          return struct(icebergType.asStructType(), repetition, id, name);
+          return typeToMessageType.struct(icebergType.asStructType(), repetition, id, name);
         default:
           throw new SFException(
               ErrorCode.INTERNAL_ERROR,
@@ -232,169 +207,5 @@ public class IcebergDataTypeParser {
     } else {
       return Types.MapType.ofOptional(keyId, valueId, keyType, valueType);
     }
-  }
-
-  private static GroupType struct(
-      Types.StructType struct,
-      org.apache.parquet.schema.Type.Repetition repetition,
-      int id,
-      String name) {
-    org.apache.parquet.schema.Types.GroupBuilder<GroupType> builder =
-        org.apache.parquet.schema.Types.buildGroup(repetition);
-
-    for (Types.NestedField field : struct.fields()) {
-      builder.addField(field(field));
-    }
-
-    return builder.id(id).named(name);
-  }
-
-  private static org.apache.parquet.schema.Type field(Types.NestedField field) {
-    org.apache.parquet.schema.Type.Repetition repetition =
-        field.isOptional()
-            ? org.apache.parquet.schema.Type.Repetition.OPTIONAL
-            : org.apache.parquet.schema.Type.Repetition.REQUIRED;
-    int id = field.fieldId();
-    String name = field.name();
-
-    if (field.type().isPrimitiveType()) {
-      return primitive(field.type().asPrimitiveType(), repetition, id, name);
-
-    } else {
-      Type.NestedType nested = field.type().asNestedType();
-      if (nested.isStructType()) {
-        return struct(nested.asStructType(), repetition, id, name);
-      } else if (nested.isMapType()) {
-        return map(nested.asMapType(), repetition, id, name);
-      } else if (nested.isListType()) {
-        return list(nested.asListType(), repetition, id, name);
-      }
-      throw new UnsupportedOperationException("Can't convert unknown type: " + nested);
-    }
-  }
-
-  private static GroupType list(
-      Types.ListType list,
-      org.apache.parquet.schema.Type.Repetition repetition,
-      int id,
-      String name) {
-    Types.NestedField elementField = list.fields().get(0);
-    return org.apache.parquet.schema.Types.list(repetition)
-        .element(field(elementField))
-        .id(id)
-        .named(name);
-  }
-
-  private static GroupType map(
-      Types.MapType map,
-      org.apache.parquet.schema.Type.Repetition repetition,
-      int id,
-      String name) {
-    Types.NestedField keyField = map.fields().get(0);
-    Types.NestedField valueField = map.fields().get(1);
-    return org.apache.parquet.schema.Types.map(repetition)
-        .key(field(keyField))
-        .value(field(valueField))
-        .id(id)
-        .named(name);
-  }
-
-  public static org.apache.parquet.schema.Type primitive(
-      Type.PrimitiveType primitive,
-      org.apache.parquet.schema.Type.Repetition repetition,
-      int id,
-      String name) {
-    switch (primitive.typeId()) {
-      case BOOLEAN:
-        return org.apache.parquet.schema.Types.primitive(BOOLEAN, repetition).id(id).named(name);
-      case INTEGER:
-        return org.apache.parquet.schema.Types.primitive(INT32, repetition).id(id).named(name);
-      case LONG:
-        return org.apache.parquet.schema.Types.primitive(INT64, repetition).id(id).named(name);
-      case FLOAT:
-        return org.apache.parquet.schema.Types.primitive(FLOAT, repetition).id(id).named(name);
-      case DOUBLE:
-        return org.apache.parquet.schema.Types.primitive(DOUBLE, repetition).id(id).named(name);
-      case DATE:
-        return org.apache.parquet.schema.Types.primitive(INT32, repetition)
-            .as(DATE)
-            .id(id)
-            .named(name);
-      case TIME:
-        return org.apache.parquet.schema.Types.primitive(INT64, repetition)
-            .as(TIME_MICROS)
-            .id(id)
-            .named(name);
-      case TIMESTAMP:
-        if (((Types.TimestampType) primitive).shouldAdjustToUTC()) {
-          return org.apache.parquet.schema.Types.primitive(INT64, repetition)
-              .as(TIMESTAMPTZ_MICROS)
-              .id(id)
-              .named(name);
-        } else {
-          return org.apache.parquet.schema.Types.primitive(INT64, repetition)
-              .as(TIMESTAMP_MICROS)
-              .id(id)
-              .named(name);
-        }
-      case STRING:
-        return org.apache.parquet.schema.Types.primitive(BINARY, repetition)
-            .as(STRING)
-            .id(id)
-            .named(name);
-      case BINARY:
-        return org.apache.parquet.schema.Types.primitive(BINARY, repetition).id(id).named(name);
-      case FIXED:
-        Types.FixedType fixed = (Types.FixedType) primitive;
-
-        return org.apache.parquet.schema.Types.primitive(FIXED_LEN_BYTE_ARRAY, repetition)
-            .length(fixed.length())
-            .id(id)
-            .named(name);
-
-      case DECIMAL:
-        Types.DecimalType decimal = (Types.DecimalType) primitive;
-
-        if (decimal.precision() <= DECIMAL_INT32_MAX_DIGITS) {
-          /* Store as an int. */
-          return org.apache.parquet.schema.Types.primitive(INT32, repetition)
-              .as(decimalAnnotation(decimal.precision(), decimal.scale()))
-              .id(id)
-              .named(name);
-
-        } else if (decimal.precision() <= DECIMAL_INT64_MAX_DIGITS) {
-          /* Store as a long. */
-          return org.apache.parquet.schema.Types.primitive(INT64, repetition)
-              .as(decimalAnnotation(decimal.precision(), decimal.scale()))
-              .id(id)
-              .named(name);
-
-        } else {
-          /* Does not follow Iceberg spec which should be minimum number of bytes. Use fix(16) (SB16) instead. */
-          if (decimal.precision() > DECIMAL_MAX_DIGITS) {
-            throw new IllegalArgumentException(
-                "Unsupported decimal precision: " + decimal.precision());
-          }
-          return org.apache.parquet.schema.Types.primitive(FIXED_LEN_BYTE_ARRAY, repetition)
-              .length(DECIMAL_MAX_BYTES)
-              .as(decimalAnnotation(decimal.precision(), decimal.scale()))
-              .id(id)
-              .named(name);
-        }
-
-      case UUID:
-        return org.apache.parquet.schema.Types.primitive(FIXED_LEN_BYTE_ARRAY, repetition)
-            .length(16)
-            .as(LogicalTypeAnnotation.uuidType())
-            .id(id)
-            .named(name);
-
-      default:
-        throw new UnsupportedOperationException("Unsupported type for Parquet: " + primitive);
-    }
-  }
-
-  private static LogicalTypeAnnotation decimalAnnotation(int precision, int scale) {
-    return LogicalTypeAnnotation.decimalType(scale, precision);
   }
 }

--- a/src/main/java/net/snowflake/ingest/utils/IcebergDataTypeParser.java
+++ b/src/main/java/net/snowflake/ingest/utils/IcebergDataTypeParser.java
@@ -4,6 +4,14 @@
 
 package net.snowflake.ingest.utils;
 
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,10 +20,11 @@ import com.google.common.collect.Lists;
 import java.util.Iterator;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.apache.iceberg.parquet.TypeToMessageType;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 
 /**
  * This class is used to Iceberg data type (include primitive types and nested types) serialization
@@ -23,7 +32,9 @@ import org.apache.iceberg.util.JsonUtil;
  *
  * <p>This code is modified from
  * GlobalServices/modules/data-lake/datalake-api/src/main/java/com/snowflake/metadata/iceberg
- * /IcebergDataTypeParser.java
+ * /IcebergDataTypeParser.java and <a
+ * href="https://github.com/apache/iceberg/blob/main/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java">
+ * TypeToMessageType.java</a>
  */
 public class IcebergDataTypeParser {
   private static final String TYPE = "type";
@@ -44,11 +55,25 @@ public class IcebergDataTypeParser {
   private static final String ELEMENT_REQUIRED = "element-required";
   private static final String VALUE_REQUIRED = "value-required";
 
+  private static final LogicalTypeAnnotation STRING = LogicalTypeAnnotation.stringType();
+  private static final LogicalTypeAnnotation DATE = LogicalTypeAnnotation.dateType();
+  private static final LogicalTypeAnnotation TIME_MICROS =
+      LogicalTypeAnnotation.timeType(
+          false /* not adjusted to UTC */, LogicalTypeAnnotation.TimeUnit.MICROS);
+  private static final LogicalTypeAnnotation TIMESTAMP_MICROS =
+      LogicalTypeAnnotation.timestampType(
+          false /* not adjusted to UTC */, LogicalTypeAnnotation.TimeUnit.MICROS);
+  private static final LogicalTypeAnnotation TIMESTAMPTZ_MICROS =
+      LogicalTypeAnnotation.timestampType(
+          true /* adjusted to UTC */, LogicalTypeAnnotation.TimeUnit.MICROS);
+
+  private static final int DECIMAL_INT32_MAX_DIGITS = 9;
+  private static final int DECIMAL_INT64_MAX_DIGITS = 18;
+  private static final int DECIMAL_MAX_DIGITS = 38;
+  private static final int DECIMAL_MAX_BYTES = 16;
+
   /** Object mapper for this class */
   private static final ObjectMapper MAPPER = new ObjectMapper();
-
-  /** Util class that contains the mapping between Iceberg data type and Parquet data type */
-  private static final TypeToMessageType typeToMessageType = new TypeToMessageType();
 
   /**
    * Get Iceberg data type information by deserialization.
@@ -66,15 +91,15 @@ public class IcebergDataTypeParser {
       String name) {
     Type icebergType = deserializeIcebergType(icebergDataType);
     if (icebergType.isPrimitiveType()) {
-      return typeToMessageType.primitive(icebergType.asPrimitiveType(), repetition, id, name);
+      return primitive(icebergType.asPrimitiveType(), repetition, id, name);
     } else {
       switch (icebergType.typeId()) {
         case LIST:
-          return typeToMessageType.list(icebergType.asListType(), repetition, id, name);
+          return list(icebergType.asListType(), repetition, id, name);
         case MAP:
-          return typeToMessageType.map(icebergType.asMapType(), repetition, id, name);
+          return map(icebergType.asMapType(), repetition, id, name);
         case STRUCT:
-          return typeToMessageType.struct(icebergType.asStructType(), repetition, id, name);
+          return struct(icebergType.asStructType(), repetition, id, name);
         default:
           throw new SFException(
               ErrorCode.INTERNAL_ERROR,
@@ -207,5 +232,169 @@ public class IcebergDataTypeParser {
     } else {
       return Types.MapType.ofOptional(keyId, valueId, keyType, valueType);
     }
+  }
+
+  private static GroupType struct(
+      Types.StructType struct,
+      org.apache.parquet.schema.Type.Repetition repetition,
+      int id,
+      String name) {
+    org.apache.parquet.schema.Types.GroupBuilder<GroupType> builder =
+        org.apache.parquet.schema.Types.buildGroup(repetition);
+
+    for (Types.NestedField field : struct.fields()) {
+      builder.addField(field(field));
+    }
+
+    return builder.id(id).named(name);
+  }
+
+  private static org.apache.parquet.schema.Type field(Types.NestedField field) {
+    org.apache.parquet.schema.Type.Repetition repetition =
+        field.isOptional()
+            ? org.apache.parquet.schema.Type.Repetition.OPTIONAL
+            : org.apache.parquet.schema.Type.Repetition.REQUIRED;
+    int id = field.fieldId();
+    String name = field.name();
+
+    if (field.type().isPrimitiveType()) {
+      return primitive(field.type().asPrimitiveType(), repetition, id, name);
+
+    } else {
+      Type.NestedType nested = field.type().asNestedType();
+      if (nested.isStructType()) {
+        return struct(nested.asStructType(), repetition, id, name);
+      } else if (nested.isMapType()) {
+        return map(nested.asMapType(), repetition, id, name);
+      } else if (nested.isListType()) {
+        return list(nested.asListType(), repetition, id, name);
+      }
+      throw new UnsupportedOperationException("Can't convert unknown type: " + nested);
+    }
+  }
+
+  private static GroupType list(
+      Types.ListType list,
+      org.apache.parquet.schema.Type.Repetition repetition,
+      int id,
+      String name) {
+    Types.NestedField elementField = list.fields().get(0);
+    return org.apache.parquet.schema.Types.list(repetition)
+        .element(field(elementField))
+        .id(id)
+        .named(name);
+  }
+
+  private static GroupType map(
+      Types.MapType map,
+      org.apache.parquet.schema.Type.Repetition repetition,
+      int id,
+      String name) {
+    Types.NestedField keyField = map.fields().get(0);
+    Types.NestedField valueField = map.fields().get(1);
+    return org.apache.parquet.schema.Types.map(repetition)
+        .key(field(keyField))
+        .value(field(valueField))
+        .id(id)
+        .named(name);
+  }
+
+  public static org.apache.parquet.schema.Type primitive(
+      Type.PrimitiveType primitive,
+      org.apache.parquet.schema.Type.Repetition repetition,
+      int id,
+      String name) {
+    switch (primitive.typeId()) {
+      case BOOLEAN:
+        return org.apache.parquet.schema.Types.primitive(BOOLEAN, repetition).id(id).named(name);
+      case INTEGER:
+        return org.apache.parquet.schema.Types.primitive(INT32, repetition).id(id).named(name);
+      case LONG:
+        return org.apache.parquet.schema.Types.primitive(INT64, repetition).id(id).named(name);
+      case FLOAT:
+        return org.apache.parquet.schema.Types.primitive(FLOAT, repetition).id(id).named(name);
+      case DOUBLE:
+        return org.apache.parquet.schema.Types.primitive(DOUBLE, repetition).id(id).named(name);
+      case DATE:
+        return org.apache.parquet.schema.Types.primitive(INT32, repetition)
+            .as(DATE)
+            .id(id)
+            .named(name);
+      case TIME:
+        return org.apache.parquet.schema.Types.primitive(INT64, repetition)
+            .as(TIME_MICROS)
+            .id(id)
+            .named(name);
+      case TIMESTAMP:
+        if (((Types.TimestampType) primitive).shouldAdjustToUTC()) {
+          return org.apache.parquet.schema.Types.primitive(INT64, repetition)
+              .as(TIMESTAMPTZ_MICROS)
+              .id(id)
+              .named(name);
+        } else {
+          return org.apache.parquet.schema.Types.primitive(INT64, repetition)
+              .as(TIMESTAMP_MICROS)
+              .id(id)
+              .named(name);
+        }
+      case STRING:
+        return org.apache.parquet.schema.Types.primitive(BINARY, repetition)
+            .as(STRING)
+            .id(id)
+            .named(name);
+      case BINARY:
+        return org.apache.parquet.schema.Types.primitive(BINARY, repetition).id(id).named(name);
+      case FIXED:
+        Types.FixedType fixed = (Types.FixedType) primitive;
+
+        return org.apache.parquet.schema.Types.primitive(FIXED_LEN_BYTE_ARRAY, repetition)
+            .length(fixed.length())
+            .id(id)
+            .named(name);
+
+      case DECIMAL:
+        Types.DecimalType decimal = (Types.DecimalType) primitive;
+
+        if (decimal.precision() <= DECIMAL_INT32_MAX_DIGITS) {
+          /* Store as an int. */
+          return org.apache.parquet.schema.Types.primitive(INT32, repetition)
+              .as(decimalAnnotation(decimal.precision(), decimal.scale()))
+              .id(id)
+              .named(name);
+
+        } else if (decimal.precision() <= DECIMAL_INT64_MAX_DIGITS) {
+          /* Store as a long. */
+          return org.apache.parquet.schema.Types.primitive(INT64, repetition)
+              .as(decimalAnnotation(decimal.precision(), decimal.scale()))
+              .id(id)
+              .named(name);
+
+        } else {
+          /* Does not follow Iceberg spec which should be minimum number of bytes. Use fix(16) (SB16) instead. */
+          if (decimal.precision() > DECIMAL_MAX_DIGITS) {
+            throw new IllegalArgumentException(
+                "Unsupported decimal precision: " + decimal.precision());
+          }
+          return org.apache.parquet.schema.Types.primitive(FIXED_LEN_BYTE_ARRAY, repetition)
+              .length(DECIMAL_MAX_BYTES)
+              .as(decimalAnnotation(decimal.precision(), decimal.scale()))
+              .id(id)
+              .named(name);
+        }
+
+      case UUID:
+        return org.apache.parquet.schema.Types.primitive(FIXED_LEN_BYTE_ARRAY, repetition)
+            .length(16)
+            .as(LogicalTypeAnnotation.uuidType())
+            .id(id)
+            .named(name);
+
+      default:
+        throw new UnsupportedOperationException("Unsupported type for Parquet: " + primitive);
+    }
+  }
+
+  private static LogicalTypeAnnotation decimalAnnotation(int precision, int scale) {
+    return LogicalTypeAnnotation.decimalType(scale, precision);
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergNumericTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergNumericTypesIT.java
@@ -45,7 +45,7 @@ public class IcebergNumericTypesIT extends AbstractDataTypeTest {
     super.beforeIceberg(compressionAlgorithm, icebergSerializationPolicy);
     long seed = System.currentTimeMillis();
     logger.info("Random seed: {}", seed);
-    generator = new Random(123);
+    generator = new Random(seed);
     randomStringGenerator =
         new RandomStringGenerator.Builder()
             .usingRandom(generator::nextInt)
@@ -418,6 +418,7 @@ public class IcebergNumericTypesIT extends AbstractDataTypeTest {
         bigDecimals_38_10);
   }
 
+  /** Generate a list of random BigDecimal(p', s') where p' <= precision and s' <= scale */
   private static List<Object> randomBigDecimal(int count, int precision, int scale) {
     List<Object> list = new ArrayList<>();
     for (int i = 0; i < count; i++) {


### PR DESCRIPTION
## Summary
This PR addresses the issue where the scanner encounters an error when scanning delta-encoded decimal values with a precision greater than 18.

## Changes
1. Removed `sfVer` metadata in Iceberg mode: This prevents the scanner from applying optimizations specific to Snowflake-written Parquet files, which was the root cause of the issue with scanning.
2. Add tests for multiple random generated decimals.