### PR TITLE
Fix empty map & list ingestion

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParser.java
@@ -492,6 +492,11 @@ class IcebergParquetValueParser {
       listVal.add(Collections.singletonList(parsedValue.getValue()));
       estimatedParquetSize += parsedValue.getSize();
     }
+    if (listVal.isEmpty()) {
+      subColumnFinder
+          .getSubColumns(path)
+          .forEach(subColumn -> statsMap.get(subColumn).incCurrentNullCount());
+    }
     return new ParquetBufferValue(listVal, estimatedParquetSize);
   }
 
@@ -538,6 +543,11 @@ class IcebergParquetValueParser {
               true);
       listVal.add(Arrays.asList(parsedKey.getValue(), parsedValue.getValue()));
       estimatedParquetSize += parsedKey.getSize() + parsedValue.getSize();
+    }
+    if (listVal.isEmpty()) {
+      subColumnFinder
+          .getSubColumns(path)
+          .forEach(subColumn -> statsMap.get(subColumn).incCurrentNullCount());
     }
     return new ParquetBufferValue(listVal, estimatedParquetSize);
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RowBufferStats.java
@@ -286,6 +286,9 @@ class RowBufferStats {
 
   void incCurrentNullCount() {
     this.currentNullCount += 1;
+    if (enableValuesCount) {
+      numberOfValues++;
+    }
   }
 
   long getCurrentNullCount() {

--- a/src/main/java/org/apache/parquet/hadoop/SnowflakeParquetWriter.java
+++ b/src/main/java/org/apache/parquet/hadoop/SnowflakeParquetWriter.java
@@ -389,12 +389,13 @@ public class SnowflakeParquetWriter implements AutoCloseable {
               }
             } else {
               /* Struct */
-              recordConsumer.startGroup();
-              if (val instanceof List) {
-                writeValues((List<?>) val, cols.get(i).asGroupType());
-              } else {
+              if (!(val instanceof List)) {
                 throw new ParquetEncodingException(
                     String.format("Field %s should be a 2 level struct", fieldName));
+              }
+              recordConsumer.startGroup();
+              if (!((List<?>) val).isEmpty()) {
+                writeValues((List<?>) val, cols.get(i).asGroupType());
               }
               recordConsumer.endGroup();
             }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
@@ -239,7 +239,7 @@ public class RowBufferStatsTest {
     Assert.assertEquals(2, result.getCurrentNullCount());
     Assert.assertEquals(5, result.getCurrentMaxLength());
     Assert.assertEquals(enableNDVAndNV ? 7 : -1, result.getDistinctValues());
-    Assert.assertEquals(enableNDVAndNV ? 8 : -1, result.getNumberOfValues());
+    Assert.assertEquals(enableNDVAndNV ? 10 : -1, result.getNumberOfValues());
 
     Assert.assertNull(result.getCurrentMinRealValue());
     Assert.assertNull(result.getCurrentMaxRealValue());
@@ -309,7 +309,7 @@ public class RowBufferStatsTest {
     Assert.assertArrayEquals("g".getBytes(StandardCharsets.UTF_8), result.getCurrentMaxStrValue());
 
     Assert.assertEquals(enableNDVAndNV ? 4 : -1, result.getDistinctValues());
-    Assert.assertEquals(enableNDVAndNV ? 4 : -1, result.getNumberOfValues());
+    Assert.assertEquals(enableNDVAndNV ? 5 : -1, result.getNumberOfValues());
     Assert.assertEquals(1, result.getCurrentNullCount());
 
     Assert.assertNull(result.getCurrentMinRealValue());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferStatsTest.java
@@ -180,7 +180,7 @@ public class RowBufferStatsTest {
     Assert.assertEquals(BigInteger.valueOf(1), result.getCurrentMinIntValue());
     Assert.assertEquals(BigInteger.valueOf(8), result.getCurrentMaxIntValue());
     Assert.assertEquals(enableNDVAndNV ? 7 : -1, result.getDistinctValues());
-    Assert.assertEquals(enableNDVAndNV ? 8 : -1, result.getNumberOfValues());
+    Assert.assertEquals(enableNDVAndNV ? 10 : -1, result.getNumberOfValues());
 
     Assert.assertEquals(2, result.getCurrentNullCount());
     Assert.assertNull(result.getCurrentMinStrValue());
@@ -264,7 +264,7 @@ public class RowBufferStatsTest {
     Assert.assertEquals(BigInteger.valueOf(2), result.getCurrentMinIntValue());
     Assert.assertEquals(BigInteger.valueOf(8), result.getCurrentMaxIntValue());
     Assert.assertEquals(enableNDVAndNV ? 4 : -1, result.getDistinctValues());
-    Assert.assertEquals(enableNDVAndNV ? 4 : -1, result.getNumberOfValues());
+    Assert.assertEquals(enableNDVAndNV ? 6 : -1, result.getNumberOfValues());
 
     Assert.assertEquals(2, result.getCurrentNullCount());
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -2097,7 +2097,7 @@ public class RowBufferTest {
         .isEqualTo("key2".getBytes(StandardCharsets.UTF_8));
     assertThat(columnEpStats.get("COLMAP.key_value.key").getCurrentNullCount()).isEqualTo(1);
     assertThat(columnEpStats.get("COLMAP.key_value.key").getDistinctValues()).isEqualTo(2);
-    assertThat(columnEpStats.get("COLMAP.key_value.key").getNumberOfValues()).isEqualTo(2);
+    assertThat(columnEpStats.get("COLMAP.key_value.key").getNumberOfValues()).isEqualTo(3);
 
     assertThat(columnEpStats.get("COLMAP.key_value.value").getCurrentMinIntValue())
         .isEqualTo(BigInteger.ONE);
@@ -2105,7 +2105,7 @@ public class RowBufferTest {
         .isEqualTo(BigInteger.ONE);
     assertThat(columnEpStats.get("COLMAP.key_value.value").getCurrentNullCount()).isEqualTo(1);
     assertThat(columnEpStats.get("COLMAP.key_value.value").getDistinctValues()).isEqualTo(1);
-    assertThat(columnEpStats.get("COLMAP.key_value.value").getNumberOfValues()).isEqualTo(2);
+    assertThat(columnEpStats.get("COLMAP.key_value.value").getNumberOfValues()).isEqualTo(3);
 
     assertThat(columnEpStats.get("COLARRAY.list.element").getCurrentMinIntValue())
         .isEqualTo(BigInteger.ONE);
@@ -2113,7 +2113,7 @@ public class RowBufferTest {
         .isEqualTo(BigInteger.ONE);
     assertThat(columnEpStats.get("COLARRAY.list.element").getCurrentNullCount()).isEqualTo(1);
     assertThat(columnEpStats.get("COLARRAY.list.element").getDistinctValues()).isEqualTo(1);
-    assertThat(columnEpStats.get("COLARRAY.list.element").getNumberOfValues()).isEqualTo(4);
+    assertThat(columnEpStats.get("COLARRAY.list.element").getNumberOfValues()).isEqualTo(5);
   }
 
   private static Thread getThreadThatWaitsForLockReleaseAndFlushes(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
@@ -46,6 +46,8 @@ public class IcebergStructuredIT extends AbstractDataTypeTest {
         "object(a int, b string, c boolean)", "{\"a\": 1, \"b\": \"test\", \"c\": true}");
     assertStructuredDataType("map(string, int)", "{\"key1\": 1}");
     assertStructuredDataType("array(int)", "[1, 2, 3]");
+    assertStructuredDataType("array(string) not null", "[]");
+    assertStructuredDataType("map(string, int) not null", "{}");
     assertMap(
         "map(string, int)",
         new HashMap<String, Integer>() {
@@ -95,59 +97,28 @@ public class IcebergStructuredIT extends AbstractDataTypeTest {
         .isInstanceOf(SFException.class)
         .extracting("vendorCode")
         .isEqualTo(ErrorCode.INVALID_FORMAT_ROW.getMessageCode());
+  }
 
-    /* Nested data types. Should be fixed. Fixed in server side. */
-    Assertions.assertThatThrownBy(
-            () -> assertStructuredDataType("array(array(int))", "[[1, 2], [3, 4]]"))
-        .isInstanceOf(SFException.class);
-    Assertions.assertThatThrownBy(
-            () ->
-                assertStructuredDataType(
-                    "array(map(string, int))", "[{\"key1\": 1}, {\"key2\": 2}]"))
-        .isInstanceOf(SFException.class);
-    Assertions.assertThatThrownBy(
-            () ->
-                assertStructuredDataType(
-                    "array(object(a int, b string, c boolean))",
-                    "[{\"a\": 1, \"b\": \"test\", \"c\": true}]"))
-        .isInstanceOf(SFException.class);
-    Assertions.assertThatThrownBy(
-            () ->
-                assertStructuredDataType(
-                    "map(string, object(a int, b string, c boolean))",
-                    "{\"key1\": {\"a\": 1, \"b\": \"test\", \"c\": true}}"))
-        .isInstanceOf(SFException.class);
-    Assertions.assertThatThrownBy(
-            () -> assertStructuredDataType("map(string, array(int))", "{\"key1\": [1, 2, 3]}"))
-        .isInstanceOf(SFException.class);
-    Assertions.assertThatThrownBy(
-            () ->
-                assertStructuredDataType(
-                    "map(string, map(string, int))", "{\"key1\": {\"key2\": 2}}"))
-        .isInstanceOf(SFException.class);
-    Assertions.assertThatThrownBy(
-            () ->
-                assertStructuredDataType(
-                    "map(string, array(array(int)))", "{\"key1\": [[1, 2], [3, 4]]}"))
-        .isInstanceOf(SFException.class);
-    Assertions.assertThatThrownBy(
-            () ->
-                assertStructuredDataType(
-                    "map(string, array(map(string, int)))",
-                    "{\"key1\": [{\"key2\": 2}, {\"key3\": 3}]}"))
-        .isInstanceOf(SFException.class);
-    Assertions.assertThatThrownBy(
-            () ->
-                assertStructuredDataType(
-                    "map(string, array(object(a int, b string, c boolean)))",
-                    "{\"key1\": [{\"a\": 1, \"b\": \"test\", \"c\": true}]}"))
-        .isInstanceOf(SFException.class);
-    Assertions.assertThatThrownBy(
-            () ->
-                assertStructuredDataType(
-                    "object(a int, b array(int), c map(string, int))",
-                    "{\"a\": 1, \"b\": [1, 2, 3], \"c\": {\"key1\": 1}}"))
-        .isInstanceOf(SFException.class);
+  @Test
+  public void testNestedDataType() throws Exception {
+    assertStructuredDataType("array(array(int))", "[[1, 2], [3, 4]]");
+    assertStructuredDataType("array(map(string, int))", "[{\"key1\": 1}, {\"key2\": 2}]");
+    assertStructuredDataType(
+        "array(object(a int, b string, c boolean))", "[{\"a\": 1, \"b\": \"test\", \"c\": true}]");
+    assertStructuredDataType(
+        "map(string, object(a int, b string, c boolean))",
+        "{\"key1\": {\"a\": 1, \"b\": \"test\", \"c\": true}}");
+    assertStructuredDataType("map(string, array(int))", "{\"key1\": [1, 2, 3]}");
+    assertStructuredDataType("map(string, map(string, int))", "{\"key1\": {\"key2\": 2}}");
+    assertStructuredDataType("map(string, array(array(int)))", "{\"key1\": [[1, 2], [3, 4]]}");
+    assertStructuredDataType(
+        "map(string, array(map(string, int)))", "{\"key1\": [{\"key2\": 2}, {\"key3\": 3}]}");
+    assertStructuredDataType(
+        "map(string, array(object(a int, b string, c boolean)))",
+        "{\"key1\": [{\"a\": 1, \"b\": \"test\", \"c\": true}]}");
+    assertStructuredDataType(
+        "object(a int, b array(int), c map(string, int))",
+        "{\"a\": 1, \"b\": [1, 2, 3], \"c\": {\"key1\": 1}}");
   }
 
   private void assertStructuredDataType(String dataType, String value) throws Exception {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
@@ -101,6 +101,8 @@ public class IcebergStructuredIT extends AbstractDataTypeTest {
 
   @Test
   public void testNestedDataType() throws Exception {
+    assertStructuredDataType("map(string, map(string, object(a int, b string)))", "{}");
+    assertStructuredDataType("array(map(string, int))", "[{}]");
     assertStructuredDataType("array(array(int))", "[[1, 2], [3, 4]]");
     assertStructuredDataType("array(map(string, int))", "[{\"key1\": 1}, {\"key2\": 2}]");
     assertStructuredDataType(


### PR DESCRIPTION
This PR includes following changes:
1. Fix empty list & map ingestion.
2. Added test for empty list & map. 
3. Removed assert exception for nested type as the EP key fix should be available on prepod now.