### PR TITLE
Add enableIcebergStreaming to telemetry calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -651,12 +651,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -130,6 +130,7 @@ public class RequestBuilder {
    * @param userName - the username of the entity loading files
    * @param credential - the credential we'll use to authenticate
    */
+  @Deprecated
   public RequestBuilder(String accountName, String userName, Object credential) {
     this(
         accountName, userName, credential, DEFAULT_SCHEME, DEFAULT_HOST_SUFFIX, DEFAULT_PORT, null);
@@ -143,6 +144,7 @@ public class RequestBuilder {
    * @param credential - the credential we'll use to authenticate
    * @param userAgentSuffix - The suffix part of HTTP Header User-Agent
    */
+  @Deprecated
   public RequestBuilder(
       String accountName,
       String userName,
@@ -164,6 +166,7 @@ public class RequestBuilder {
    * @param hostName - the host for this snowflake instance
    * @param portNum - the port number
    */
+  @Deprecated
   public RequestBuilder(
       String accountName,
       String userName,
@@ -185,6 +188,7 @@ public class RequestBuilder {
    * @param portNum - the port number
    * @param userAgentSuffix - The suffix part of HTTP Header User-Agent
    */
+  @Deprecated
   public RequestBuilder(
       String accountName,
       String userName,
@@ -201,9 +205,10 @@ public class RequestBuilder {
         hostName,
         portNum,
         userAgentSuffix,
-        null,
-        null,
-        null);
+        null /* securityManager */,
+        null /* httpClient */,
+        false /* enableIcebergStreaming */,
+        null /* clientName */);
   }
 
   /**
@@ -213,6 +218,7 @@ public class RequestBuilder {
    * @param userName - the username of the entity loading files
    * @param credential - the credential we'll use to authenticate
    * @param httpClient - reference to the http client
+   * @param enableIcebergStreaming whether the client is running in iceberg mode
    * @param clientName - name of the client, used to uniquely identify a client if used
    */
   public RequestBuilder(
@@ -220,6 +226,7 @@ public class RequestBuilder {
       String userName,
       Object credential,
       CloseableHttpClient httpClient,
+      boolean enableIcebergStreaming,
       String clientName) {
     this(
         url.getAccount(),
@@ -228,9 +235,10 @@ public class RequestBuilder {
         url.getScheme(),
         url.getUrlWithoutPort(),
         url.getPort(),
-        null,
-        null,
+        null /* userAgentSuffix */,
+        null /* securityManager */,
         httpClient,
+        enableIcebergStreaming,
         clientName);
   }
 
@@ -246,6 +254,7 @@ public class RequestBuilder {
    * @param userAgentSuffix - The suffix part of HTTP Header User-Agent
    * @param securityManager - The security manager for authentication
    * @param httpClient - reference to the http client
+   * @param enableIcebergStreaming whether the client is running in iceberg mode
    * @param clientName - name of the client, used to uniquely identify a client if used
    */
   public RequestBuilder(
@@ -258,6 +267,7 @@ public class RequestBuilder {
       String userAgentSuffix,
       SecurityManager securityManager,
       CloseableHttpClient httpClient,
+      boolean enableIcebergStreaming,
       String clientName) {
     // none of these arguments should be null
     if (accountName == null || userName == null || credential == null) {
@@ -269,7 +279,10 @@ public class RequestBuilder {
     this.telemetryService =
         ENABLE_TELEMETRY_TO_SF && credential instanceof KeyPair
             ? new TelemetryService(
-                httpClient, clientName, schemeName + "://" + hostName + ":" + portNum)
+                httpClient,
+                enableIcebergStreaming,
+                clientName,
+                schemeName + "://" + hostName + ":" + portNum)
             : null;
 
     // stash references to the account and username as well

--- a/src/main/java/net/snowflake/ingest/connection/TelemetryService.java
+++ b/src/main/java/net/snowflake/ingest/connection/TelemetryService.java
@@ -26,6 +26,8 @@ import net.snowflake.ingest.utils.Logging;
  * telemetry API
  */
 public class TelemetryService {
+  private final String enableIcebergStreaming;
+
   // Enum for different client telemetries
   enum TelemetryType {
     STREAMING_INGEST_LATENCY_IN_SEC("streaming_ingest_latency_in_ms"),
@@ -51,6 +53,7 @@ public class TelemetryService {
 
   private static final String TYPE = "type";
   private static final String CLIENT_NAME = "client_name";
+  private static final String ENABLE_ICEBERG_STREAMING = "enable_iceberg_streaming";
   private static final String COUNT = "count";
   private static final String MAX = "max";
   private static final String MIN = "min";
@@ -65,11 +68,17 @@ public class TelemetryService {
    * Default constructor
    *
    * @param httpClient http client
+   * @param enableIcebergStreaming whether the ingestion client is running in iceberg mode
    * @param clientName name of the client
    * @param url account url
    */
-  TelemetryService(CloseableHttpClient httpClient, String clientName, String url) {
+  TelemetryService(
+      CloseableHttpClient httpClient,
+      boolean enableIcebergStreaming,
+      String clientName,
+      String url) {
     this.clientName = clientName;
+    this.enableIcebergStreaming = String.valueOf(enableIcebergStreaming);
     this.telemetry = (TelemetryClient) TelemetryClient.createSessionlessTelemetry(httpClient, url);
     this.rateLimitersMap = new HashMap<>();
   }
@@ -157,6 +166,7 @@ public class TelemetryService {
     try {
       msg.put(TYPE, type.toString());
       msg.put(CLIENT_NAME, clientName);
+      msg.put(ENABLE_ICEBERG_STREAMING, enableIcebergStreaming);
       telemetry.addLogToBatch(TelemetryUtil.buildJobData(msg));
     } catch (Exception e) {
       logger.logWarn("Failed to send telemetry data, error: {}", e.getMessage());

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -219,6 +219,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
               prop.get(USER).toString(),
               credential,
               this.httpClient,
+              parameterProvider.isEnableIcebergStreaming(),
               String.format("%s_%s", this.name, System.currentTimeMillis()));
 
       logger.logInfo("Using {} for authorization", this.requestBuilder.getAuthType());

--- a/src/test/java/net/snowflake/ingest/connection/TelemetryServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/connection/TelemetryServiceTest.java
@@ -6,16 +6,33 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.mockito.Mockito;
 
+@RunWith(Parameterized.class)
 public class TelemetryServiceTest {
+  @Parameters(name = "{index}: {0}")
+  public static Object[] icebergStreamingModes() {
+    return new Object[] {false};
+  }
+  ;
+
+  @Parameter public boolean enableIcebergStreaming;
+
   @Test
   public void testReportLatencyInSec() {
     CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
 
     TelemetryService telemetryService =
         Mockito.spy(
-            new TelemetryService(httpClient, "testReportLatencyInSec", "snowflake.dev.local:8082"));
+            new TelemetryService(
+                httpClient,
+                enableIcebergStreaming,
+                "testReportLatencyInSec",
+                "snowflake.dev.local:8082"));
     Mockito.doNothing().when(telemetryService).send(Mockito.any(), Mockito.any());
     MetricRegistry metrics = new MetricRegistry();
     Timer flushLatency = metrics.timer(MetricRegistry.name("latency", "flush"));
@@ -34,7 +51,10 @@ public class TelemetryServiceTest {
     TelemetryService telemetryService =
         Mockito.spy(
             new TelemetryService(
-                httpClient, "testReportClientFailure", "snowflake.dev.local:8082"));
+                httpClient,
+                enableIcebergStreaming,
+                "testReportClientFailure",
+                "snowflake.dev.local:8082"));
     Mockito.doNothing().when(telemetryService).send(Mockito.any(), Mockito.any());
 
     // Make sure there is no exception thrown
@@ -48,7 +68,10 @@ public class TelemetryServiceTest {
     TelemetryService telemetryService =
         Mockito.spy(
             new TelemetryService(
-                httpClient, "testReportThroughputBytesPerSecond", "snowflake.dev.local:8082"));
+                httpClient,
+                enableIcebergStreaming,
+                "testReportThroughputBytesPerSecond",
+                "snowflake.dev.local:8082"));
     Mockito.doNothing().when(telemetryService).send(Mockito.any(), Mockito.any());
     MetricRegistry metrics = new MetricRegistry();
     Meter uploadThroughput = metrics.meter(MetricRegistry.name("throughput", "upload"));
@@ -65,7 +88,10 @@ public class TelemetryServiceTest {
     TelemetryService telemetryService =
         Mockito.spy(
             new TelemetryService(
-                httpClient, "testReportCpuMemoryUsage", "snowflake.dev.local:8082"));
+                httpClient,
+                enableIcebergStreaming,
+                "testReportCpuMemoryUsage",
+                "snowflake.dev.local:8082"));
     Mockito.doNothing().when(telemetryService).send(Mockito.any(), Mockito.any());
     MetricRegistry metrics = new MetricRegistry();
     Histogram cpuHistogram = metrics.histogram(MetricRegistry.name("cpu", "usage", "histogram"));
@@ -81,7 +107,10 @@ public class TelemetryServiceTest {
     TelemetryService telemetryService =
         Mockito.spy(
             new TelemetryService(
-                httpClient, "testReportClientFailure", "snowflake.dev.local:8082"));
+                httpClient,
+                enableIcebergStreaming,
+                "testReportClientFailure",
+                "snowflake.dev.local:8082"));
     Mockito.doNothing().when(telemetryService).send(Mockito.any(), Mockito.any());
 
     // Make sure there is no exception thrown

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ChannelCacheTest.java
@@ -46,7 +46,8 @@ public class ChannelCacheTest {
   public void setup() {
     cache = new ChannelCache<>();
     CloseableHttpClient httpClient = MockSnowflakeServiceClient.createHttpClient();
-    RequestBuilder requestBuilder = MockSnowflakeServiceClient.createRequestBuilder(httpClient);
+    RequestBuilder requestBuilder =
+        MockSnowflakeServiceClient.createRequestBuilder(httpClient, enableIcebergStreaming);
     Properties prop = new Properties();
     prop.setProperty(
         ParameterProvider.ENABLE_ICEBERG_STREAMING, String.valueOf(enableIcebergStreaming));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -118,7 +118,7 @@ public class FlushServiceTest {
           Mockito.spy(
               enableIcebergStreaming
                   ? new SubscopedTokenExternalVolumeManager(
-                      "role", "client", MockSnowflakeServiceClient.create())
+                      "role", "client", MockSnowflakeServiceClient.create(enableIcebergStreaming))
                   : new InternalStageManager(true, "role", "client", null));
       Mockito.doReturn(storage).when(storageManager).getStorage(ArgumentMatchers.any());
       Mockito.when(storageManager.getClientPrefix()).thenReturn("client_prefix");

--- a/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/InsertRowsBenchmarkTest.java
@@ -56,7 +56,8 @@ public class InsertRowsBenchmarkTest {
   public void setUpBeforeAll() {
     // SNOW-1490151: Testing gaps
     CloseableHttpClient httpClient = MockSnowflakeServiceClient.createHttpClient();
-    RequestBuilder requestBuilder = MockSnowflakeServiceClient.createRequestBuilder(httpClient);
+    RequestBuilder requestBuilder =
+        MockSnowflakeServiceClient.createRequestBuilder(httpClient, enableIcebergStreaming);
     Properties prop = new Properties();
     prop.setProperty(
         ParameterProvider.ENABLE_ICEBERG_STREAMING, String.valueOf(enableIcebergStreaming));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/MockSnowflakeServiceClient.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/MockSnowflakeServiceClient.java
@@ -64,17 +64,18 @@ public class MockSnowflakeServiceClient {
     }
   }
 
-  public static SnowflakeServiceClient create() {
+  public static SnowflakeServiceClient create(boolean enableIcebergStreaming) {
     try {
       CloseableHttpClient httpClient = createHttpClient(new ApiOverride());
-      RequestBuilder requestBuilder = createRequestBuilder(httpClient);
+      RequestBuilder requestBuilder = createRequestBuilder(httpClient, enableIcebergStreaming);
       return new SnowflakeServiceClient(httpClient, requestBuilder);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
 
-  public static RequestBuilder createRequestBuilder(CloseableHttpClient httpClient) {
+  public static RequestBuilder createRequestBuilder(
+      CloseableHttpClient httpClient, boolean enableIcebergStreaming) {
     try {
       return new RequestBuilder(
           "test_host",
@@ -86,6 +87,7 @@ public class MockSnowflakeServiceClient {
           null,
           null,
           httpClient,
+          enableIcebergStreaming,
           "mock_client");
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/OAuthBasicTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/OAuthBasicTest.java
@@ -17,12 +17,25 @@ import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 /**
  * This test only contains basic construction of client using OAuth authentication. Further
  * integration test would be added in dew.
  */
+@RunWith(Parameterized.class)
 public class OAuthBasicTest {
+
+  @Parameters(name = "{index}: {0}")
+  public static Object[] icebergStreamingModes() {
+    return new Object[] {false};
+  }
+  ;
+
+  @Parameter public boolean enableIcebergStreaming;
 
   /** Create client with invalid authorization type, this should fail. */
   @Test
@@ -135,6 +148,7 @@ public class OAuthBasicTest {
             null,
             oAuthManager,
             null,
+            enableIcebergStreaming,
             null);
     client.injectRequestBuilder(requestBuilder);
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
@@ -42,7 +42,8 @@ public class RegisterServiceTest {
   @Before
   public void setup() {
     CloseableHttpClient httpClient = MockSnowflakeServiceClient.createHttpClient();
-    RequestBuilder requestBuilder = MockSnowflakeServiceClient.createRequestBuilder(httpClient);
+    RequestBuilder requestBuilder =
+        MockSnowflakeServiceClient.createRequestBuilder(httpClient, enableIcebergStreaming);
     Properties prop = new Properties();
     prop.setProperty(
         ParameterProvider.ENABLE_ICEBERG_STREAMING, String.valueOf(enableIcebergStreaming));

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeServiceClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeServiceClientTest.java
@@ -25,7 +25,7 @@ public class SnowflakeServiceClientTest {
 
   @Before
   public void setUp() {
-    snowflakeServiceClient = MockSnowflakeServiceClient.create();
+    snowflakeServiceClient = MockSnowflakeServiceClient.create(enableIcebergStreaming);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -94,7 +94,8 @@ public class SnowflakeStreamingIngestChannelTest {
   public void setup() {
     apiOverride = new MockSnowflakeServiceClient.ApiOverride();
     CloseableHttpClient httpClient = MockSnowflakeServiceClient.createHttpClient(apiOverride);
-    RequestBuilder requestBuilder = MockSnowflakeServiceClient.createRequestBuilder(httpClient);
+    RequestBuilder requestBuilder =
+        MockSnowflakeServiceClient.createRequestBuilder(httpClient, enableIcebergStreaming);
     client =
         new SnowflakeStreamingIngestClientInternal<>(
             "client",
@@ -340,7 +341,8 @@ public class SnowflakeStreamingIngestChannelTest {
         Utils.createKeyPairFromPrivateKey(
             (PrivateKey) prop.get(SFSessionProperty.PRIVATE_KEY.getPropertyKey()));
     RequestBuilder requestBuilder =
-        new RequestBuilder(url, prop.get(USER).toString(), keyPair, null, null);
+        new RequestBuilder(
+            url, prop.get(USER).toString(), keyPair, null, enableIcebergStreaming, null);
 
     Map<Object, Object> payload = new HashMap<>();
     payload.put("channel", "CHANNEL");

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -117,7 +117,9 @@ public class SnowflakeStreamingIngestClientTest {
 
     apiOverride = new MockSnowflakeServiceClient.ApiOverride();
     CloseableHttpClient httpClient = MockSnowflakeServiceClient.createHttpClient(apiOverride);
-    requestBuilder = Mockito.spy(MockSnowflakeServiceClient.createRequestBuilder(httpClient));
+    requestBuilder =
+        Mockito.spy(
+            MockSnowflakeServiceClient.createRequestBuilder(httpClient, enableIcebergStreaming));
     client =
         new SnowflakeStreamingIngestClientInternal<>(
             "client",
@@ -476,7 +478,8 @@ public class SnowflakeStreamingIngestClientTest {
             (PrivateKey) prop.get(SFSessionProperty.PRIVATE_KEY.getPropertyKey()));
     CloseableHttpClient httpClient = MockSnowflakeServiceClient.createHttpClient();
     RequestBuilder requestBuilder =
-        new RequestBuilder(url, prop.get(USER).toString(), keyPair, httpClient, null);
+        new RequestBuilder(
+            url, prop.get(USER).toString(), keyPair, httpClient, enableIcebergStreaming, null);
 
     SnowflakeStreamingIngestClientInternal<?> client =
         new SnowflakeStreamingIngestClientInternal<>(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -77,6 +77,14 @@ public class StreamingIngestIT {
   private String testDb;
 
   @Parameters(name = "{index}: {0}")
+  public static Object[] icebergStreamingModes() {
+    return new Object[] {false};
+  }
+  ;
+
+  @Parameter public boolean enableIcebergStreaming;
+
+  @Parameters(name = "{index}: {0}")
   public static Object[] compressionAlgorithms() {
     return new Object[] {"GZIP", "ZSTD"};
   }
@@ -163,6 +171,7 @@ public class StreamingIngestIT {
                 TestUtils.getUser(),
                 TestUtils.getKeyPair(),
                 HttpUtil.getHttpClient(url.getAccount()),
+                enableIcebergStreaming,
                 "testrequestbuilder"));
     client.injectRequestBuilder(requestBuilder);
 
@@ -249,6 +258,7 @@ public class StreamingIngestIT {
                 TestUtils.getUser(),
                 TestUtils.getKeyPair(),
                 HttpUtil.getHttpClient(url.getAccount()),
+                enableIcebergStreaming,
                 "testrequestbuilder"));
     client.injectRequestBuilder(requestBuilder);
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestIT.java
@@ -6,8 +6,7 @@ import static net.snowflake.ingest.utils.Constants.DROP_CHANNEL_ENDPOINT;
 import static net.snowflake.ingest.utils.Constants.REGISTER_BLOB_ENDPOINT;
 import static net.snowflake.ingest.utils.Constants.USER;
 import static net.snowflake.ingest.utils.ParameterProvider.BDEC_PARQUET_COMPRESSION_ALGORITHM;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.atLeastOnce;
 
 import java.math.BigDecimal;
@@ -76,20 +75,17 @@ public class StreamingIngestIT {
   private Connection jdbcConnection;
   private String testDb;
 
-  @Parameters(name = "{index}: {0}")
-  public static Object[] icebergStreamingModes() {
-    return new Object[] {false};
-  }
-  ;
-
-  @Parameter public boolean enableIcebergStreaming;
-
-  @Parameters(name = "{index}: {0}")
-  public static Object[] compressionAlgorithms() {
-    return new Object[] {"GZIP", "ZSTD"};
+  @Parameters
+  public static Iterable<Object[]> getParameterPermutations() {
+    return Arrays.asList(
+        new Object[][] {{"GZIP", false}, {"ZSTD", false}, {"GZIP", true}, {"ZSTD", true}});
   }
 
-  @Parameter public String compressionAlgorithm;
+  @Parameter(0)
+  public String compressionAlgorithm;
+
+  @Parameter(1)
+  public boolean enableIcebergStreaming;
 
   private static final OffsetTokenVerificationFunction offsetTokenVerificationFunction =
       (prevBatchEndOffset, curBatchStartOffset, curBatchEndOffset, rowCount) -> {
@@ -1493,11 +1489,12 @@ public class StreamingIngestIT {
         for (int col : columnIndexes) {
           String value = result.getString("C" + col);
           String expectedValue = String.format(valueFormat, col, startIndex + i);
-          String errorMessage =
-              String.format(
-                  "Ingested value mismatch: table %s, startIndex %d, column %s, index %d",
-                  tableName, startIndex, "c" + col, i);
-          assertThat(errorMessage, value, is(expectedValue));
+
+          assertThat(value)
+              .describedAs(
+                  "Ingested value mismatch for table %s, startIndex %d, column c%d, index %d",
+                  tableName, startIndex, col, i)
+              .isEqualTo(expectedValue);
         }
       }
     }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtilsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtilsIT.java
@@ -54,6 +54,7 @@ public class StreamingIngestUtilsIT {
                 "testJWTRetries",
                 spyManager,
                 httpClient,
+                false /* enableIcebergMode */,
                 "testJWTRetries"));
 
     // build payload

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SubscopedTokenExternalVolumeManagerTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SubscopedTokenExternalVolumeManagerTest.java
@@ -37,7 +37,9 @@ public class SubscopedTokenExternalVolumeManagerTest {
   public void setup() {
     this.manager =
         new SubscopedTokenExternalVolumeManager(
-            "role", "clientName", MockSnowflakeServiceClient.create());
+            "role",
+            "clientName",
+            MockSnowflakeServiceClient.create(true /* enableIcebergStreaming */));
   }
 
   @After


### PR DESCRIPTION
adding the enableIcebergStreaming boolean flag to all telemetry service calls done by the SDK.
Marking many of the RequestBuilder ctors as Deprecated.