### PR TITLE
Enhance error messages in the SDK

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -627,8 +627,8 @@ class DataValidationUtil {
           ErrorCode.INVALID_VALUE_ROW,
           String.format(
               "Timestamp out of representable inclusive range of years between 1 and 9999,"
-                  + " rowIndex:%d",
-              insertRowIndex));
+                  + " rowIndex:%d, column:%s, value:%s",
+              insertRowIndex, columnName, offsetDateTime));
     }
     return new TimestampWrapper(offsetDateTime, scale);
   }
@@ -767,8 +767,8 @@ class DataValidationUtil {
           ErrorCode.INVALID_VALUE_ROW,
           String.format(
               "Date out of representable inclusive range of years between -9999 and 9999,"
-                  + " rowIndex:%d",
-              insertRowIndex));
+                  + " rowIndex:%d, column:%s, value:%s",
+              insertRowIndex, columnName, offsetDateTime));
     }
 
     return Math.toIntExact(offsetDateTime.toLocalDate().toEpochDay());
@@ -989,8 +989,8 @@ class DataValidationUtil {
           ErrorCode.INVALID_VALUE_ROW,
           String.format(
               "Number out of representable inclusive range of integers between %d and %d,"
-                  + " rowIndex:%d",
-              Integer.MIN_VALUE, Integer.MAX_VALUE, insertRowIndex));
+                  + " rowIndex:%d, column:%s, value:%s",
+              Integer.MIN_VALUE, Integer.MAX_VALUE, insertRowIndex, columnName, input));
     }
   }
 
@@ -1019,8 +1019,8 @@ class DataValidationUtil {
           ErrorCode.INVALID_VALUE_ROW,
           String.format(
               "Number out of representable inclusive range of integers between %d and %d,"
-                  + " rowIndex:%d",
-              Long.MIN_VALUE, Long.MAX_VALUE, insertRowIndex));
+                  + " rowIndex:%d, column:%s, value:%s",
+              Long.MIN_VALUE, Long.MAX_VALUE, insertRowIndex, columnName, input));
     }
   }
 
@@ -1082,8 +1082,9 @@ class DataValidationUtil {
         throw new SFException(
             ErrorCode.INVALID_FORMAT_ROW,
             String.format(
-                "Field name of struct %s must be of type String, rowIndex:%d",
-                columnName, insertRowIndex));
+                "Field name of struct typed column must be of type String, but found %s."
+                    + " rowIndex:%d, column:%s",
+                key.getClass().getName(), insertRowIndex, columnName));
       }
     }
 
@@ -1133,7 +1134,11 @@ class DataValidationUtil {
   }
 
   static void checkValueInRange(
-      BigDecimal bigDecimalValue, int scale, int precision, final long insertRowIndex) {
+      String columnName,
+      BigDecimal bigDecimalValue,
+      int scale,
+      int precision,
+      final long insertRowIndex) {
     BigDecimal comparand =
         (precision >= scale) && (precision - scale) < POWER_10.length
             ? POWER_10[precision - scale]
@@ -1142,18 +1147,20 @@ class DataValidationUtil {
       throw new SFException(
           ErrorCode.INVALID_FORMAT_ROW,
           String.format(
-              "Number out of representable exclusive range of (-1e%s..1e%s), rowIndex:%d",
-              precision - scale, precision - scale, insertRowIndex));
+              "Number out of representable exclusive range of (-1e%s..1e%s), rowIndex:%d,"
+                  + " column:%s, value:%s",
+              precision - scale, precision - scale, insertRowIndex, columnName, bigDecimalValue));
     }
   }
 
-  static void checkFixedLengthByteArray(byte[] bytes, int length, final long insertRowIndex) {
+  static void checkFixedLengthByteArray(
+      String columnName, byte[] bytes, int length, final long insertRowIndex) {
     if (bytes.length != length) {
       throw new SFException(
           ErrorCode.INVALID_VALUE_ROW,
           String.format(
-              "Binary length mismatch: expected=%d, actual=%d, rowIndex:%d",
-              length, bytes.length, insertRowIndex));
+              "Binary length mismatch: expected:%d, actual:%d, rowIndex:%d, column:%s",
+              length, bytes.length, insertRowIndex, columnName));
     }
   }
 
@@ -1219,9 +1226,9 @@ class DataValidationUtil {
     return new SFException(
         ErrorCode.INVALID_VALUE_ROW,
         String.format(
-            "Value cannot be ingested into Snowflake column %s of type %s, rowIndex:%d, reason:"
-                + " %s",
-            columnName, snowflakeType, rowIndex, reason));
+            "Value cannot be ingested into Snowflake column %s of type %s, rowIndex:%d, column:%s,"
+                + " reason:%s",
+            columnName, snowflakeType, rowIndex, columnName, reason));
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -1226,9 +1226,8 @@ class DataValidationUtil {
     return new SFException(
         ErrorCode.INVALID_VALUE_ROW,
         String.format(
-            "Value cannot be ingested into Snowflake column %s of type %s, rowIndex:%d, column:%s,"
-                + " reason:%s",
-            columnName, snowflakeType, rowIndex, columnName, reason));
+            "Value cannot be ingested into Snowflake column %s of type %s, rowIndex:%d, reason: %s",
+            columnName, snowflakeType, rowIndex, reason));
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java
@@ -65,7 +65,10 @@ public class ParquetTypeGenerator {
         logicalType = AbstractRowBuffer.ColumnLogicalType.valueOf(column.getLogicalType());
       } catch (IllegalArgumentException e) {
         throw new SFException(
-            ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
+            ErrorCode.UNKNOWN_DATA_TYPE,
+            column.getName(),
+            column.getLogicalType(),
+            column.getPhysicalType());
       }
 
       metadata.put(
@@ -137,7 +140,10 @@ public class ParquetTypeGenerator {
           break;
         default:
           throw new SFException(
-              ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
+              ErrorCode.UNKNOWN_DATA_TYPE,
+              column.getName(),
+              column.getLogicalType(),
+              column.getPhysicalType());
       }
     }
     return new ParquetTypeInfo(parquetType, metadata);
@@ -196,7 +202,10 @@ public class ParquetTypeGenerator {
           break;
         default:
           throw new SFException(
-              ErrorCode.UNKNOWN_DATA_TYPE, column.getLogicalType(), column.getPhysicalType());
+              ErrorCode.UNKNOWN_DATA_TYPE,
+              column.getName(),
+              column.getLogicalType(),
+              column.getPhysicalType());
       }
     }
     return parquetType;
@@ -225,7 +234,9 @@ public class ParquetTypeGenerator {
     if (scale == null || scale > 9 || scale < 0 || !supportedPhysicalTypes.contains(physicalType)) {
       throw new SFException(
           ErrorCode.UNKNOWN_DATA_TYPE,
-          "Data type: " + logicalType + ", " + physicalType + ", scale: " + scale);
+          name,
+          String.format("%s(%d)", logicalType, scale),
+          physicalType);
     }
 
     PrimitiveType.PrimitiveTypeName type = getTimePrimitiveType(physicalType);
@@ -245,7 +256,7 @@ public class ParquetTypeGenerator {
         length = 16;
         break;
       default:
-        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
+        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, name, logicalType, physicalType);
     }
     return Types.primitive(type, repetition).as(typeAnnotation).length(length).id(id).named(name);
   }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeParquetValueParser.java
@@ -128,7 +128,8 @@ class SnowflakeParquetValueParser {
           estimatedParquetSize += 16;
           break;
         default:
-          throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
+          throw new SFException(
+              ErrorCode.UNKNOWN_DATA_TYPE, columnMetadata.getName(), logicalType, physicalType);
       }
     }
 
@@ -137,7 +138,7 @@ class SnowflakeParquetValueParser {
         throw new SFException(
             ErrorCode.INVALID_FORMAT_ROW,
             columnMetadata.getName(),
-            "Passed null to non nullable field");
+            String.format("Passed null to non nullable field, rowIndex:%d", insertRowsCurrIndex));
       }
       stats.incCurrentNullCount();
     }
@@ -180,11 +181,11 @@ class SnowflakeParquetValueParser {
             DataValidationUtil.validateAndParseBigDecimal(columnName, value, insertRowsCurrIndex);
         bigDecimalValue = bigDecimalValue.setScale(scale, RoundingMode.HALF_UP);
         DataValidationUtil.checkValueInRange(
-            bigDecimalValue, scale, precision, insertRowsCurrIndex);
+            columnName, bigDecimalValue, scale, precision, insertRowsCurrIndex);
         intVal = bigDecimalValue.intValue();
         break;
       default:
-        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
+        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, columnName, logicalType, physicalType);
     }
     return intVal;
   }
@@ -237,11 +238,11 @@ class SnowflakeParquetValueParser {
             DataValidationUtil.validateAndParseBigDecimal(columnName, value, insertRowsCurrIndex);
         bigDecimalValue = bigDecimalValue.setScale(scale, RoundingMode.HALF_UP);
         DataValidationUtil.checkValueInRange(
-            bigDecimalValue, scale, precision, insertRowsCurrIndex);
+            columnName, bigDecimalValue, scale, precision, insertRowsCurrIndex);
         longValue = bigDecimalValue.longValue();
         break;
       default:
-        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
+        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, columnName, logicalType, physicalType);
     }
     return longValue;
   }
@@ -282,10 +283,10 @@ class SnowflakeParquetValueParser {
         // explicitly match the BigDecimal input scale with the Snowflake data type scale
         bigDecimalValue = bigDecimalValue.setScale(scale, RoundingMode.HALF_UP);
         DataValidationUtil.checkValueInRange(
-            bigDecimalValue, scale, precision, insertRowsCurrIndex);
+            columnName, bigDecimalValue, scale, precision, insertRowsCurrIndex);
         return bigDecimalValue.unscaledValue();
       default:
-        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, logicalType, physicalType);
+        throw new SFException(ErrorCode.UNKNOWN_DATA_TYPE, columnName, logicalType, physicalType);
     }
   }
 
@@ -352,7 +353,10 @@ class SnowflakeParquetValueParser {
           break;
         default:
           throw new SFException(
-              ErrorCode.UNKNOWN_DATA_TYPE, logicalType, columnMetadata.getPhysicalType());
+              ErrorCode.UNKNOWN_DATA_TYPE,
+              columnMetadata.getName(),
+              logicalType,
+              columnMetadata.getPhysicalType());
       }
     } else {
       String maxLengthString = columnMetadata.getLength().toString();

--- a/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
+++ b/src/main/resources/net/snowflake/ingest/ingest_error_messages.properties
@@ -11,7 +11,7 @@
 0002=Required value is null, Key: {0}.
 0003=Required value is empty, Key: {0}.
 0004=The given row cannot be converted to the internal format: {0}. {1}
-0005=Unknown data type for logical: {0}, physical: {1}.
+0005=Unknown data type for column: {0}. logical: {1}, physical: {2}.
 0006=Register blob request failed: {0}.
 0007=Open channel request failed: {0}.
 0008=Failed to construct HTTP request: {0}.

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeParquetValueParserTest.java
@@ -510,7 +510,8 @@ public class SnowflakeParquetValueParserTest {
                     0,
                     ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT));
     Assert.assertEquals(
-        "Unknown data type for logical: TIMESTAMP_NTZ, physical: SB4.", exception.getMessage());
+        "Unknown data type for column: testCol. logical: TIMESTAMP_NTZ, physical: SB4.",
+        exception.getMessage());
   }
 
   @Test
@@ -694,6 +695,7 @@ public class SnowflakeParquetValueParserTest {
                     0,
                     ParameterProvider.ENABLE_NEW_JSON_PARSING_LOGIC_DEFAULT));
     Assert.assertEquals(
-        "Unknown data type for logical: TIME, physical: SB16.", exception.getMessage());
+        "Unknown data type for column: testCol. logical: TIME, physical: SB16.",
+        exception.getMessage());
   }
 }


### PR DESCRIPTION
Many of the data validation error messages were lacking information around (a) which column the offending value was in, and (b) what was the offending value.

Took a pass at all the validation errors (INVALID_VALUE_ROW, INVALID_FORMAT_ROW, UNKNOWN_DATA_TYPE) and fixed them up.