### PR TITLE
Schema evolution test for Iceberg ingestion

### DIFF
--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -6,6 +6,7 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.math.BigDecimal;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/AbstractDataTypeTest.java
@@ -4,6 +4,7 @@
 
 package net.snowflake.ingest.streaming.internal.datatypes;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -16,8 +17,12 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
 import net.snowflake.ingest.TestUtils;
@@ -124,6 +129,19 @@ public abstract class AbstractDataTypeTest {
                 VALUE_COLUMN_NAME,
                 dataType,
                 getIcebergTableConfig(tableName)));
+
+    return tableName;
+  }
+
+  protected String createIcebergTableWithColumns(String columns) throws SQLException {
+    String tableName = getRandomIdentifier();
+    String baseLocation =
+        String.format("SDK_IT/%s/%s/%s", databaseName, columns.replace(" ", "_"), tableName);
+    conn.createStatement()
+        .execute(
+            String.format(
+                "create or replace iceberg table %s (%s) %s",
+                tableName, columns, getIcebergTableConfig(tableName)));
 
     return tableName;
   }
@@ -526,20 +544,55 @@ public abstract class AbstractDataTypeTest {
     for (Object expectedValue : expectedValues) {
       Assertions.assertThat(resultSet.next()).isTrue();
       Object res = resultSet.getObject(1);
-      if (expectedValue instanceof BigDecimal) {
-        Assertions.assertThat(res)
-            .usingComparatorForType(BigDecimal::compareTo, BigDecimal.class)
-            .usingRecursiveComparison()
-            .isEqualTo(expectedValue);
-      } else if (expectedValue instanceof Map) {
-        Assertions.assertThat(objectMapper.readTree((String) res))
-            .isEqualTo(objectMapper.valueToTree(expectedValue));
-      } else if (expectedValue instanceof Timestamp) {
-        Assertions.assertThat(res.toString()).isEqualTo(expectedValue.toString());
-      } else {
-        Assertions.assertThat(res).isEqualTo(expectedValue);
-      }
+      assertEqualValues(expectedValue, res);
     }
     Assertions.assertThat(resultSet.next()).isFalse();
+  }
+
+  protected void verifyMultipleColumns(
+      String tableName,
+      List<Map<String, Object>> values,
+      List<Map<String, Object>> expectedValues,
+      String orderBy)
+      throws Exception {
+    SnowflakeStreamingIngestChannel channel = openChannel(tableName);
+    Set<String> keySet = new HashSet<>();
+    for (Map<String, Object> value : values) {
+      String offsetToken = UUID.randomUUID().toString();
+      channel.insertRow(value, offsetToken);
+      TestUtils.waitForOffset(channel, offsetToken);
+    }
+
+    for (Map<String, Object> value : expectedValues) {
+      keySet.addAll(value.keySet());
+    }
+
+    for (String key : keySet) {
+      String query = String.format("select %s from %s order by %s", key, tableName, orderBy);
+      ResultSet resultSet = conn.createStatement().executeQuery(query);
+
+      for (Map<String, Object> expectedValue : expectedValues) {
+        Assertions.assertThat(resultSet.next()).isTrue();
+        Object res = resultSet.getObject(1);
+        assertEqualValues(expectedValue.get(key), res);
+      }
+      Assertions.assertThat(resultSet.next()).isFalse();
+    }
+  }
+
+  private void assertEqualValues(Object expectedValue, Object actualValue) throws JsonProcessingException {
+    if (expectedValue instanceof BigDecimal) {
+      Assertions.assertThat(actualValue)
+          .usingComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+          .usingRecursiveComparison()
+          .isEqualTo(expectedValue);
+    } else if (expectedValue instanceof Map) {
+      Assertions.assertThat(objectMapper.readTree((String) actualValue))
+          .isEqualTo(objectMapper.valueToTree(expectedValue));
+    } else if (expectedValue instanceof Timestamp) {
+      Assertions.assertThat(actualValue.toString()).isEqualTo(expectedValue.toString());
+    } else {
+      Assertions.assertThat(actualValue).isEqualTo(expectedValue);
+    }
   }
 }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/it/IcebergSchemaEvolutionIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/it/IcebergSchemaEvolutionIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal.it;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import net.snowflake.ingest.streaming.internal.datatypes.AbstractDataTypeTest;
+import net.snowflake.ingest.utils.Constants;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+public class IcebergSchemaEvolutionIT extends AbstractDataTypeTest {
+  @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {"ZSTD", Constants.IcebergSerializationPolicy.COMPATIBLE},
+      {"ZSTD", Constants.IcebergSerializationPolicy.OPTIMIZED}
+    };
+  }
+
+  @Parameterized.Parameter public static String compressionAlgorithm;
+
+  @Parameterized.Parameter(1)
+  public static Constants.IcebergSerializationPolicy icebergSerializationPolicy;
+
+  @Before
+  public void before() throws Exception {
+    super.beforeIceberg(compressionAlgorithm, icebergSerializationPolicy);
+  }
+
+  @Test
+  public void testPrimitiveColumns() throws Exception {
+    String tableName =
+        createIcebergTableWithColumns(
+            "id int, int_col int, string_col string, double_col double, boolean_col boolean, "
+                + " binary_col binary");
+    Map<String, Object> value = new HashMap<>();
+    value.put("id", 0L);
+    value.put("int_col", 1L);
+    value.put("string_col", "2");
+    value.put("double_col", 3.0);
+    value.put("boolean_col", true);
+    value.put("binary_col", "4".getBytes());
+    verifyMultipleColumns(
+        tableName, Collections.singletonList(value), Collections.singletonList(value), "id");
+
+    conn.createStatement()
+        .execute(
+            String.format(
+                "ALTER ICEBERG TABLE %s ADD COLUMN new_int_col int, new_string_col string,"
+                    + " new_boolean_col boolean, new_binary_col binary",
+                tableName));
+    Map<String, Object> newValue = new HashMap<>();
+    newValue.put("id", 1L);
+    newValue.put("int_col", 2L);
+    newValue.put("string_col", "3");
+    newValue.put("double_col", 4.0);
+    newValue.put("boolean_col", false);
+    newValue.put("binary_col", "5".getBytes());
+    newValue.put("new_int_col", 6L);
+    newValue.put("new_string_col", "7");
+    newValue.put("new_boolean_col", true);
+    newValue.put("new_binary_col", "8".getBytes());
+    verifyMultipleColumns(
+        tableName, Collections.singletonList(newValue), Arrays.asList(value, newValue), "id");
+  }
+}


### PR DESCRIPTION
Add a schema evolution test for Iceberg ingestion. Will add one for structured data type after #869 is merge as that PR includes logic for object comparison.