### PR TITLE
SNOW-1787322 Fix InsertError for structured data type

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/InsertValidationResponse.java
+++ b/src/main/java/net/snowflake/ingest/streaming/InsertValidationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2021-2024 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.ingest.streaming;
@@ -115,6 +115,18 @@ public class InsertValidationResponse {
       this.extraColNames = extraColNames;
     }
 
+    /**
+     * Add an extra column name in the input row compared with the table schema
+     *
+     * @param extraColName the extra column name
+     */
+    public void addExtraColName(String extraColName) {
+      if (extraColNames == null) {
+        extraColNames = new ArrayList<>();
+      }
+      extraColNames.add(extraColName);
+    }
+
     /** Get the list of extra column names in the input row compared with the table schema */
     public List<String> getExtraColNames() {
       return extraColNames;
@@ -123,6 +135,18 @@ public class InsertValidationResponse {
     /** Set the missing non-nullable column names in the input row compared with the table schema */
     public void setMissingNotNullColNames(List<String> missingNotNullColNames) {
       this.missingNotNullColNames = missingNotNullColNames;
+    }
+
+    /**
+     * Add a missing non-nullable column name in the input row compared with the table schema
+     *
+     * @param missingNotNullColName the missing non-nullable column name
+     */
+    public void addMissingNotNullColName(String missingNotNullColName) {
+      if (missingNotNullColNames == null) {
+        missingNotNullColNames = new ArrayList<>();
+      }
+      missingNotNullColNames.add(missingNotNullColName);
     }
 
     /**
@@ -139,6 +163,19 @@ public class InsertValidationResponse {
      */
     public void setNullValueForNotNullColNames(List<String> nullValueForNotNullColNames) {
       this.nullValueForNotNullColNames = nullValueForNotNullColNames;
+    }
+
+    /**
+     * Add a name of non-nullable column which have null value in the input row compared with the
+     * table schema
+     *
+     * @param nullValueForNotNullColName the name of non-nullable column which have null value
+     */
+    public void addNullValueForNotNullColName(String nullValueForNotNullColName) {
+      if (nullValueForNotNullColNames == null) {
+        nullValueForNotNullColNames = new ArrayList<>();
+      }
+      nullValueForNotNullColNames.add(nullValueForNotNullColName);
     }
 
     /**

--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -162,7 +162,12 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
           Set<String> inputColumnNames = verifyInputColumns(row, error, rowIndex);
           rowsSizeInBytes +=
               addRow(
-                  row, rowBuffer.bufferedRowCount, rowBuffer.statsMap, inputColumnNames, rowIndex);
+                  row,
+                  rowBuffer.bufferedRowCount,
+                  rowBuffer.statsMap,
+                  inputColumnNames,
+                  rowIndex,
+                  error);
           rowBuffer.bufferedRowCount++;
         } catch (SFException e) {
           error.setException(e);
@@ -200,7 +205,13 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       for (Map<String, Object> row : rows) {
         Set<String> inputColumnNames = verifyInputColumns(row, null, tempRowCount);
         tempRowsSizeInBytes +=
-            addTempRow(row, tempRowCount, rowBuffer.tempStatsMap, inputColumnNames, tempRowCount);
+            addTempRow(
+                row,
+                tempRowCount,
+                rowBuffer.tempStatsMap,
+                inputColumnNames,
+                tempRowCount,
+                null /* error */);
         tempRowCount++;
         if ((long) rowBuffer.bufferedRowCount + tempRowCount >= Integer.MAX_VALUE) {
           throw new SFException(ErrorCode.INTERNAL_ERROR, "Row count reaches MAX value");
@@ -249,7 +260,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
         try {
           Set<String> inputColumnNames = verifyInputColumns(row, error, rowIndex);
           tempRowsSizeInBytes +=
-              addTempRow(row, tempRowCount, rowBuffer.tempStatsMap, inputColumnNames, rowIndex);
+              addTempRow(
+                  row, tempRowCount, rowBuffer.tempStatsMap, inputColumnNames, rowIndex, error);
           tempRowCount++;
         } catch (SFException e) {
           error.setException(e);
@@ -575,6 +587,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
    * @param formattedInputColumnNames list of input column names after formatting
    * @param insertRowIndex Index of the rows given in insertRows API. Not the same as
    *     bufferedRowIndex
+   * @param error
    * @return row size
    */
   abstract float addRow(
@@ -582,7 +595,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       int bufferedRowIndex,
       Map<String, RowBufferStats> statsMap,
       Set<String> formattedInputColumnNames,
-      final long insertRowIndex);
+      final long insertRowIndex,
+      InsertValidationResponse.InsertError error);
 
   /**
    * Add an input row to the temporary row buffer.
@@ -595,6 +609,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
    * @param statsMap column stats map
    * @param formattedInputColumnNames list of input column names after formatting
    * @param insertRowIndex index of the row being inserteed from User Input List
+   * @param error
    * @return row size
    */
   abstract float addTempRow(
@@ -602,7 +617,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
       int curRowIndex,
       Map<String, RowBufferStats> statsMap,
       Set<String> formattedInputColumnNames,
-      long insertRowIndex);
+      long insertRowIndex,
+      InsertValidationResponse.InsertError error);
 
   /** Move rows from the temporary buffer to the current row buffer. */
   abstract void moveTempRowsToActualBuffer(int tempRowCount);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java
@@ -211,7 +211,7 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
                 rowBuffer.tempStatsMap,
                 inputColumnNames,
                 tempRowCount,
-                null /* error */);
+                new InsertValidationResponse.InsertError(row, 0) /* dummy error */);
         tempRowCount++;
         if ((long) rowBuffer.bufferedRowCount + tempRowCount >= Integer.MAX_VALUE) {
           throw new SFException(ErrorCode.INTERNAL_ERROR, "Row count reaches MAX value");
@@ -587,7 +587,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
    * @param formattedInputColumnNames list of input column names after formatting
    * @param insertRowIndex Index of the rows given in insertRows API. Not the same as
    *     bufferedRowIndex
-   * @param error
+   * @param error Insert error object, used to populate error details when doing structured data
+   *     type parsing
    * @return row size
    */
   abstract float addRow(
@@ -609,7 +610,8 @@ abstract class AbstractRowBuffer<T> implements RowBuffer<T> {
    * @param statsMap column stats map
    * @param formattedInputColumnNames list of input column names after formatting
    * @param insertRowIndex index of the row being inserteed from User Input List
-   * @param error
+   * @param error Insert error object, used to populate error details when doing structured data
+   *     type parsing
    * @return row size
    */
   abstract float addTempRow(

--- a/src/main/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParser.java
@@ -5,6 +5,7 @@
 package net.snowflake.ingest.streaming.internal;
 
 import static net.snowflake.ingest.streaming.internal.DataValidationUtil.checkFixedLengthByteArray;
+import static net.snowflake.ingest.utils.Utils.concatDotPath;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -20,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
@@ -49,6 +51,7 @@ class IcebergParquetValueParser {
    * @param defaultTimezone default timezone to use for timestamp parsing
    * @param insertRowsCurrIndex Row index corresponding the row to parse (w.r.t input rows in
    *     insertRows API, and not buffered row)
+   * @param error InsertError object to add errors
    * @return parsed value and byte size of Parquet internal representation
    */
   static ParquetBufferValue parseColumnValueToParquet(
@@ -57,10 +60,18 @@ class IcebergParquetValueParser {
       Map<String, RowBufferStats> statsMap,
       SubColumnFinder subColumnFinder,
       ZoneId defaultTimezone,
-      long insertRowsCurrIndex) {
+      long insertRowsCurrIndex,
+      InsertValidationResponse.InsertError error) {
     Utils.assertNotNull("Parquet column stats map", statsMap);
     return parseColumnValueToParquet(
-        value, type, statsMap, subColumnFinder, defaultTimezone, insertRowsCurrIndex, false);
+        value,
+        type,
+        statsMap,
+        subColumnFinder,
+        defaultTimezone,
+        insertRowsCurrIndex,
+        false /* isDescendantsOfRepeatingGroup */,
+        error);
   }
 
   private static ParquetBufferValue parseColumnValueToParquet(
@@ -70,7 +81,8 @@ class IcebergParquetValueParser {
       SubColumnFinder subColumnFinder,
       ZoneId defaultTimezone,
       long insertRowsCurrIndex,
-      boolean isDescendantsOfRepeatingGroup) {
+      boolean isDescendantsOfRepeatingGroup,
+      InsertValidationResponse.InsertError error) {
     float estimatedParquetSize = 0F;
 
     if (type.getId() == null) {
@@ -160,12 +172,16 @@ class IcebergParquetValueParser {
             subColumnFinder,
             defaultTimezone,
             insertRowsCurrIndex,
-            isDescendantsOfRepeatingGroup);
+            isDescendantsOfRepeatingGroup,
+            error);
       }
     }
 
     if (value == null) {
       if (type.isRepetition(Repetition.REQUIRED)) {
+        if (error != null) {
+          error.addNullValueForNotNullColName(subColumnFinder.getDotPath(id));
+        }
         throw new SFException(
             ErrorCode.INVALID_FORMAT_ROW,
             subColumnFinder.getDotPath(id),
@@ -381,6 +397,7 @@ class IcebergParquetValueParser {
    * @param defaultTimezone default timezone to use for timestamp parsing
    * @param insertRowsCurrIndex Used for logging the row of index given in insertRows API
    * @param isDescendantsOfRepeatingGroup true if the column is a descendant of a repeating group,
+   * @param error InsertError object to add errors
    * @return list of parsed values
    */
   private static ParquetBufferValue getGroupValue(
@@ -390,7 +407,8 @@ class IcebergParquetValueParser {
       SubColumnFinder subColumnFinder,
       ZoneId defaultTimezone,
       final long insertRowsCurrIndex,
-      boolean isDescendantsOfRepeatingGroup) {
+      boolean isDescendantsOfRepeatingGroup,
+      InsertValidationResponse.InsertError error) {
     LogicalTypeAnnotation logicalTypeAnnotation = type.getLogicalTypeAnnotation();
     if (logicalTypeAnnotation == null) {
       return getStructValue(
@@ -400,15 +418,16 @@ class IcebergParquetValueParser {
           subColumnFinder,
           defaultTimezone,
           insertRowsCurrIndex,
-          isDescendantsOfRepeatingGroup);
+          isDescendantsOfRepeatingGroup,
+          error);
     }
     if (logicalTypeAnnotation instanceof LogicalTypeAnnotation.ListLogicalTypeAnnotation) {
       return get3LevelListValue(
-          value, type, statsMap, subColumnFinder, defaultTimezone, insertRowsCurrIndex);
+          value, type, statsMap, subColumnFinder, defaultTimezone, insertRowsCurrIndex, error);
     }
     if (logicalTypeAnnotation instanceof LogicalTypeAnnotation.MapLogicalTypeAnnotation) {
       return get3LevelMapValue(
-          value, type, statsMap, subColumnFinder, defaultTimezone, insertRowsCurrIndex);
+          value, type, statsMap, subColumnFinder, defaultTimezone, insertRowsCurrIndex, error);
     }
     throw new SFException(
         ErrorCode.UNKNOWN_DATA_TYPE,
@@ -429,28 +448,68 @@ class IcebergParquetValueParser {
       SubColumnFinder subColumnFinder,
       ZoneId defaultTimezone,
       final long insertRowsCurrIndex,
-      boolean isDescendantsOfRepeatingGroup) {
+      boolean isDescendantsOfRepeatingGroup,
+      InsertValidationResponse.InsertError error) {
     Map<String, ?> structVal =
         DataValidationUtil.validateAndParseIcebergStruct(
             subColumnFinder.getDotPath(type.getId()), value, insertRowsCurrIndex);
     Set<String> extraFields = new HashSet<>(structVal.keySet());
+    List<String> missingFields = new ArrayList<>();
     List<Object> listVal = new ArrayList<>(type.getFieldCount());
     float estimatedParquetSize = 0f;
     for (int i = 0; i < type.getFieldCount(); i++) {
-      ParquetBufferValue parsedValue =
-          parseColumnValueToParquet(
-              structVal.getOrDefault(type.getFieldName(i), null),
-              type.getType(i),
-              statsMap,
-              subColumnFinder,
-              defaultTimezone,
-              insertRowsCurrIndex,
-              isDescendantsOfRepeatingGroup);
       extraFields.remove(type.getFieldName(i));
-      listVal.add(parsedValue.getValue());
-      estimatedParquetSize += parsedValue.getSize();
+      if (structVal.containsKey(type.getFieldName(i))) {
+        ParquetBufferValue parsedValue =
+            parseColumnValueToParquet(
+                structVal.get(type.getFieldName(i)),
+                type.getType(i),
+                statsMap,
+                subColumnFinder,
+                defaultTimezone,
+                insertRowsCurrIndex,
+                isDescendantsOfRepeatingGroup,
+                error);
+        listVal.add(parsedValue.getValue());
+        estimatedParquetSize += parsedValue.getSize();
+      } else {
+        if (type.getType(i).isRepetition(Repetition.REQUIRED)) {
+          missingFields.add(type.getFieldName(i));
+        } else {
+          listVal.add(null);
+        }
+      }
     }
+
+    if (!missingFields.isEmpty()) {
+      missingFields.forEach(
+          missingField -> {
+            if (error != null) {
+              List<String> missingFieldPath =
+                  new ArrayList<>(subColumnFinder.getPath(type.getId()));
+              missingFieldPath.add(missingField);
+              error.addMissingNotNullColName(
+                  concatDotPath(missingFieldPath.toArray(new String[0])));
+            }
+          });
+      String missingFieldsStr = missingFields.stream().collect(Collectors.joining(", ", "[", "]"));
+      throw new SFException(
+          ErrorCode.INVALID_FORMAT_ROW,
+          "Missing fields: " + missingFieldsStr,
+          String.format(
+              "Fields %s are required but not present in the struct %s, rowIndex:%d",
+              missingFieldsStr, subColumnFinder.getDotPath(type.getId()), insertRowsCurrIndex));
+    }
+
     if (!extraFields.isEmpty()) {
+      extraFields.forEach(
+          extraField -> {
+            if (error != null) {
+              List<String> extraFieldPath = new ArrayList<>(subColumnFinder.getPath(type.getId()));
+              extraFieldPath.add(extraField);
+              error.addExtraColName(concatDotPath(extraFieldPath.toArray(new String[0])));
+            }
+          });
       String extraFieldsStr = extraFields.stream().collect(Collectors.joining(", ", "[", "]"));
       throw new SFException(
           ErrorCode.INVALID_FORMAT_ROW,
@@ -475,7 +534,8 @@ class IcebergParquetValueParser {
       Map<String, RowBufferStats> statsMap,
       SubColumnFinder subColumnFinder,
       ZoneId defaultTimezone,
-      final long insertRowsCurrIndex) {
+      final long insertRowsCurrIndex,
+      InsertValidationResponse.InsertError error) {
     Iterable<?> iterableVal =
         DataValidationUtil.validateAndParseIcebergList(
             subColumnFinder.getDotPath(type.getId()), value, insertRowsCurrIndex);
@@ -490,7 +550,8 @@ class IcebergParquetValueParser {
               subColumnFinder,
               defaultTimezone,
               insertRowsCurrIndex,
-              true);
+              true /* isDecedentOfRepeatingGroup */,
+              error);
       listVal.add(Collections.singletonList(parsedValue.getValue()));
       estimatedParquetSize += parsedValue.getSize();
     }
@@ -515,7 +576,8 @@ class IcebergParquetValueParser {
       Map<String, RowBufferStats> statsMap,
       SubColumnFinder subColumnFinder,
       ZoneId defaultTimezone,
-      final long insertRowsCurrIndex) {
+      final long insertRowsCurrIndex,
+      InsertValidationResponse.InsertError error) {
     Map<?, ?> mapVal =
         DataValidationUtil.validateAndParseIcebergMap(
             subColumnFinder.getDotPath(type.getId()), value, insertRowsCurrIndex);
@@ -530,7 +592,8 @@ class IcebergParquetValueParser {
               subColumnFinder,
               defaultTimezone,
               insertRowsCurrIndex,
-              true);
+              true /* isDecedentOfRepeatingGroup */,
+              error);
       ParquetBufferValue parsedValue =
           parseColumnValueToParquet(
               entry.getValue(),
@@ -539,7 +602,8 @@ class IcebergParquetValueParser {
               subColumnFinder,
               defaultTimezone,
               insertRowsCurrIndex,
-              true);
+              true /* isDecedentOfRepeatingGroup */,
+              error);
       listVal.add(Arrays.asList(parsedKey.getValue(), parsedValue.getValue()));
       estimatedParquetSize += parsedKey.getSize() + parsedValue.getSize();
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetRowBuffer.java
@@ -352,6 +352,19 @@ public class ParquetRowBuffer extends AbstractRowBuffer<ParquetChunkData> {
       size += valueWithSize.getSize();
     }
 
+    if (error.getMissingNotNullColNames() != null
+        || error.getExtraColNames() != null
+        || error.getNullValueForNotNullColNames() != null) {
+      throw new SFException(
+          ErrorCode.INVALID_FORMAT_ROW,
+          String.format("Invalid row %d", insertRowsCurrIndex),
+          String.format(
+              "missingNotNullColNames=%s, extraColNames=%s, nullValueForNotNullColNames=%s",
+              error.getMissingNotNullColNames(),
+              error.getExtraColNames(),
+              error.getNullValueForNotNullColNames()));
+    }
+
     long rowSizeRoundedUp = Double.valueOf(Math.ceil(size)).longValue();
 
     if (rowSizeRoundedUp > clientBufferParameters.getMaxAllowedRowSizeInBytes()) {

--- a/src/main/java/net/snowflake/ingest/utils/SubColumnFinder.java
+++ b/src/main/java/net/snowflake/ingest/utils/SubColumnFinder.java
@@ -89,7 +89,7 @@ public class SubColumnFinder {
     if (!accessMap.containsKey(id)) {
       throw new IllegalArgumentException(String.format("Field %s not found in schema", id));
     }
-    return accessMap.get(id).path;
+    return Collections.unmodifiableList(accessMap.get(id).path);
   }
 
   /**

--- a/src/main/java/net/snowflake/ingest/utils/SubColumnFinder.java
+++ b/src/main/java/net/snowflake/ingest/utils/SubColumnFinder.java
@@ -30,11 +30,13 @@ public class SubColumnFinder {
 
     /* Dot path of the node. */
     final String dotPath;
+    final List<String> path;
 
-    SubtreeInfo(int startTag, int endTag, String dotPath) {
+    SubtreeInfo(int startTag, int endTag, String dotPath, List<String> path) {
       this.startTag = startTag;
       this.endTag = endTag;
       this.dotPath = dotPath;
+      this.path = path;
     }
   }
 
@@ -78,6 +80,19 @@ public class SubColumnFinder {
   }
 
   /**
+   * Get the path of a node in the schema.
+   *
+   * @param id Field ID of the node
+   * @return Path of the node
+   */
+  public List<String> getPath(Type.ID id) {
+    if (!accessMap.containsKey(id)) {
+      throw new IllegalArgumentException(String.format("Field %s not found in schema", id));
+    }
+    return accessMap.get(id).path;
+  }
+
+  /**
    * Build the list of leaf columns in preorder traversal and the map of field id to the interval of
    * a node's leaf columns in the list.
    *
@@ -106,7 +121,10 @@ public class SubColumnFinder {
       accessMap.put(
           node.getId(),
           new SubtreeInfo(
-              startTag, list.size(), concatDotPath(currentPath.toArray(new String[0]))));
+              startTag,
+              list.size(),
+              concatDotPath(currentPath.toArray(new String[0])),
+              new ArrayList<>(currentPath)));
     }
     if (!currentPath.isEmpty()) {
       /* Remove the last element of the path at the end of recursion. */

--- a/src/test/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParserTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParserTest.java
@@ -60,7 +60,7 @@ public class IcebergParquetValueParserTest {
 
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            true, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            true, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -85,7 +85,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            Integer.MAX_VALUE, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            Integer.MAX_VALUE, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -113,7 +113,13 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            new BigDecimal("12345.6789"), type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            new BigDecimal("12345.6789"),
+            type,
+            rowBufferStatsMap,
+            mockSubColumnFinder,
+            UTC,
+            0,
+            null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -141,7 +147,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            "2024-01-01", type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            "2024-01-01", type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -166,7 +172,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            Long.MAX_VALUE, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            Long.MAX_VALUE, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -199,7 +205,8 @@ public class IcebergParquetValueParserTest {
             rowBufferStatsMap,
             mockSubColumnFinder,
             UTC,
-            0);
+            0,
+            null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -227,7 +234,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            "12:34:56.789", type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            "12:34:56.789", type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -255,7 +262,13 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            "2024-01-01T12:34:56.789+08:00", type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            "2024-01-01T12:34:56.789+08:00",
+            type,
+            rowBufferStatsMap,
+            mockSubColumnFinder,
+            UTC,
+            0,
+            null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -283,7 +296,13 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            "2024-01-01T12:34:56.789+08:00", type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            "2024-01-01T12:34:56.789+08:00",
+            type,
+            rowBufferStatsMap,
+            mockSubColumnFinder,
+            UTC,
+            0,
+            null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -308,7 +327,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            Float.MAX_VALUE, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            Float.MAX_VALUE, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -333,7 +352,7 @@ public class IcebergParquetValueParserTest {
         };
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            Double.MAX_VALUE, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            Double.MAX_VALUE, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -359,7 +378,7 @@ public class IcebergParquetValueParserTest {
     byte[] value = "snowflake_to_the_moon".getBytes();
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -389,7 +408,7 @@ public class IcebergParquetValueParserTest {
     String value = "snowflake_to_the_moon";
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -421,7 +440,7 @@ public class IcebergParquetValueParserTest {
     byte[] value = "snow".getBytes();
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -452,7 +471,7 @@ public class IcebergParquetValueParserTest {
     BigDecimal value = new BigDecimal("1234567890.0123456789");
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .rowBufferStats(rowBufferStats)
@@ -480,10 +499,16 @@ public class IcebergParquetValueParserTest {
         };
 
     IcebergParquetValueParser.parseColumnValueToParquet(
-        null, list, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+        null, list, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            Arrays.asList(1, 2, 3, 4, 5), list, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            Arrays.asList(1, 2, 3, 4, 5),
+            list,
+            rowBufferStatsMap,
+            mockSubColumnFinder,
+            UTC,
+            0,
+            null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .rowBufferStats(rowBufferStats)
         .parquetBufferValue(pv)
@@ -507,10 +532,10 @@ public class IcebergParquetValueParserTest {
         SFException.class,
         () ->
             IcebergParquetValueParser.parseColumnValueToParquet(
-                null, requiredList, rowBufferStatsMap, mockSubColumnFinder, UTC, 0));
+                null, requiredList, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null));
     pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
-            new ArrayList<>(), requiredList, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+            new ArrayList<>(), requiredList, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .rowBufferStats(rowBufferStats)
         .parquetBufferValue(pv)
@@ -536,7 +561,8 @@ public class IcebergParquetValueParserTest {
                 rowBufferStatsMap,
                 mockSubColumnFinder,
                 UTC,
-                0));
+                0,
+                null));
   }
 
   @Test
@@ -557,7 +583,7 @@ public class IcebergParquetValueParserTest {
           }
         };
     IcebergParquetValueParser.parseColumnValueToParquet(
-        null, map, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+        null, map, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
             new java.util.HashMap<Integer, Integer>() {
@@ -570,7 +596,8 @@ public class IcebergParquetValueParserTest {
             rowBufferStatsMap,
             mockSubColumnFinder,
             UTC,
-            0);
+            0,
+            null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .rowBufferStats(rowBufferKeyStats)
         .parquetBufferValue(pv)
@@ -596,7 +623,7 @@ public class IcebergParquetValueParserTest {
         SFException.class,
         () ->
             IcebergParquetValueParser.parseColumnValueToParquet(
-                null, requiredMap, rowBufferStatsMap, mockSubColumnFinder, UTC, 0));
+                null, requiredMap, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null));
     pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
             new java.util.HashMap<Integer, Integer>(),
@@ -604,7 +631,8 @@ public class IcebergParquetValueParserTest {
             rowBufferStatsMap,
             mockSubColumnFinder,
             UTC,
-            0);
+            0,
+            null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .rowBufferStats(rowBufferKeyStats)
         .parquetBufferValue(pv)
@@ -635,7 +663,8 @@ public class IcebergParquetValueParserTest {
                 rowBufferStatsMap,
                 mockSubColumnFinder,
                 UTC,
-                0));
+                0,
+                null));
   }
 
   @Test
@@ -662,7 +691,7 @@ public class IcebergParquetValueParserTest {
         };
 
     IcebergParquetValueParser.parseColumnValueToParquet(
-        null, struct, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+        null, struct, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
     Assert.assertThrows(
         SFException.class,
         () ->
@@ -676,7 +705,8 @@ public class IcebergParquetValueParserTest {
                 rowBufferStatsMap,
                 mockSubColumnFinder,
                 UTC,
-                0));
+                0,
+                null));
     Assert.assertThrows(
         SFException.class,
         () ->
@@ -690,7 +720,8 @@ public class IcebergParquetValueParserTest {
                 rowBufferStatsMap,
                 mockSubColumnFinder,
                 UTC,
-                0));
+                0,
+                null));
     ParquetBufferValue pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
             Collections.unmodifiableMap(
@@ -704,7 +735,8 @@ public class IcebergParquetValueParserTest {
             rowBufferStatsMap,
             mockSubColumnFinder,
             UTC,
-            0);
+            0,
+            null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .expectedValueClass(ArrayList.class)
@@ -729,7 +761,7 @@ public class IcebergParquetValueParserTest {
         SFException.class,
         () ->
             IcebergParquetValueParser.parseColumnValueToParquet(
-                null, requiredStruct, rowBufferStatsMap, mockSubColumnFinder, UTC, 0));
+                null, requiredStruct, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null));
     pv =
         IcebergParquetValueParser.parseColumnValueToParquet(
             new java.util.HashMap<String, Object>(),
@@ -737,7 +769,8 @@ public class IcebergParquetValueParserTest {
             rowBufferStatsMap,
             mockSubColumnFinder,
             UTC,
-            0);
+            0,
+            null);
     ParquetValueParserAssertionBuilder.newBuilder()
         .parquetBufferValue(pv)
         .expectedValueClass(ArrayList.class)
@@ -758,7 +791,7 @@ public class IcebergParquetValueParserTest {
       List<?> reference = (List<?>) res.getSecond();
       ParquetBufferValue pv =
           IcebergParquetValueParser.parseColumnValueToParquet(
-              value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0);
+              value, type, rowBufferStatsMap, mockSubColumnFinder, UTC, 0, null);
       ParquetValueParserAssertionBuilder.newBuilder()
           .parquetBufferValue(pv)
           .expectedValueClass(ArrayList.class)


### PR DESCRIPTION
Currently the `InsertError` doesn't populate extra columns, missing columns, null value for non null columns in `InsertValidationResponse` when ingesting structured data type to Iceberg tables. The PR is fixing this.

We use parquet dot path with escaping dot and back slash character in field name to represent sub-columns. For example, column `x` in `map_col(string, object("a.b" array(object("c\d" object(x int)))))` has a path `MAP_COL.key_value.value.a\.b.list.element.c\\d.x`