### PR TITLE
Enable ColumNamesIT for Iceberg mode

### DIFF
--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/BinaryIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/BinaryIT.java
@@ -3,11 +3,23 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public class BinaryIT extends AbstractDataTypeTest {
+  @Parameters(name = "{index}: {0}")
+  public static Object[] parameters() {
+    return new Object[] {"GZIP", "ZSTD"};
+  }
+
+  @Parameter public String compressionAlgorithm;
+
   @Before
   public void before() throws Exception {
-    super.before();
+    super.setUp(false, compressionAlgorithm, null);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/DateTimeIT.java
@@ -12,16 +12,27 @@ import java.time.ZonedDateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public class DateTimeIT extends AbstractDataTypeTest {
-
   private static final ZoneId TZ_LOS_ANGELES = ZoneId.of("America/Los_Angeles");
   private static final ZoneId TZ_BERLIN = ZoneId.of("Europe/Berlin");
   private static final ZoneId TZ_TOKYO = ZoneId.of("Asia/Tokyo");
 
+  @Parameters(name = "{index}: {0}")
+  public static Object[] parameters() {
+    return new Object[] {"GZIP", "ZSTD"};
+  }
+
+  @Parameter public String compressionAlgorithm;
+
   @Before
   public void setup() throws Exception {
-    super.before();
+    super.setUp(false, compressionAlgorithm, null);
     // Set to a random time zone not to interfere with any of the tests
     conn.createStatement().execute("alter session set timezone = 'America/New_York';");
   }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergDateTimeIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergDateTimeIT.java
@@ -21,11 +21,12 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @Ignore("This test can be enabled after server side Iceberg EP support is released")
+@RunWith(Parameterized.class)
 public class IcebergDateTimeIT extends AbstractDataTypeTest {
-
   @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
   public static Object[][] parameters() {
     return new Object[][] {
@@ -34,14 +35,15 @@ public class IcebergDateTimeIT extends AbstractDataTypeTest {
     };
   }
 
-  @Parameterized.Parameter public static String compressionAlgorithm;
+  @Parameterized.Parameter(0)
+  public static String compressionAlgorithm;
 
   @Parameterized.Parameter(1)
   public static Constants.IcebergSerializationPolicy icebergSerializationPolicy;
 
   @Before
   public void before() throws Exception {
-    super.beforeIceberg(compressionAlgorithm, icebergSerializationPolicy);
+    super.setUp(true, compressionAlgorithm, icebergSerializationPolicy);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergLogicalTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergLogicalTypesIT.java
@@ -8,9 +8,11 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @Ignore("This test can be enabled after server side Iceberg EP support is released")
+@RunWith(Parameterized.class)
 public class IcebergLogicalTypesIT extends AbstractDataTypeTest {
   @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
   public static Object[][] parameters() {
@@ -20,14 +22,15 @@ public class IcebergLogicalTypesIT extends AbstractDataTypeTest {
     };
   }
 
-  @Parameterized.Parameter public static String compressionAlgorithm;
+  @Parameterized.Parameter(0)
+  public static String compressionAlgorithm;
 
   @Parameterized.Parameter(1)
   public static Constants.IcebergSerializationPolicy icebergSerializationPolicy;
 
   @Before
   public void before() throws Exception {
-    super.beforeIceberg(compressionAlgorithm, icebergSerializationPolicy);
+    super.setUp(true, compressionAlgorithm, icebergSerializationPolicy);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergNumericTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergNumericTypesIT.java
@@ -17,11 +17,13 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Ignore("This test can be enabled after server side Iceberg EP support is released")
+@RunWith(Parameterized.class)
 public class IcebergNumericTypesIT extends AbstractDataTypeTest {
   @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
   public static Object[][] parameters() {
@@ -31,7 +33,8 @@ public class IcebergNumericTypesIT extends AbstractDataTypeTest {
     };
   }
 
-  @Parameterized.Parameter public static String compressionAlgorithm;
+  @Parameterized.Parameter(0)
+  public static String compressionAlgorithm;
 
   @Parameterized.Parameter(1)
   public static Constants.IcebergSerializationPolicy icebergSerializationPolicy;
@@ -42,7 +45,7 @@ public class IcebergNumericTypesIT extends AbstractDataTypeTest {
 
   @Before
   public void before() throws Exception {
-    super.beforeIceberg(compressionAlgorithm, icebergSerializationPolicy);
+    super.setUp(true, compressionAlgorithm, icebergSerializationPolicy);
     long seed = System.currentTimeMillis();
     logger.info("Random seed: {}", seed);
     generator = new Random(seed);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStringIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStringIT.java
@@ -10,9 +10,11 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @Ignore("This test can be enabled after server side Iceberg EP support is released")
+@RunWith(Parameterized.class)
 public class IcebergStringIT extends AbstractDataTypeTest {
   @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
   public static Object[][] parameters() {
@@ -22,14 +24,15 @@ public class IcebergStringIT extends AbstractDataTypeTest {
     };
   }
 
-  @Parameterized.Parameter public static String compressionAlgorithm;
+  @Parameterized.Parameter(0)
+  public static String compressionAlgorithm;
 
   @Parameterized.Parameter(1)
   public static Constants.IcebergSerializationPolicy icebergSerializationPolicy;
 
   @Before
   public void before() throws Exception {
-    super.beforeIceberg(compressionAlgorithm, icebergSerializationPolicy);
+    super.setUp(true, compressionAlgorithm, icebergSerializationPolicy);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
@@ -26,9 +26,11 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @Ignore("This test can be enabled after server side Iceberg EP support is released")
+@RunWith(Parameterized.class)
 public class IcebergStructuredIT extends AbstractDataTypeTest {
   @Parameterized.Parameters(name = "compressionAlgorithm={0}, icebergSerializationPolicy={1}")
   public static Object[][] parameters() {
@@ -38,14 +40,15 @@ public class IcebergStructuredIT extends AbstractDataTypeTest {
     };
   }
 
-  @Parameterized.Parameter public static String compressionAlgorithm;
+  @Parameterized.Parameter(0)
+  public static String compressionAlgorithm;
 
   @Parameterized.Parameter(1)
   public static Constants.IcebergSerializationPolicy icebergSerializationPolicy;
 
   @Before
   public void before() throws Exception {
-    super.beforeIceberg(compressionAlgorithm, icebergSerializationPolicy);
+    super.setUp(true, compressionAlgorithm, icebergSerializationPolicy);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
@@ -80,8 +80,9 @@ public class IcebergStructuredIT extends AbstractDataTypeTest {
                     }))
         .isInstanceOf(SFException.class)
         .hasMessage(
-            "The given row cannot be converted to the internal format: VALUE.key_value.key. "
-                + "Passed null to non nullable field, rowIndex:0, column:VALUE.key_value.key")
+            "The given row cannot be converted to the internal format: Invalid row 0."
+                + " missingNotNullColNames=null, extraColNames=null,"
+                + " nullValueForNotNullColNames=[VALUE.key_value.key]")
         .extracting("vendorCode")
         .isEqualTo(ErrorCode.INVALID_FORMAT_ROW.getMessageCode());
 
@@ -91,8 +92,9 @@ public class IcebergStructuredIT extends AbstractDataTypeTest {
                 assertStructuredDataType("object(a int, b string)", "{\"a\": 1, \"c\": \"test\"}"))
         .isInstanceOf(SFException.class)
         .hasMessage(
-            "The given row cannot be converted to the internal format: Extra fields: [c]. "
-                + "Fields not present in the struct VALUE shouldn't be specified, rowIndex:0")
+            "The given row cannot be converted to the internal format: Invalid row 0."
+                + " missingNotNullColNames=null, extraColNames=[VALUE.c],"
+                + " nullValueForNotNullColNames=null")
         .extracting("vendorCode")
         .isEqualTo(ErrorCode.INVALID_FORMAT_ROW.getMessageCode());
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/LogicalTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/LogicalTypesIT.java
@@ -4,11 +4,23 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public class LogicalTypesIT extends AbstractDataTypeTest {
+  @Parameters(name = "{index}: {0}")
+  public static Object[] parameters() {
+    return new Object[] {"GZIP", "ZSTD"};
+  }
+
+  @Parameter public String compressionAlgorithm;
+
   @Before
   public void before() throws Exception {
-    super.before();
+    super.setUp(false, compressionAlgorithm, null);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NullIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NullIT.java
@@ -3,11 +3,23 @@ package net.snowflake.ingest.streaming.internal.datatypes;
 import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public class NullIT extends AbstractDataTypeTest {
+  @Parameters(name = "{index}: {0}")
+  public static Object[] parameters() {
+    return new Object[] {"GZIP", "ZSTD"};
+  }
+
+  @Parameter public String compressionAlgorithm;
+
   @Before
   public void before() throws Exception {
-    super.before();
+    super.setUp(false, compressionAlgorithm, null);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NumericTypesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/NumericTypesIT.java
@@ -4,11 +4,23 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public class NumericTypesIT extends AbstractDataTypeTest {
+  @Parameters(name = "{index}: {0}")
+  public static Object[] parameters() {
+    return new Object[] {"GZIP", "ZSTD"};
+  }
+
+  @Parameter public String compressionAlgorithm;
+
   @Before
   public void before() throws Exception {
-    super.before();
+    super.setUp(false, compressionAlgorithm, null);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/SemiStructuredIT.java
@@ -18,11 +18,23 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public class SemiStructuredIT extends AbstractDataTypeTest {
+  @Parameters(name = "{index}: {0}")
+  public static Object[] parameters() {
+    return new Object[] {"GZIP", "ZSTD"};
+  }
+
+  @Parameter public String compressionAlgorithm;
+
   @Before
   public void before() throws Exception {
-    super.before();
+    super.setUp(false, compressionAlgorithm, null);
   }
 
   // TODO SNOW-664249: There is a few-byte mismatch between the value sent by the user and its

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/StringsIT.java
@@ -12,14 +12,26 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public class StringsIT extends AbstractDataTypeTest {
 
   private static final int MB_16 = 16 * 1024 * 1024;
 
+  @Parameters(name = "{index}: {0}")
+  public static Object[] parameters() {
+    return new Object[] {"GZIP", "ZSTD"};
+  }
+
+  @Parameter public String compressionAlgorithm;
+
   @Before
   public void before() throws Exception {
-    super.before();
+    super.setUp(false, compressionAlgorithm, null);
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/it/FdnColumnNamesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/it/FdnColumnNamesIT.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal.it;
+
+import org.junit.Before;
+
+public class FdnColumnNamesIT extends ColumnNamesITBase {
+  @Before
+  public void before() throws Exception {
+    super.setUp(false, "GZIP", null);
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/it/IcebergColumnNamesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/it/IcebergColumnNamesIT.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal.it;
+
+import net.snowflake.ingest.utils.Constants.IcebergSerializationPolicy;
+import org.junit.Before;
+import org.junit.Ignore;
+
+@Ignore("Enable this after the Iceberg testing on GCS / Azure is ready")
+public class IcebergColumnNamesIT extends ColumnNamesITBase {
+  @Before
+  public void before() throws Exception {
+    super.setUp(true, "ZSTD", IcebergSerializationPolicy.OPTIMIZED);
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/it/ManyTablesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/it/ManyTablesIT.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
  */
 
-package net.snowflake.ingest.streaming.internal;
+package net.snowflake.ingest.streaming.internal.it;
 
 import static net.snowflake.ingest.utils.Constants.ROLE;
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/it/StreamingIngestBigFilesIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/it/StreamingIngestBigFilesIT.java
@@ -1,4 +1,4 @@
-package net.snowflake.ingest.streaming.internal;
+package net.snowflake.ingest.streaming.internal.it;
 
 import static net.snowflake.ingest.TestUtils.verifyTableRowCount;
 import static net.snowflake.ingest.utils.Constants.ROLE;
@@ -13,6 +13,7 @@ import net.snowflake.ingest.TestUtils;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
+import net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientInternal;
 import net.snowflake.ingest.utils.Constants;
 import org.junit.After;
 import org.junit.Assert;


### PR DESCRIPTION
Enable ColumnNamesIT for Iceberg mode. Split into two test classes as we are planning adding test group for Iceberg/non-Iceberg ITs.