### PR TITLE
[SNOW-1711460] Upgrade to iceberg version 1.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <fasterxml.version>2.17.2</fasterxml.version>
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.4.0</hadoop.version>
-    <iceberg.version>1.5.2</iceberg.version>
+    <iceberg.version>1.6.1</iceberg.version>
     <jacoco.skip.instrument>true</jacoco.skip.instrument>
     <jacoco.version>0.8.5</jacoco.version>
     <license.processing.dependencyJarsDir>${project.build.directory}/dependency-jars</license.processing.dependencyJarsDir>


### PR DESCRIPTION
AVRO CVE is a false alarm and does not affect this dependency so we will keep using Iceberg 1.6.1 due to java 8 support 

CVE does not affect Iceberg: https://www.mail-archive.com/dev@iceberg.apache.org/msg07864.html