### PR TITLE
Explicitly specify avro dependency to override apache iceberg version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 
   <!-- Set our Language Level to Java 8 -->
   <properties>
+    <avro.version>1.11.4</avro.version>
     <bouncycastle.version>1.78.1</bouncycastle.version>
     <codehaus.version>1.9.13</codehaus.version>
     <commonscodec.version>1.15</commonscodec.version>
@@ -83,6 +84,11 @@
         <version>${fasterxml.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>${avro.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Iceberg.core 1.6.1 uses avro 1.11.3
We want to use avro 1.11.4 to patch a CVE (even though it does not affect iceberg