### PR TITLE
SNOW-1808626 Fix struct type statistic for missing fields

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParser.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/IcebergParquetValueParser.java
@@ -468,6 +468,9 @@ class IcebergParquetValueParser {
           missingFields.add(type.getFieldName(i));
         } else {
           listVal.add(null);
+          subColumnFinder
+              .getSubColumns(type.getType(i).getId())
+              .forEach(subColumn -> statsMap.get(subColumn).incCurrentNullCount());
         }
       }
     }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/datatypes/IcebergStructuredIT.java
@@ -472,6 +472,12 @@ public class IcebergStructuredIT extends AbstractDataTypeTest {
     assertThat(actualNode).isEqualTo(expectedNode);
   }
 
+  /**
+   * Remove null fields from the JSON node. This is used to compare the JSON node ignoring null
+   * values. e.g. "{}" and "{a: null}".
+   *
+   * @param node JSON node
+   */
   private void removeNullFields(JsonNode node) {
     if (node == null) {
       return;


### PR DESCRIPTION
The original logic didn't calculate null count for missing fields, fix this.