### PR TITLE
SNOW-1821246 Add parameter for blob upload timeout

### DIFF
--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -43,7 +43,6 @@ public class Constants {
       10L; // Don't change, should match server side
   public static final long RESPONSE_ERR_ENQUEUE_TABLE_CHUNK_QUEUE_FULL =
       7L; // Don't change, should match server side
-  public static final int BLOB_UPLOAD_TIMEOUT_IN_SEC = 5;
   public static final int INSERT_THROTTLE_MAX_RETRY_COUNT = 60;
   public static final long MAX_BLOB_SIZE_IN_BYTES = 1024 * 1024 * 1024;
   public static final int BLOB_TAG_SIZE_IN_BYTES = 4;

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -38,8 +38,8 @@ public class ParameterProvider {
   public static final String MAX_CHUNKS_IN_BLOB = "MAX_CHUNKS_IN_BLOB".toLowerCase();
   public static final String MAX_CHUNKS_IN_REGISTRATION_REQUEST =
       "MAX_CHUNKS_IN_REGISTRATION_REQUEST".toLowerCase();
-  public static final String BLOB_UPLOAD_TIMEOUT_IN_SEC =
-      "BLOB_UPLOAD_TIMEOUT_IN_SEC".toLowerCase();
+  public static final String BLOB_UPLOAD_TIMEOUT_IN_SECONDS =
+      "BLOB_UPLOAD_TIMEOUT_IN_SECONDS".toLowerCase();
 
   public static final String MAX_CLIENT_LAG = "MAX_CLIENT_LAG".toLowerCase();
 
@@ -64,8 +64,8 @@ public class ParameterProvider {
   public static final long MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT = -1L;
   public static final long MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT = 64 * 1024 * 1024;
   public static final long MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 256 * 1024 * 1024;
-  public static final int BLOB_UPLOAD_TIMEOUT_IN_SEC_DEFAULT = 5;
-  public static final int BLOB_UPLOAD_TIMEOUT_IN_SEC_ICEBERG_MODE_DEFAULT = 20;
+  public static final int BLOB_UPLOAD_TIMEOUT_IN_SECONDS_DEFAULT = 5;
+  public static final int BLOB_UPLOAD_TIMEOUT_IN_SECONDS_ICEBERG_MODE_DEFAULT = 30;
 
   // Lag related parameters
   public static final long MAX_CLIENT_LAG_DEFAULT = 1000; // 1 second
@@ -278,10 +278,10 @@ public class ParameterProvider {
         false /* enforceDefault */);
 
     this.checkAndUpdate(
-        BLOB_UPLOAD_TIMEOUT_IN_SEC,
+        BLOB_UPLOAD_TIMEOUT_IN_SECONDS,
         isEnableIcebergStreaming()
-            ? BLOB_UPLOAD_TIMEOUT_IN_SEC_ICEBERG_MODE_DEFAULT
-            : BLOB_UPLOAD_TIMEOUT_IN_SEC_DEFAULT,
+            ? BLOB_UPLOAD_TIMEOUT_IN_SECONDS_ICEBERG_MODE_DEFAULT
+            : BLOB_UPLOAD_TIMEOUT_IN_SECONDS_DEFAULT,
         parameterOverrides,
         props,
         false /* enforceDefault */);
@@ -552,10 +552,10 @@ public class ParameterProvider {
     }
     Object val =
         this.parameterMap.getOrDefault(
-            BLOB_UPLOAD_TIMEOUT_IN_SEC,
+            BLOB_UPLOAD_TIMEOUT_IN_SECONDS,
             isEnableIcebergStreaming()
-                ? BLOB_UPLOAD_TIMEOUT_IN_SEC_ICEBERG_MODE_DEFAULT
-                : BLOB_UPLOAD_TIMEOUT_IN_SEC_DEFAULT);
+                ? BLOB_UPLOAD_TIMEOUT_IN_SECONDS_ICEBERG_MODE_DEFAULT
+                : BLOB_UPLOAD_TIMEOUT_IN_SECONDS_DEFAULT);
     cachedBlobUploadTimeoutInSec =
         (val instanceof String) ? Integer.parseInt(val.toString()) : (int) val;
     return cachedBlobUploadTimeoutInSec;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -170,6 +170,11 @@ public class ParameterProviderTest {
     Assert.assertEquals(
         ParameterProvider.MAX_CHUNKS_IN_REGISTRATION_REQUEST_DEFAULT,
         parameterProvider.getMaxChunksInRegistrationRequest());
+    Assert.assertEquals(
+        enableIcebergStreaming
+            ? ParameterProvider.BLOB_UPLOAD_TIMEOUT_IN_SEC_ICEBERG_MODE_DEFAULT
+            : ParameterProvider.BLOB_UPLOAD_TIMEOUT_IN_SEC_DEFAULT,
+        parameterProvider.getBlobUploadTimeOutInSec());
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -172,8 +172,8 @@ public class ParameterProviderTest {
         parameterProvider.getMaxChunksInRegistrationRequest());
     Assert.assertEquals(
         enableIcebergStreaming
-            ? ParameterProvider.BLOB_UPLOAD_TIMEOUT_IN_SEC_ICEBERG_MODE_DEFAULT
-            : ParameterProvider.BLOB_UPLOAD_TIMEOUT_IN_SEC_DEFAULT,
+            ? ParameterProvider.BLOB_UPLOAD_TIMEOUT_IN_SECONDS_ICEBERG_MODE_DEFAULT
+            : ParameterProvider.BLOB_UPLOAD_TIMEOUT_IN_SECONDS_DEFAULT,
         parameterProvider.getBlobUploadTimeOutInSec());
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
@@ -4,8 +4,6 @@
 
 package net.snowflake.ingest.streaming.internal;
 
-import static net.snowflake.ingest.utils.Constants.BLOB_UPLOAD_TIMEOUT_IN_SEC;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -120,7 +118,9 @@ public class RegisterServiceTest {
     future.thenRunAsync(
         () -> {
           try {
-            Thread.sleep(TimeUnit.SECONDS.toMillis(BLOB_UPLOAD_TIMEOUT_IN_SEC) + 5);
+            Thread.sleep(
+                TimeUnit.SECONDS.toMillis(client.getParameterProvider().getBlobUploadTimeOutInSec())
+                    + 5);
           } catch (InterruptedException e) {
             e.printStackTrace();
           }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
@@ -64,8 +64,8 @@ public class RegisterServiceTest {
     Mockito.when(parameterProvider.getBlobUploadTimeOutInSec())
         .thenReturn(
             enableIcebergStreaming
-                ? ParameterProvider.BLOB_UPLOAD_TIMEOUT_IN_SEC_ICEBERG_MODE_DEFAULT
-                : ParameterProvider.BLOB_UPLOAD_TIMEOUT_IN_SEC_DEFAULT);
+                ? ParameterProvider.BLOB_UPLOAD_TIMEOUT_IN_SECONDS_ICEBERG_MODE_DEFAULT
+                : ParameterProvider.BLOB_UPLOAD_TIMEOUT_IN_SECONDS_DEFAULT);
     Mockito.when(client.getParameterProvider()).thenReturn(parameterProvider);
 
     RegisterService<StubChunkData> rs = new RegisterService<>(client, true);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
@@ -25,6 +25,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 
 @RunWith(Parameterized.class)
 public class RegisterServiceTest {
@@ -57,7 +58,17 @@ public class RegisterServiceTest {
 
   @Test
   public void testRegisterService() throws ExecutionException, InterruptedException {
-    RegisterService<StubChunkData> rs = new RegisterService<>(null, true);
+    SnowflakeStreamingIngestClientInternal<StubChunkData> client =
+        Mockito.mock(SnowflakeStreamingIngestClientInternal.class);
+    ParameterProvider parameterProvider = Mockito.mock(ParameterProvider.class);
+    Mockito.when(parameterProvider.getBlobUploadTimeOutInSec())
+        .thenReturn(
+            enableIcebergStreaming
+                ? ParameterProvider.BLOB_UPLOAD_TIMEOUT_IN_SEC_ICEBERG_MODE_DEFAULT
+                : ParameterProvider.BLOB_UPLOAD_TIMEOUT_IN_SEC_DEFAULT);
+    Mockito.when(client.getParameterProvider()).thenReturn(parameterProvider);
+
+    RegisterService<StubChunkData> rs = new RegisterService<>(client, true);
 
     Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blobFuture =
         new Pair<>(


### PR DESCRIPTION
The original blob upload timeout is hard coded as 5 seconds. This might not be feasible for Iceberg table streaming as the 30 seconds client lag in Iceberg streaming might create larger file which requires larger blob upload timeout. Make the `BLOB_UPLOAD_TIMEOUT` constant to configurable parameter and keep the default timeout of FDN table streaming as 5 seconds while have a 20 seconds default for Iceberg table streaming.