### PR TITLE
Send clientname and clientkey with every registerblobs request for metering views

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/InternalStage.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/InternalStage.java
@@ -181,8 +181,8 @@ class InternalStage implements IStorage {
                 fileTransferMetadataCopy,
                 inStream,
                 proxyProperties,
-                clientPrefix,
                 clientName,
+                clientPrefix,
                 fullFilePath));
       } else {
         SnowflakeFileTransferAgent.uploadWithoutConnection(

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RegisterBlobRequest.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RegisterBlobRequest.java
@@ -20,16 +20,29 @@ class RegisterBlobRequest implements IStreamingIngestRequest {
   @JsonProperty("blobs")
   private List<BlobMetadata> blobs;
 
+  @JsonProperty("client_name")
+  private String clientName;
+
+  @JsonProperty("client_key")
+  private String clientKey;
+
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonProperty("is_iceberg")
   private boolean enableIcebergStreaming;
 
   RegisterBlobRequest(
-      String requestId, String role, List<BlobMetadata> blobs, boolean enableIcebergStreaming) {
+      String requestId,
+      String role,
+      List<BlobMetadata> blobs,
+      boolean enableIcebergStreaming,
+      String clientName,
+      String clientKey) {
     this.requestId = requestId;
     this.role = role;
     this.blobs = blobs;
     this.enableIcebergStreaming = enableIcebergStreaming;
+    this.clientName = clientName;
+    this.clientKey = clientKey;
   }
 
   String getRequestId() {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -585,9 +585,11 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
    */
   void registerBlobs(List<BlobMetadata> blobs, final int executionCount) {
     logger.logInfo(
-        "Register blob request preparing for blob={}, client={}, executionCount={}",
+        "Register blob request preparing for blob={}, clientName={}, clientKey={},"
+            + " executionCount={}",
         blobs.stream().map(BlobMetadata::getPath).collect(Collectors.toList()),
         this.name,
+        this.storageManager.getClientPrefix(),
         executionCount);
 
     RegisterBlobResponse response = null;
@@ -597,7 +599,9 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
               this.storageManager.getClientPrefix() + "_" + counter.getAndIncrement(),
               this.role,
               blobs,
-              this.parameterProvider.isEnableIcebergStreaming());
+              this.parameterProvider.isEnableIcebergStreaming(),
+              this.getName(),
+              this.storageManager.getClientPrefix());
       response = snowflakeServiceClient.registerBlob(request, executionCount);
     } catch (IOException | IngestResponseException e) {
       throw new SFException(e, ErrorCode.REGISTER_BLOB_FAILURE, e.getMessage());


### PR DESCRIPTION
Iceberg's billing needs the clientname and clientkey at the time of DML Commit. While it can be read via a S3 get-metadata call, its a wasteful approach. This PR optimizes away that S3 call by sending the metadata inline with the registerBlobs API call.

Ran FDN and Iceberg ITs locally against sfctest0 to make sure the json backcompat fix from months ago will allow unknown fields to appear on the payload without causing issues. IT run from this PR's merge gate should be green.