### PR TITLE
[SNOW-1882616] Error out for duplicate keys in variant

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -181,7 +181,12 @@ class DataValidationUtil {
           throw valueFormatNotAllowedException(
               columnName, snowflakeType, "Not a valid JSON: duplicate field", insertRowIndex);
         }
-        throw new SFException(e, ErrorCode.IO_ERROR, "Cannot create JSON Parser or JSON generator");
+        throw new SFException(
+            e,
+            ErrorCode.IO_ERROR,
+            String.format(
+                "Cannot create JSON Parser or JSON generator for column %s of type %s, rowIndex:%d",
+                columnName, snowflakeType, insertRowIndex));
       }
       // We return the minified string from the result writer
       return resultWriter.toString();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/DataValidationUtil.java
@@ -78,7 +78,8 @@ class DataValidationUtil {
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
-  private static final JsonFactory factory = new JsonFactory();
+  private static final JsonFactory factory =
+      new JsonFactory().configure(JsonGenerator.Feature.STRICT_DUPLICATE_DETECTION, true);
 
   // The version of Jackson we are using does not support serialization of date objects from the
   // java.time package. Here we define a module with custom java.time serializers. Additionally, we
@@ -176,6 +177,10 @@ class DataValidationUtil {
         throw valueFormatNotAllowedException(
             columnName, snowflakeType, "Not a valid JSON", insertRowIndex);
       } catch (IOException e) {
+        if (e.getMessage().contains("Duplicate field")) {
+          throw valueFormatNotAllowedException(
+              columnName, snowflakeType, "Not a valid JSON: duplicate field", insertRowIndex);
+        }
         throw new SFException(e, ErrorCode.IO_ERROR, "Cannot create JSON Parser or JSON generator");
       }
       // We return the minified string from the result writer

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -857,6 +857,29 @@ public class DataValidationUtilTest {
   }
 
   @Test
+  public void testValidateDuplicateKeys() {
+    // simple JSON object with duplicate keys can not be ingested
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () -> validateAndParseObjectNew("COL", "{\"key\":1, \"key\":2}", 0));
+
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () -> validateAndParseObjectNew("COL", "{\"key\":1, \"key\":2}".getBytes(), 0));
+
+    // nested JSON object with duplicate keys can not be ingested
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () ->
+            validateAndParseObjectNew("COL", "{\"key\":1, \"nested\":{\"key\":2, \"key\":3}}", 0));
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () ->
+            validateAndParseObjectNew(
+                "COL", "{\"key\":1, \"nested\":{\"key\":2, \"key\":3}}".getBytes(), 0));
+  }
+
+  @Test
   public void testTooLargeVariant() {
     char[] stringContent = new char[16 * 1024 * 1024 - 16]; // {"a":"11","b":""}
     Arrays.fill(stringContent, 'c');

--- a/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/DataValidationUtilTest.java
@@ -862,10 +862,9 @@ public class DataValidationUtilTest {
     expectError(
         ErrorCode.INVALID_VALUE_ROW,
         () -> validateAndParseObjectNew("COL", "{\"key\":1, \"key\":2}", 0));
-
     expectError(
         ErrorCode.INVALID_VALUE_ROW,
-        () -> validateAndParseObjectNew("COL", "{\"key\":1, \"key\":2}".getBytes(), 0));
+        () -> validateAndParseVariantNew("COL", "{\"key\":1, \"key\":2}", 0));
 
     // nested JSON object with duplicate keys can not be ingested
     expectError(
@@ -875,8 +874,15 @@ public class DataValidationUtilTest {
     expectError(
         ErrorCode.INVALID_VALUE_ROW,
         () ->
-            validateAndParseObjectNew(
-                "COL", "{\"key\":1, \"nested\":{\"key\":2, \"key\":3}}".getBytes(), 0));
+            validateAndParseVariantNew("COL", "{\"key\":1, \"nested\":{\"key\":2, \"key\":3}}", 0));
+
+    // array of objects with duplicate keys can not be ingested
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () -> validateAndParseArrayNew("COL", "[{\"key\":1, \"key\":2}]", 0));
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () -> validateAndParseVariantNew("COL", "[{\"key\":1, \"key\":2}]", 0));
   }
 
   @Test


### PR DESCRIPTION
The SDK should not ingest the variant like {"key": 1, "key": 2} otherwise, we would have issues in the XP during select and there is no good mitigation on that.

In this change, we would error out with INVALID_VALUE_ROW for such duplicate cases.

Added Unit test for the change.