### PR TITLE
close httpClient when closing simpleIngestManager

### DIFF
--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -608,6 +608,11 @@ public class SimpleIngestManager implements AutoCloseable {
   @Override
   public void close() {
     builder.closeResources();
+    try {
+      httpClient.close();
+    } catch (IOException e) {
+      LOGGER.error("Error closing http client", e);
+    }
     HttpUtil.shutdownHttpConnectionManagerDaemonThread();
   }
 


### PR DESCRIPTION
The CloseableHttpResponse is closed with try catch ([ref](https://github.com/snowflakedb/snowflake-ingest-java/blob/v3.0.1/src/main/java/net/snowflake/ingest/SimpleIngestManager.java#L532)), but the client itself is not getting closed, in case if exception is thrown [here](https://github.com/snowflakedb/snowflake-kafka-connector/blob/master/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceV1.java#L122). This is causing connection leaks, timeout errors and decrease in throughput.

Added the fix to close the httpClient in SimpleIngestManager close() method.

Will add ingestManager.close() [here](https://github.com/snowflakedb/snowflake-kafka-connector/blob/master/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceV1.java#L122) post this change.