### PR TITLE
allow passing custom metadata to `ParquetFlusher` for testing

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
@@ -25,7 +25,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.zip.CRC32;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
@@ -63,8 +62,8 @@ class BlobBuilder {
    * Builds blob.
    *
    * @param filePath Path of the destination file in cloud storage
-   * @param customFileId Allows setting a custom file ID to be embedded for all chunks in storage.
-   *     Used for testing.
+   * @param fileMetadataTestingOverrides Allows setting a custom file ID and SDK version to be
+   *     embedded for all chunks in storage. Used for testing.
    * @param blobData All the data for one blob. Assumes that all ChannelData in the inner List
    *     belongs to the same table. Will error if this is not the case
    * @param bdecVersion version of blob
@@ -72,7 +71,7 @@ class BlobBuilder {
    */
   static <T> Blob constructBlobAndMetadata(
       String filePath,
-      Optional<String> customFileId,
+      FileMetadataTestingOverrides fileMetadataTestingOverrides,
       List<List<ChannelData<T>>> blobData,
       Constants.BdecVersion bdecVersion,
       InternalParameterProvider internalParameterProvider,
@@ -105,7 +104,8 @@ class BlobBuilder {
 
       Flusher<T> flusher = channelsDataPerTable.get(0).createFlusher();
       Flusher.SerializationResult serializedChunk =
-          flusher.serialize(channelsDataPerTable, filePath, curDataSize, customFileId);
+          flusher.serialize(
+              channelsDataPerTable, filePath, curDataSize, fileMetadataTestingOverrides);
 
       if (!serializedChunk.channelsMetadataList.isEmpty()) {
         final byte[] compressedChunkData;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
@@ -65,6 +65,7 @@ class BlobBuilder {
    *
    * @param filePath Path of the destination file in cloud storage
    * @param customFileId Allows setting a custom file ID to be embedded for all chunks in storage.
+   *     Used for testing.
    * @param blobData All the data for one blob. Assumes that all ChannelData in the inner List
    *     belongs to the same table. Will error if this is not the case
    * @param bdecVersion version of blob

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
@@ -215,13 +215,13 @@ class BlobBuilder {
   private static String defaultFileId(String filePath, long chunkStartOffset) {
     String shortName = StreamingIngestUtils.getShortname(filePath);
     if (chunkStartOffset == 0) {
-        return shortName;
+      return shortName;
     } else {
-        // Using chunk offset as suffix ensures that for interleaved tables, the file
-        // id key is unique for each chunk.
-        final String[] parts = shortName.split("\\.");
-        Preconditions.checkState(parts.length == 2, "Invalid file name format");
-        return String.format("%s_%d.%s", parts[0], chunkStartOffset, parts[1]);
+      // Using chunk offset as suffix ensures that for interleaved tables, the file
+      // id key is unique for each chunk.
+      final String[] parts = shortName.split("\\.");
+      Preconditions.checkState(parts.length == 2, "Invalid file name format");
+      return String.format("%s_%d.%s", parts[0], chunkStartOffset, parts[1]);
     }
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/BlobBuilder.java
@@ -104,7 +104,7 @@ class BlobBuilder {
                   firstChannelFlushContext.getEncryptionKeyId()));
 
       Flusher<T> flusher = channelsDataPerTable.get(0).createFlusher();
-      String fileId = customFileId.orElse(defaultFileId(filePath, curDataSize));
+      String fileId = customFileId.orElse(createFileId(filePath, curDataSize));
       Flusher.SerializationResult serializedChunk =
           flusher.serialize(channelsDataPerTable, filePath, curDataSize, fileId);
 
@@ -212,7 +212,7 @@ class BlobBuilder {
     return new Blob(blobBytes, chunksMetadataList, new BlobStats());
   }
 
-  private static String defaultFileId(String filePath, long chunkStartOffset) {
+  private static String createFileId(String filePath, long chunkStartOffset) {
     String shortName = StreamingIngestUtils.getShortname(filePath);
     if (chunkStartOffset == 0) {
       return shortName;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileMetadataTestingOverrides.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileMetadataTestingOverrides.java
@@ -1,0 +1,37 @@
+package net.snowflake.ingest.streaming.internal;
+
+import java.util.Optional;
+
+/**
+ * Container for optional overrides of metadata being written to files. Used for testing. In normal
+ * operation, the overrides are inactive.
+ */
+public class FileMetadataTestingOverrides {
+  public final Optional<String> customFileId;
+  /**
+   *
+   * <li>Optional.empty() - no override, use the default SDK version.
+   * <li>Optional.of(Optional.empty()) - don't send an SDK version.
+   * <li>Optional.of("<version>") - send a custom SDK version.
+   */
+  public final Optional<Optional<String>> customSdkVersion;
+
+  FileMetadataTestingOverrides(
+      Optional<String> customFileId, Optional<Optional<String>> customSdkVersion) {
+    this.customFileId = customFileId;
+    this.customSdkVersion = customSdkVersion;
+  }
+
+  public static FileMetadataTestingOverrides none() {
+    return new FileMetadataTestingOverrides(Optional.empty(), Optional.empty());
+  }
+
+  @Override
+  public String toString() {
+    return "{customFileId="
+        + customFileId.orElse("<unchanged>")
+        + ", customSdkVersion="
+        + customSdkVersion.map((v) -> v.orElse("<removed>")).orElse("<unchanged>")
+        + "}";
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileMetadataTestingOverrides.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileMetadataTestingOverrides.java
@@ -34,4 +34,14 @@ public class FileMetadataTestingOverrides {
         + customSdkVersion.map((v) -> v.orElse("<removed>")).orElse("<unchanged>")
         + "}";
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof FileMetadataTestingOverrides)) {
+      return false;
+    }
+    FileMetadataTestingOverrides other = (FileMetadataTestingOverrides) o;
+    return customFileId.equals(other.customFileId)
+        && customSdkVersion.equals(other.customSdkVersion);
+  }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -508,7 +508,11 @@ class FlushService<T> {
             try {
               BlobMetadata blobMetadata =
                   buildAndUpload(
-                      blobPath, Optional.empty(), blobData, fullyQualifiedTableName, encryptionKeysPerTable);
+                      blobPath,
+                      Optional.empty(),
+                      blobData,
+                      fullyQualifiedTableName,
+                      encryptionKeysPerTable);
               blobMetadata.getBlobStats().setFlushStartMs(flushStartMs);
               return blobMetadata;
             } catch (Throwable e) {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -509,7 +509,7 @@ class FlushService<T> {
               BlobMetadata blobMetadata =
                   buildAndUpload(
                       blobPath,
-                      Optional.empty(),
+                      FileMetadataTestingOverrides.none(),
                       blobData,
                       fullyQualifiedTableName,
                       encryptionKeysPerTable);
@@ -595,8 +595,8 @@ class FlushService<T> {
    * Builds and uploads blob to cloud storage.
    *
    * @param blobPath Path of the destination blob in cloud storage
-   * @param customFileId Allows setting a custom file ID to be embedded for all chunks in storage.
-   *     Used for testing.
+   * @param fileMetadataTestingOverrides Allows setting a custom file ID and SDK version to be
+   *     embedded for all chunks in storage. Used for testing.
    * @param blobData All the data for one blob. Assumes that all ChannelData in the inner List
    *     belongs to the same table. Will error if this is not the case
    * @param fullyQualifiedTableName the table name of the first channel in the blob, only matters in
@@ -605,7 +605,7 @@ class FlushService<T> {
    */
   BlobMetadata buildAndUpload(
       BlobPath blobPath,
-      Optional<String> customFileId,
+      FileMetadataTestingOverrides fileMetadataTestingOverrides,
       List<List<ChannelData<T>>> blobData,
       String fullyQualifiedTableName,
       Map<FullyQualifiedTableName, EncryptionKey> encryptionKeysPerTable)
@@ -618,7 +618,7 @@ class FlushService<T> {
     BlobBuilder.Blob blob =
         BlobBuilder.constructBlobAndMetadata(
             blobPath.fileRegistrationPath,
-            customFileId,
+            fileMetadataTestingOverrides,
             blobData,
             bdecVersion,
             this.owningClient.getInternalParameterProvider(),

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -508,7 +508,7 @@ class FlushService<T> {
             try {
               BlobMetadata blobMetadata =
                   buildAndUpload(
-                      blobPath, blobData, fullyQualifiedTableName, encryptionKeysPerTable);
+                      blobPath, Optional.empty(), blobData, fullyQualifiedTableName, encryptionKeysPerTable);
               blobMetadata.getBlobStats().setFlushStartMs(flushStartMs);
               return blobMetadata;
             } catch (Throwable e) {
@@ -599,6 +599,7 @@ class FlushService<T> {
    */
   BlobMetadata buildAndUpload(
       BlobPath blobPath,
+      Optional<String> customFileId,
       List<List<ChannelData<T>>> blobData,
       String fullyQualifiedTableName,
       Map<FullyQualifiedTableName, EncryptionKey> encryptionKeysPerTable)
@@ -611,6 +612,7 @@ class FlushService<T> {
     BlobBuilder.Blob blob =
         BlobBuilder.constructBlobAndMetadata(
             blobPath.fileRegistrationPath,
+            customFileId,
             blobData,
             bdecVersion,
             this.owningClient.getInternalParameterProvider(),

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -595,6 +595,8 @@ class FlushService<T> {
    * Builds and uploads blob to cloud storage.
    *
    * @param blobPath Path of the destination blob in cloud storage
+   * @param customFileId Allows setting a custom file ID to be embedded for all chunks in storage.
+   *     Used for testing.
    * @param blobData All the data for one blob. Assumes that all ChannelData in the inner List
    *     belongs to the same table. Will error if this is not the case
    * @param fullyQualifiedTableName the table name of the first channel in the blob, only matters in

--- a/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
@@ -24,11 +24,12 @@ public interface Flusher<T> {
    * @param channelsDataPerTable buffered rows
    * @param filePath file path
    * @param chunkStartOffset
+   * @param fileId the file ID to be stored within the chunk
    * @return {@link SerializationResult}
    * @throws IOException
    */
   SerializationResult serialize(
-      List<ChannelData<T>> channelsDataPerTable, String filePath, long chunkStartOffset)
+      List<ChannelData<T>> channelsDataPerTable, String filePath, long chunkStartOffset, String fileId)
       throws IOException;
 
   /** Holds result of the buffered rows conversion: channel metadata and stats. */

--- a/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
@@ -8,7 +8,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import net.snowflake.ingest.utils.Pair;
 
 /**
@@ -24,8 +23,8 @@ public interface Flusher<T> {
    * @param channelsDataPerTable buffered rows
    * @param filePath file path
    * @param chunkStartOffset
-   * @param customFileId Allows setting a custom file ID to be embedded for all chunks in storage.
-   *     Used for testing.
+   * @param fileMetadataTestingOverrides Allows setting a custom file ID and SDK version to be
+   *     embedded for all chunks in storage. Used for testing.
    * @return {@link SerializationResult}
    * @throws IOException
    */
@@ -33,7 +32,7 @@ public interface Flusher<T> {
       List<ChannelData<T>> channelsDataPerTable,
       String filePath,
       long chunkStartOffset,
-      Optional<String> customFileId)
+      FileMetadataTestingOverrides fileMetadataTestingOverrides)
       throws IOException;
 
   /** Holds result of the buffered rows conversion: channel metadata and stats. */

--- a/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import net.snowflake.ingest.utils.Pair;
 
 /**
@@ -20,11 +21,11 @@ public interface Flusher<T> {
   /**
    * Serialize buffered rows into the underlying format.
    *
-   * @param fullyQualifiedTableName
    * @param channelsDataPerTable buffered rows
    * @param filePath file path
    * @param chunkStartOffset
-   * @param fileId the file ID to be stored within the chunk
+   * @param customFileId Allows setting a custom file ID to be embedded for all chunks in storage.
+   *     Used for testing.
    * @return {@link SerializationResult}
    * @throws IOException
    */
@@ -32,7 +33,7 @@ public interface Flusher<T> {
       List<ChannelData<T>> channelsDataPerTable,
       String filePath,
       long chunkStartOffset,
-      String fileId)
+      Optional<String> customFileId)
       throws IOException;
 
   /** Holds result of the buffered rows conversion: channel metadata and stats. */

--- a/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/Flusher.java
@@ -29,7 +29,10 @@ public interface Flusher<T> {
    * @throws IOException
    */
   SerializationResult serialize(
-      List<ChannelData<T>> channelsDataPerTable, String filePath, long chunkStartOffset, String fileId)
+      List<ChannelData<T>> channelsDataPerTable,
+      String filePath,
+      long chunkStartOffset,
+      String fileId)
       throws IOException;
 
   /** Holds result of the buffered rows conversion: channel metadata and stats. */

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ParquetFlusher.java
@@ -93,7 +93,8 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       channelsMetadataList.add(channelMetadata);
 
       logger.logDebug(
-          "Parquet Flusher: Start building channel={}, rowCount={}, bufferSize={} in blob={}, fileId={}",
+          "Parquet Flusher: Start building channel={}, rowCount={}, bufferSize={} in blob={},"
+              + " fileId={}",
           data.getChannelContext().getFullyQualifiedName(),
           data.getRowCount(),
           data.getBufferSize(),
@@ -127,7 +128,8 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
       chunkEstimatedUncompressedSize += data.getBufferSize();
 
       logger.logDebug(
-          "Parquet Flusher: Finish building channel={}, rowCount={}, bufferSize={} in blob={}, fileId={}",
+          "Parquet Flusher: Finish building channel={}, rowCount={}, bufferSize={} in blob={},"
+              + " fileId={}",
           data.getChannelContext().getFullyQualifiedName(),
           data.getRowCount(),
           data.getBufferSize(),
@@ -172,7 +174,7 @@ public class ParquetFlusher implements Flusher<ParquetChunkData> {
     // Each chunk is logically a separate Parquet file that happens to be bundled together.
     if (enableIcebergStreaming) {
       Preconditions.checkState(
-              chunkStartOffset == 0, "Iceberg streaming is not supported with non-zero offsets");
+          chunkStartOffset == 0, "Iceberg streaming is not supported with non-zero offsets");
       metadata.put(Constants.ASSIGNED_FULL_FILE_NAME_KEY, fileId);
     } else {
       metadata.put(Constants.PRIMARY_FILE_ID_KEY, fileId);

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -57,7 +57,7 @@ public class BlobBuilderTest {
     // Construction succeeds if both data and metadata contain 1 row
     BlobBuilder.constructBlobAndMetadata(
         "a.bdec",
-        Optional.empty(),
+        FileMetadataTestingOverrides.none(),
         Collections.singletonList(createChannelDataPerTable(1)),
         Constants.BdecVersion.THREE,
         new InternalParameterProvider(enableIcebergStreaming, false /* enableNDVCount */),
@@ -67,7 +67,7 @@ public class BlobBuilderTest {
     try {
       BlobBuilder.constructBlobAndMetadata(
           "a.bdec",
-          Optional.empty(),
+          FileMetadataTestingOverrides.none(),
           Collections.singletonList(createChannelDataPerTable(0)),
           Constants.BdecVersion.THREE,
           new InternalParameterProvider(enableIcebergStreaming, false /* enableNDVCount */),
@@ -93,7 +93,7 @@ public class BlobBuilderTest {
     BlobBuilder.Blob blob =
         BlobBuilder.constructBlobAndMetadata(
             "a.parquet",
-            Optional.empty(),
+            FileMetadataTestingOverrides.none(),
             Collections.singletonList(createChannelDataPerTable(1)),
             Constants.BdecVersion.THREE,
             new InternalParameterProvider(enableIcebergStreaming, false /* enableNDVCount */),

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -57,6 +57,7 @@ public class BlobBuilderTest {
     // Construction succeeds if both data and metadata contain 1 row
     BlobBuilder.constructBlobAndMetadata(
         "a.bdec",
+        Optional.empty(),
         Collections.singletonList(createChannelDataPerTable(1)),
         Constants.BdecVersion.THREE,
         new InternalParameterProvider(enableIcebergStreaming, false /* enableNDVCount */),
@@ -66,6 +67,7 @@ public class BlobBuilderTest {
     try {
       BlobBuilder.constructBlobAndMetadata(
           "a.bdec",
+          Optional.empty(),
           Collections.singletonList(createChannelDataPerTable(0)),
           Constants.BdecVersion.THREE,
           new InternalParameterProvider(enableIcebergStreaming, false /* enableNDVCount */),
@@ -91,6 +93,7 @@ public class BlobBuilderTest {
     BlobBuilder.Blob blob =
         BlobBuilder.constructBlobAndMetadata(
             "a.parquet",
+            Optional.empty(),
             Collections.singletonList(createChannelDataPerTable(1)),
             Constants.BdecVersion.THREE,
             new InternalParameterProvider(enableIcebergStreaming, false /* enableNDVCount */),

--- a/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/BlobBuilderTest.java
@@ -7,8 +7,6 @@ package net.snowflake.ingest.streaming.internal;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -133,101 +131,28 @@ public class BlobBuilderTest {
                 - Integer.BYTES);
   }
 
-  @Test
-  public void testFileIdCreationSingleTable() throws Exception {
-    ParquetFlusher flusher = Mockito.spy(createParquetFlusher(createSchema("C1")));
-
-    Map<FullyQualifiedTableName, EncryptionKey> encryptionKeysPerTable = new ConcurrentHashMap<>();
-    encryptionKeysPerTable.put(
-        new FullyQualifiedTableName("DB", "SCHEMA", "TABLE"),
-        new EncryptionKey("DB", "SCHEMA", "TABLE", "KEY", 1234L));
-
-    ChannelData<ParquetChunkData> channelData = Mockito.spy(createChannelDataPerTable(1).get(0));
-    channelData.setFlusherFactory(() -> flusher);
-    List<ChannelData<ParquetChunkData>> tableData = Collections.singletonList(channelData);
-
-    BlobBuilder.constructBlobAndMetadata(
-        "a.bdec",
-        Optional.empty(),
-        Collections.singletonList(tableData),
-        Constants.BdecVersion.THREE,
-        new InternalParameterProvider(enableIcebergStreaming, false /* enableNDVCount */),
-        encryptionKeysPerTable);
-
-    Mockito.verify(flusher)
-        .serialize(Mockito.any(), Mockito.eq("a.bdec"), Mockito.eq(0L), Mockito.eq("a.bdec"));
-  }
-
-  @Test
-  public void testFileIdCreationMultipleTables() throws Exception {
-    ParquetFlusher flusher = Mockito.spy(createParquetFlusher(createSchema("C1")));
-
-    Map<FullyQualifiedTableName, EncryptionKey> encryptionKeysPerTable = new ConcurrentHashMap<>();
-    List<List<ChannelData<ParquetChunkData>>> blobData = new ArrayList<>();
-    for (String tableName : Arrays.asList("TABLE", "OTHERTABLE")) {
-      encryptionKeysPerTable.put(
-          new FullyQualifiedTableName("DB", "SCHEMA", tableName),
-          new EncryptionKey("DB", "SCHEMA", tableName, "KEY", 1234L));
-
-      ChannelData<ParquetChunkData> channelData =
-          Mockito.spy(createChannelDataPerTable(1, tableName).get(0));
-      channelData.setFlusherFactory(() -> flusher);
-      blobData.add(Collections.singletonList(channelData));
-    }
-
-    try {
-      BlobBuilder.constructBlobAndMetadata(
-          "a.bdec",
-          Optional.empty(),
-          blobData,
-          Constants.BdecVersion.THREE,
-          new InternalParameterProvider(enableIcebergStreaming, false /* enableNDVCount */),
-          encryptionKeysPerTable);
-    } catch (IllegalStateException e) {
-      if (enableIcebergStreaming) {
-        Assert.assertTrue(
-            e.getMessage().contains("Iceberg streaming is not supported with non-zero offsets"));
-        return;
-      } else {
-        throw e;
-      }
-    }
-
-    Mockito.verify(flusher)
-        .serialize(Mockito.any(), Mockito.eq("a.bdec"), Mockito.eq(0L), Mockito.eq("a.bdec"));
-
-    Mockito.verify(flusher)
-        .serialize(Mockito.any(), Mockito.eq("a.bdec"), Mockito.eq(336L), Mockito.eq("a_336.bdec"));
-  }
-
-  private List<ChannelData<ParquetChunkData>> createChannelDataPerTable(int metadataRowCount)
-      throws IOException {
-    return createChannelDataPerTable(metadataRowCount, "TABLE");
-  }
-
-  private ParquetFlusher createParquetFlusher(MessageType schema) {
-    return new ParquetFlusher(
-        schema,
-        100L,
-        enableIcebergStreaming ? Optional.of(1) : Optional.empty(),
-        Constants.BdecParquetCompression.GZIP,
-        enableIcebergStreaming
-            ? ParquetProperties.WriterVersion.PARQUET_2_0
-            : ParquetProperties.WriterVersion.PARQUET_1_0,
-        enableIcebergStreaming,
-        enableIcebergStreaming);
-  }
-
   /**
    * Creates a channel data configurable number of rows in metadata and 1 physical row (using both
    * with and without internal buffering optimization)
    */
-  private List<ChannelData<ParquetChunkData>> createChannelDataPerTable(
-      int metadataRowCount, String tableName) throws IOException {
+  private List<ChannelData<ParquetChunkData>> createChannelDataPerTable(int metadataRowCount)
+      throws IOException {
     String columnName = "C1";
     ChannelData<ParquetChunkData> channelData = Mockito.spy(new ChannelData<>());
     MessageType schema = createSchema(columnName);
-    Mockito.doReturn(createParquetFlusher(schema)).when(channelData).createFlusher();
+    Mockito.doReturn(
+            new ParquetFlusher(
+                schema,
+                100L,
+                enableIcebergStreaming ? Optional.of(1) : Optional.empty(),
+                Constants.BdecParquetCompression.GZIP,
+                enableIcebergStreaming
+                    ? ParquetProperties.WriterVersion.PARQUET_2_0
+                    : ParquetProperties.WriterVersion.PARQUET_1_0,
+                enableIcebergStreaming,
+                enableIcebergStreaming))
+        .when(channelData)
+        .createFlusher();
 
     channelData.setRowSequencer(1L);
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
@@ -270,7 +195,7 @@ public class BlobBuilderTest {
                     enableIcebergStreaming)
                 : new RowBufferStats(columnName, null, 1, null, null, false, false));
     channelData.setChannelContext(
-        new ChannelFlushContext("channel1", "DB", "SCHEMA", tableName, 1L, "enc", 1L));
+        new ChannelFlushContext("channel1", "DB", "SCHEMA", "TABLE", 1L, "enc", 1L));
     return Collections.singletonList(channelData);
   }
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -39,7 +39,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -168,7 +167,7 @@ public class FlushServiceTest {
       List<List<ChannelData<T>>> blobData = Collections.singletonList(channelData);
       return flushService.buildAndUpload(
           new BlobPath("file_name" /* uploadPath */, "file_name" /* fileRegistrationPath */),
-          Optional.empty(),
+          FileMetadataTestingOverrides.none(),
           blobData,
           blobData.get(0).get(0).getChannelContext().getFullyQualifiedTableName(),
           encryptionKeysPerTable);
@@ -661,7 +660,7 @@ public class FlushServiceTest {
       Mockito.verify(flushService, Mockito.atLeast(2))
           .buildAndUpload(
               Mockito.any(),
-              Mockito.eq(Optional.empty()),
+              Mockito.eq(FileMetadataTestingOverrides.none()),
               Mockito.any(),
               Mockito.any(),
               Mockito.any());
@@ -719,7 +718,7 @@ public class FlushServiceTest {
       Mockito.verify(flushService, Mockito.atLeast(2))
           .buildAndUpload(
               Mockito.any(),
-              Mockito.eq(Optional.empty()),
+              Mockito.eq(FileMetadataTestingOverrides.none()),
               Mockito.any(),
               Mockito.any(),
               Mockito.any());
@@ -762,7 +761,7 @@ public class FlushServiceTest {
       Mockito.verify(flushService, Mockito.times(2))
           .buildAndUpload(
               Mockito.any(),
-              Mockito.eq(Optional.empty()),
+              Mockito.eq(FileMetadataTestingOverrides.none()),
               Mockito.any(),
               Mockito.any(),
               Mockito.any());
@@ -815,7 +814,7 @@ public class FlushServiceTest {
     Mockito.verify(flushService, Mockito.times(expectedBlobs))
         .buildAndUpload(
             Mockito.any(),
-            Mockito.eq(Optional.empty()),
+            Mockito.eq(FileMetadataTestingOverrides.none()),
             blobDataCaptor.capture(),
             Mockito.any(),
             Mockito.any());
@@ -868,7 +867,7 @@ public class FlushServiceTest {
     Mockito.verify(flushService, Mockito.atLeast(2))
         .buildAndUpload(
             Mockito.any(),
-            Mockito.eq(Optional.empty()),
+            Mockito.eq(FileMetadataTestingOverrides.none()),
             blobDataCaptor.capture(),
             Mockito.any(),
             Mockito.any());

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -659,7 +659,12 @@ public class FlushServiceTest {
     if (!enableIcebergStreaming) {
       flushService.flush(true).get();
       Mockito.verify(flushService, Mockito.atLeast(2))
-          .buildAndUpload(Mockito.any(), Mockito.eq(Optional.empty()), Mockito.any(), Mockito.any(), Mockito.any());
+          .buildAndUpload(
+              Mockito.any(),
+              Mockito.eq(Optional.empty()),
+              Mockito.any(),
+              Mockito.any(),
+              Mockito.any());
     }
   }
 
@@ -712,7 +717,12 @@ public class FlushServiceTest {
       // Force = true flushes
       flushService.flush(true).get();
       Mockito.verify(flushService, Mockito.atLeast(2))
-          .buildAndUpload(Mockito.any(), Mockito.eq(Optional.empty()), Mockito.any(), Mockito.any(), Mockito.any());
+          .buildAndUpload(
+              Mockito.any(),
+              Mockito.eq(Optional.empty()),
+              Mockito.any(),
+              Mockito.any(),
+              Mockito.any());
     }
   }
 
@@ -750,7 +760,12 @@ public class FlushServiceTest {
       // Force = true flushes
       flushService.flush(true).get();
       Mockito.verify(flushService, Mockito.times(2))
-          .buildAndUpload(Mockito.any(), Mockito.eq(Optional.empty()), Mockito.any(), Mockito.any(), Mockito.any());
+          .buildAndUpload(
+              Mockito.any(),
+              Mockito.eq(Optional.empty()),
+              Mockito.any(),
+              Mockito.any(),
+              Mockito.any());
     }
   }
 
@@ -798,7 +813,12 @@ public class FlushServiceTest {
     ArgumentCaptor<List<List<ChannelData<List<List<Object>>>>>> blobDataCaptor =
         ArgumentCaptor.forClass(List.class);
     Mockito.verify(flushService, Mockito.times(expectedBlobs))
-        .buildAndUpload(Mockito.any(), Mockito.eq(Optional.empty()), blobDataCaptor.capture(), Mockito.any(), Mockito.any());
+        .buildAndUpload(
+            Mockito.any(),
+            Mockito.eq(Optional.empty()),
+            blobDataCaptor.capture(),
+            Mockito.any(),
+            Mockito.any());
 
     // 1. list => blobs; 2. list => chunks; 3. list => channels; 4. list => rows, 5. list => columns
     List<List<List<ChannelData<List<List<Object>>>>>> allUploadedBlobs =
@@ -846,7 +866,12 @@ public class FlushServiceTest {
     ArgumentCaptor<List<List<ChannelData<List<List<Object>>>>>> blobDataCaptor =
         ArgumentCaptor.forClass(List.class);
     Mockito.verify(flushService, Mockito.atLeast(2))
-        .buildAndUpload(Mockito.any(), Mockito.eq(Optional.empty()), blobDataCaptor.capture(), Mockito.any(), Mockito.any());
+        .buildAndUpload(
+            Mockito.any(),
+            Mockito.eq(Optional.empty()),
+            blobDataCaptor.capture(),
+            Mockito.any(),
+            Mockito.any());
 
     // 1. list => blobs; 2. list => chunks; 3. list => channels; 4. list => rows, 5. list => columns
     List<List<List<ChannelData<List<List<Object>>>>>> allUploadedBlobs =

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -167,6 +168,7 @@ public class FlushServiceTest {
       List<List<ChannelData<T>>> blobData = Collections.singletonList(channelData);
       return flushService.buildAndUpload(
           new BlobPath("file_name" /* uploadPath */, "file_name" /* fileRegistrationPath */),
+          Optional.empty(),
           blobData,
           blobData.get(0).get(0).getChannelContext().getFullyQualifiedTableName(),
           encryptionKeysPerTable);
@@ -657,7 +659,7 @@ public class FlushServiceTest {
     if (!enableIcebergStreaming) {
       flushService.flush(true).get();
       Mockito.verify(flushService, Mockito.atLeast(2))
-          .buildAndUpload(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+          .buildAndUpload(Mockito.any(), Mockito.eq(Optional.empty()), Mockito.any(), Mockito.any(), Mockito.any());
     }
   }
 
@@ -710,7 +712,7 @@ public class FlushServiceTest {
       // Force = true flushes
       flushService.flush(true).get();
       Mockito.verify(flushService, Mockito.atLeast(2))
-          .buildAndUpload(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+          .buildAndUpload(Mockito.any(), Mockito.eq(Optional.empty()), Mockito.any(), Mockito.any(), Mockito.any());
     }
   }
 
@@ -748,7 +750,7 @@ public class FlushServiceTest {
       // Force = true flushes
       flushService.flush(true).get();
       Mockito.verify(flushService, Mockito.times(2))
-          .buildAndUpload(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+          .buildAndUpload(Mockito.any(), Mockito.eq(Optional.empty()), Mockito.any(), Mockito.any(), Mockito.any());
     }
   }
 
@@ -796,7 +798,7 @@ public class FlushServiceTest {
     ArgumentCaptor<List<List<ChannelData<List<List<Object>>>>>> blobDataCaptor =
         ArgumentCaptor.forClass(List.class);
     Mockito.verify(flushService, Mockito.times(expectedBlobs))
-        .buildAndUpload(Mockito.any(), blobDataCaptor.capture(), Mockito.any(), Mockito.any());
+        .buildAndUpload(Mockito.any(), Mockito.eq(Optional.empty()), blobDataCaptor.capture(), Mockito.any(), Mockito.any());
 
     // 1. list => blobs; 2. list => chunks; 3. list => channels; 4. list => rows, 5. list => columns
     List<List<List<ChannelData<List<List<Object>>>>>> allUploadedBlobs =
@@ -844,7 +846,7 @@ public class FlushServiceTest {
     ArgumentCaptor<List<List<ChannelData<List<List<Object>>>>>> blobDataCaptor =
         ArgumentCaptor.forClass(List.class);
     Mockito.verify(flushService, Mockito.atLeast(2))
-        .buildAndUpload(Mockito.any(), blobDataCaptor.capture(), Mockito.any(), Mockito.any());
+        .buildAndUpload(Mockito.any(), Mockito.eq(Optional.empty()), blobDataCaptor.capture(), Mockito.any(), Mockito.any());
 
     // 1. list => blobs; 2. list => chunks; 3. list => channels; 4. list => rows, 5. list => columns
     List<List<List<ChannelData<List<List<Object>>>>>> allUploadedBlobs =

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -2306,6 +2306,7 @@ public class RowBufferTest {
   @Test
   public void testParquetFileNameMetadata() throws IOException {
     String filePath = "testParquetFileNameMetadata.bdec";
+    String fileId = filePath;
     final ParquetRowBuffer bufferUnderTest =
         (ParquetRowBuffer) createTestBuffer(OpenChannelRequest.OnErrorOption.CONTINUE);
 
@@ -2327,7 +2328,7 @@ public class RowBufferTest {
     ParquetFlusher flusher = (ParquetFlusher) bufferUnderTest.createFlusher();
     {
       Flusher.SerializationResult result =
-          flusher.serialize(Collections.singletonList(data), filePath, 0);
+          flusher.serialize(Collections.singletonList(data), filePath, 0, fileId);
 
       BdecParquetReader reader = new BdecParquetReader(result.chunkData.toByteArray());
       Assert.assertEquals(
@@ -2345,7 +2346,7 @@ public class RowBufferTest {
     {
       try {
         Flusher.SerializationResult result =
-            flusher.serialize(Collections.singletonList(data), filePath, 13);
+            flusher.serialize(Collections.singletonList(data), filePath, 13, fileId);
         if (enableIcebergStreaming) {
           Assert.fail(
               "Should have thrown an exception because iceberg streams do not support offsets");
@@ -2353,7 +2354,8 @@ public class RowBufferTest {
 
         BdecParquetReader reader = new BdecParquetReader(result.chunkData.toByteArray());
         Assert.assertEquals(
-            "testParquetFileNameMetadata_13.bdec",
+            // NB the file ID passed to `serialize` would normally reflect the offset, but here it's a static value.
+            "testParquetFileNameMetadata.bdec",
             reader
                 .getKeyValueMetadata()
                 .get(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -2354,7 +2354,8 @@ public class RowBufferTest {
 
         BdecParquetReader reader = new BdecParquetReader(result.chunkData.toByteArray());
         Assert.assertEquals(
-            // NB the file ID passed to `serialize` would normally reflect the offset, but here it's a static value.
+            // NB the file ID passed to `serialize` would normally reflect the offset, but here it's
+            // a static value.
             "testParquetFileNameMetadata.bdec",
             reader
                 .getKeyValueMetadata()

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RowBufferTest.java
@@ -2327,7 +2327,8 @@ public class RowBufferTest {
     ParquetFlusher flusher = (ParquetFlusher) bufferUnderTest.createFlusher();
     {
       Flusher.SerializationResult result =
-          flusher.serialize(Collections.singletonList(data), filePath, 0, Optional.empty());
+          flusher.serialize(
+              Collections.singletonList(data), filePath, 0, FileMetadataTestingOverrides.none());
 
       BdecParquetReader reader = new BdecParquetReader(result.chunkData.toByteArray());
       Assert.assertEquals(
@@ -2345,7 +2346,8 @@ public class RowBufferTest {
     {
       try {
         Flusher.SerializationResult result =
-            flusher.serialize(Collections.singletonList(data), filePath, 13, Optional.empty());
+            flusher.serialize(
+                Collections.singletonList(data), filePath, 13, FileMetadataTestingOverrides.none());
         if (enableIcebergStreaming) {
           Assert.fail(
               "Should have thrown an exception because iceberg streams do not support offsets");
@@ -2370,8 +2372,14 @@ public class RowBufferTest {
       }
     }
     {
+      // Test custom file ID and SDK version written to the file.
       Flusher.SerializationResult result =
-          flusher.serialize(Collections.singletonList(data), filePath, 0, Optional.of("customId"));
+          flusher.serialize(
+              Collections.singletonList(data),
+              filePath,
+              0,
+              new FileMetadataTestingOverrides(
+                  Optional.of("customId"), Optional.of(Optional.of("customVersion"))));
 
       BdecParquetReader reader = new BdecParquetReader(result.chunkData.toByteArray());
       Assert.assertEquals(
@@ -2383,8 +2391,27 @@ public class RowBufferTest {
                       ? Constants.ASSIGNED_FULL_FILE_NAME_KEY
                       : Constants.PRIMARY_FILE_ID_KEY));
       Assert.assertEquals(
-          RequestBuilder.DEFAULT_VERSION,
-          reader.getKeyValueMetadata().get(Constants.SDK_VERSION_KEY));
+          "customVersion", reader.getKeyValueMetadata().get(Constants.SDK_VERSION_KEY));
+    }
+    {
+      // Test removing the SDK version written to the file.
+      Flusher.SerializationResult result =
+          flusher.serialize(
+              Collections.singletonList(data),
+              filePath,
+              0,
+              new FileMetadataTestingOverrides(Optional.empty(), Optional.of(Optional.empty())));
+
+      BdecParquetReader reader = new BdecParquetReader(result.chunkData.toByteArray());
+      Assert.assertEquals(
+          "testParquetFileNameMetadata.bdec",
+          reader
+              .getKeyValueMetadata()
+              .get(
+                  enableIcebergStreaming
+                      ? Constants.ASSIGNED_FULL_FILE_NAME_KEY
+                      : Constants.PRIMARY_FILE_ID_KEY));
+      Assert.assertNull(reader.getKeyValueMetadata().get(Constants.SDK_VERSION_KEY));
     }
   }
 


### PR DESCRIPTION
The primary reason for this PR is to allow passing a custom fileId for testing PPN behavior in Snowflake. This unblocks migrating some tests to Snowfort.