### PR TITLE
Revert httpclient connection close

### DIFF
--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -608,11 +608,6 @@ public class SimpleIngestManager implements AutoCloseable {
   @Override
   public void close() {
     builder.closeResources();
-    try {
-      httpClient.close();
-    } catch (IOException e) {
-      LOGGER.error("Error closing http client", e);
-    }
     HttpUtil.shutdownHttpConnectionManagerDaemonThread();
   }
 


### PR DESCRIPTION
When an httpClient is created in SimpleIngestManager [here](https://github.com/snowflakedb/snowflake-ingest-java/blob/master/src/main/java/net/snowflake/ingest/SimpleIngestManager.java#L406), a corresponding internal static httpClient is instantiated within the HttpUtil class. A new httpClient is only created if the current one is null.

Specifically, calling HttpUtil.getHttpClient(account) multiple times will return the same httpClient instance, provided it is not already initialized. Since this httpClient is static, it is shared across multiple instances for the same account.

With the recent code changes, the httpClient is now closed within SimpleIngestManager. However, it remains non-null in HttpUtil, meaning the same closed httpClient will be returned by subsequent calls to HttpUtil.getHttpClient(account). This results in issues, as the httpClient is already closed and cannot be reused. 

To resolve this, we need to revert the changes. The static httpClient in HttpUtil is shared across instances, and closing it in one instance affects all other instances, leading to errors. The error is reproducible with snowflake kafka connector IT's.
