### PR TITLE
Revert of df6bc9e85b2fd872d912bff5c47571ed237737ec

### DIFF
--- a/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
+++ b/src/main/java/net/snowflake/ingest/SimpleIngestManager.java
@@ -608,11 +608,6 @@ public class SimpleIngestManager implements AutoCloseable {
   @Override
   public void close() {
     builder.closeResources();
-    try {
-      httpClient.close();
-    } catch (IOException e) {
-      LOGGER.error("Error closing http client", e);
-    }
     HttpUtil.shutdownHttpConnectionManagerDaemonThread();
   }
 


### PR DESCRIPTION
We are revering this (recent) change because it was reported to cause regressions to our Kafka Connector. For a discussion see https://snow-external.slack.com/archives/C02282DHC7K/p1739772667115639 (private channel but reviewers must have access).

cc @sfc-gh-xhuang @sfc-gh-tzhang 