### PR TITLE
SNOW-1881734 Silence uploadWithoutConnection exception log

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/InternalStage.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/InternalStage.java
@@ -188,6 +188,7 @@ class InternalStage implements IStorage {
         SnowflakeFileTransferAgent.uploadWithoutConnection(
             SnowflakeFileTransferConfig.Builder.newInstance()
                 .setSnowflakeFileTransferMetadata(fileTransferMetadataCopy)
+                .setSilentException(true)
                 .setUploadStream(inStream)
                 .setRequireCompress(false)
                 .setOcspMode(OCSPMode.FAIL_OPEN)


### PR DESCRIPTION
This PR takes advantage of a new feature in JDBC driver 3.22.0, which lets us silence exception log in the JDBC driver in case an upload fails. 