### PR TITLE
Adds additional docstring information

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestChannel.java
+++ b/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestChannel.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import net.snowflake.ingest.streaming.internal.ColumnProperties;
+import net.snowflake.ingest.utils.SFException;
 
 /**
  * A logical partition that represents a connection to a single Snowflake table, data will be
@@ -27,7 +28,7 @@ public interface SnowflakeStreamingIngestChannel {
    * Get the fully qualified channel name
    *
    * @return fully qualified name of the channel, in the format of
-   *     dbName.schemaName.tableName.channelName
+   *     `dbName.schemaName.tableName.channelName`
    */
   String getFullyQualifiedName();
 
@@ -62,24 +63,35 @@ public interface SnowflakeStreamingIngestChannel {
   /**
    * Get the fully qualified table name that the channel belongs to
    *
-   * @return fully qualified table name, in the format of dbName.schemaName.tableName
+   * @return fully qualified table name, in the format of `dbName.schemaName.tableName`
    */
   String getFullyQualifiedTableName();
 
   /**
-   * @return a boolean which indicates whether the channel is valid
+   * @return a boolean which indicates whether the channel is valid. Typically, this means whether
+   *     the current instance is the owner of the channel, i.e., if another Client opens a {@link
+   *     SnowflakeStreamingIngestChannel} of the same name then the current instance will be
+   *     considered "invalid" as its persisted epoch will have increased. If this returns false then
+   *     calling `insertRow(s)` on this channel instance will result in an {@link SFException} and
+   *     no further writes to the channel will be accepted.
+   *     <p>>Note: there may be a delay between server-side invalidations and the Client detecting
+   *     it so this may not immediately return false in the event of a server-side invalidation.
    */
   boolean isValid();
 
   /**
-   * @return a boolean which indicates whether the channel is closed
+   * @return a boolean which indicates whether the channel is closed. If true this means that the
+   *     current {@link SnowflakeStreamingIngestChannel} will not accept any additional rows on
+   *     calls to `insertRow(s)`
    */
   boolean isClosed();
 
   /**
-   * Close the channel, this function will make sure all the data in this channel is committed
+   * Close the channel. Closing entails draining any outstanding data in the Channel's buffer and
+   * marking the Channel as no longer being able to accept writes via `insertRow(s)`
    *
-   * @return a completable future which will be completed when the channel is closed
+   * @return a completable future which will be completed when the channel is closed after flushing
+   *     any outstanding data.
    */
   CompletableFuture<Void> close();
 
@@ -206,7 +218,7 @@ public interface SnowflakeStreamingIngestChannel {
    *                 </li>
    *
    *             </ul>
-   *
+   * <p>
    *             For TIMESTAMP_LTZ and TIMESTAMP_TZ, all input without timezone will be by default interpreted in the timezone "America/Los_Angeles". This can be changed by calling {@link net.snowflake.ingest.streaming.OpenChannelRequest.OpenChannelRequestBuilder#setDefaultTimezone(ZoneId)}.
    *         </td>
    *         <tr>
@@ -248,6 +260,9 @@ public interface SnowflakeStreamingIngestChannel {
    * @param offsetToken offset of given row, used for replay in case of failures. It could be null
    *     if you don't plan on replaying or can't replay
    * @return insert response that possibly contains errors because of insertion failures
+   * @throws SFException if the channel is not considered "valid". Typically, this means that
+   *     another Client has claimed ownership of the Channel. Writes to this channel will be
+   *     rejected and result in this exception being thrown.
    */
   InsertValidationResponse insertRow(Map<String, Object> row, @Nullable String offsetToken);
 
@@ -262,6 +277,9 @@ public interface SnowflakeStreamingIngestChannel {
    * @param endOffsetToken end offset of the batch/row-set, used for replay in case of failures, *
    *     It could be null if you don't plan on replaying or can't replay
    * @return insert response that possibly contains errors because of insertion failures
+   * @throws SFException if the channel is not considered "valid". Typically, this means that
+   *     another Client has claimed ownership of the Channel. Writes to this channel will be
+   *     rejected and result in this exception being thrown.
    */
   InsertValidationResponse insertRows(
       Iterable<Map<String, Object>> rows,
@@ -271,6 +289,10 @@ public interface SnowflakeStreamingIngestChannel {
   /**
    * Insert a batch of rows into the channel with the end offset token only, please see {@link
    * SnowflakeStreamingIngestChannel#insertRows(Iterable, String, String)} for more information.
+   *
+   * @throws SFException if the channel is not considered "valid". Typically, this means that
+   *     another Client has claimed ownership of the Channel. Writes to this channel will be
+   *     rejected and result in this exception being thrown.
    */
   InsertValidationResponse insertRows(
       Iterable<Map<String, Object>> rows, @Nullable String offsetToken);
@@ -279,6 +301,11 @@ public interface SnowflakeStreamingIngestChannel {
    * Get the latest committed offset token from Snowflake
    *
    * @return the latest committed offset token
+   * @throws SFException if Snowflake returns an invalid response code from its `status` endpoint
+   *     which typically indicates that the channel needs to be re-opened. This is evaluated with
+   *     respect to the current Client epoch, i.e. if another Client opens the channel with the same
+   *     name this will throw an exception as the current instant is not the active version of the
+   *     channel.
    */
   @Nullable
   String getLatestCommittedOffsetToken();

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelCache.java
@@ -41,7 +41,13 @@ class ChannelCache<T> {
   private final ConcurrentHashMap<String, FlushInfo> tableFlushInfo = new ConcurrentHashMap<>();
 
   /**
-   * Add a channel to the channel cache
+   * Add a channel to the channel cache.
+   *
+   * <p>Note: if there was a previous instance of the channel then the old one is considered
+   * "invalid". Callers with a reference to the old channel object will have their writes rejected
+   * as the channel reference will be marked "invalid". Similarly, calls to fetch the current status
+   * of old versions of the channel will have an exception thrown as the channel is considered
+   * invalid.
    *
    * @param channel
    */

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -482,10 +482,11 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
   }
 
   /**
-   * Fetch channels status from Snowflake
+   * Fetch the status of one or more Channels from Snowflake
    *
-   * @param channels a list of channels that we want to get the status on
+   * @param channels a list of channels that we want to get the status of
    * @return a ChannelsStatusResponse object
+   * @throws SFException if the caller cannot communicate with Snowflake
    */
   ChannelsStatusResponse getChannelsStatus(
       List<SnowflakeStreamingIngestChannelInternal<?>> channels) {
@@ -507,9 +508,11 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
         if (channelStatus.getStatusCode() != RESPONSE_SUCCESS) {
           String errorMessage =
               String.format(
-                  "Channel has failure status_code, name=%s, channel_sequencer=%d, status_code=%d",
+                  "Channel has failure status_code, name=%s, current.channel_sequencer=%d,"
+                      + " persisted.channel_sequencer=%d, status_code=%d",
                   channel.getFullyQualifiedName(),
                   channel.getChannelSequencer(),
+                  channelStatus.getPersistedClientSequencer(),
                   channelStatus.getStatusCode());
           logger.logWarn(errorMessage);
           if (getTelemetryService() != null) {


### PR DESCRIPTION
There is no information in the Javadocs regarding when an exception can be thrown. This adds the `@throws` annotation to existing methods to indicate that exceptions CAN be thrown in certain scenarios.