### PR TITLE
SNOW-1947905 Fix proxy setting for OAuth http client

### DIFF
--- a/src/main/java/net/snowflake/ingest/connection/OAuthClient.java
+++ b/src/main/java/net/snowflake/ingest/connection/OAuthClient.java
@@ -1,11 +1,14 @@
 /*
- * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2023-2025 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.ingest.connection;
 
+import static net.snowflake.ingest.utils.HttpUtil.NON_PROXY_HOSTS;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,16 +56,20 @@ public class OAuthClient {
   /**
    * Creates an AuthClient for Snowflake OAuth given account, credential and base uri
    *
-   * @param accountName - the snowflake account name of this user
    * @param oAuthCredential - the OAuth credential we're using to connect
    * @param baseURIBuilder - the uri builder with common scheme, host and port
    */
-  OAuthClient(String accountName, OAuthCredential oAuthCredential, URIBuilder baseURIBuilder) {
+  OAuthClient(OAuthCredential oAuthCredential, URIBuilder baseURIBuilder) {
     this.oAuthCredential = new AtomicReference<>(oAuthCredential);
 
     // build token request uri
     baseURIBuilder.setPath(TOKEN_REQUEST_ENDPOINT);
-    this.httpClient = HttpUtil.getHttpClient(accountName);
+    URI oAuthTokenEndpoint = oAuthCredential.getOAuthTokenEndpoint();
+    this.httpClient =
+        HttpUtil.initHttpClient(
+            System.getProperty(NON_PROXY_HOSTS) != null
+                && HttpUtil.isInNonProxyHosts(
+                    oAuthTokenEndpoint == null ? "" : oAuthTokenEndpoint.getHost()));
   }
 
   /** Get access token */

--- a/src/main/java/net/snowflake/ingest/connection/OAuthManager.java
+++ b/src/main/java/net/snowflake/ingest/connection/OAuthManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
  */
 
 package net.snowflake.ingest.connection;
@@ -89,7 +89,7 @@ public final class OAuthManager extends SecurityManager {
       throw new IllegalArgumentException("updateThresholdRatio should fall in (0, 1)");
     }
     this.updateThresholdRatio = updateThresholdRatio;
-    this.oAuthClient = new OAuthClient(accountName, oAuthCredential, baseURIBuilder);
+    this.oAuthClient = new OAuthClient(oAuthCredential, baseURIBuilder);
 
     // generate our first token
     refreshToken();

--- a/src/test/java/net/snowflake/ingest/connection/MockOAuthClient.java
+++ b/src/test/java/net/snowflake/ingest/connection/MockOAuthClient.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Snowflake Computing Inc. All rights reserved.
+ */
+
 package net.snowflake.ingest.connection;
 
 import java.util.UUID;
@@ -13,10 +17,7 @@ public class MockOAuthClient extends OAuthClient {
   private int futureRefreshFailCount = 0;
 
   public MockOAuthClient() {
-    super(
-        "ACCOUNT_NAME",
-        new OAuthCredential("CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"),
-        new URIBuilder());
+    super(new OAuthCredential("CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"), new URIBuilder());
     oAuthCredential =
         new AtomicReference<>(new OAuthCredential("CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"));
     oAuthCredential.get().setExpiresIn(600);


### PR DESCRIPTION
Decoupled the HTTP client for streaming and authentication, as the SDK previously used a single client for both streaming ingestion and OAuth authentication. This change ensures compliance with the customer's requirement to configure separate proxy settings for streaming and authentication.