### PR TITLE
SNOW-1983454: Download required dependencies before release

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -82,7 +82,6 @@ echo "[INFO] mvn clean compile"
 mvn clean compile ${MVN_OPTIONS[@]}
 
 echo "[INFO] mvn dependency resolve"
-# mvn dependency:resolve dependency:resolve-plugins -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]} -Dmaven.wagon.http.pool=false
 mvn dependency:resolve dependency:resolve-plugins dependency:go-offline -DmanualInclude=org.apache.maven:maven-archiver:pom:2.5 ${MVN_OPTIONS[@]}
 
 echo "[INFO] mvn test"
@@ -94,36 +93,36 @@ $THIS_DIR/scripts/update_project_version.py public_pom.xml $project_version > ge
 
 mvn deploy ${MVN_OPTIONS[@]} -Dossrh-deploy -Dhttp.keepAlive=false
 
-# echo "[INFO] Close and Release"
-# snowflake_repositories=$(mvn ${MVN_OPTIONS[@]} \
-#     org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-list \
-#     -DserverId=$MVN_REPOSITORY_ID \
-#     -DnexusUrl=https://oss.sonatype.org/ | grep netsnowflake | awk '{print $2}')
-# IFS=" "
-# if (( $(echo $snowflake_repositories | wc -l)!=1 )); then
-#     echo "[ERROR] Not single netsnowflake repository is staged. Login https://oss.sonatype.org/ and make sure no netsnowflake remains there."
-#     exit 1
-# fi
-# if ! mvn ${MVN_OPTIONS[@]} \
-#     org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-close \
-#     -DserverId=$MVN_REPOSITORY_ID \
-#     -DnexusUrl=https://oss.sonatype.org/ \
-#     -DstagingRepositoryId=$snowflake_repositories \
-#     -DstagingDescription="Automated Close"; then
-#     echo "[ERROR] Failed to close. Fix the errors and try this script again"
-#     mvn ${MVN_OPTIONS[@]} \
-#         nexus-staging:rc-drop \
-#         -DserverId=$MVN_REPOSITORY_ID \
-#         -DnexusUrl=https://oss.sonatype.org/ \
-#         -DstagingRepositoryId=$snowflake_repositories \
-#         -DstagingDescription="Failed to close. Dropping..."
-# fi
+echo "[INFO] Close and Release"
+snowflake_repositories=$(mvn ${MVN_OPTIONS[@]} \
+    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-list \
+    -DserverId=$MVN_REPOSITORY_ID \
+    -DnexusUrl=https://oss.sonatype.org/ | grep netsnowflake | awk '{print $2}')
+IFS=" "
+if (( $(echo $snowflake_repositories | wc -l)!=1 )); then
+    echo "[ERROR] Not single netsnowflake repository is staged. Login https://oss.sonatype.org/ and make sure no netsnowflake remains there."
+    exit 1
+fi
+if ! mvn ${MVN_OPTIONS[@]} \
+    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-close \
+    -DserverId=$MVN_REPOSITORY_ID \
+    -DnexusUrl=https://oss.sonatype.org/ \
+    -DstagingRepositoryId=$snowflake_repositories \
+    -DstagingDescription="Automated Close"; then
+    echo "[ERROR] Failed to close. Fix the errors and try this script again"
+    mvn ${MVN_OPTIONS[@]} \
+        nexus-staging:rc-drop \
+        -DserverId=$MVN_REPOSITORY_ID \
+        -DnexusUrl=https://oss.sonatype.org/ \
+        -DstagingRepositoryId=$snowflake_repositories \
+        -DstagingDescription="Failed to close. Dropping..."
+fi
 
-# mvn ${MVN_OPTIONS[@]} \
-#     org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-release \
-#     -DserverId=$MVN_REPOSITORY_ID \
-#     -DnexusUrl=https://oss.sonatype.org/ \
-#     -DstagingRepositoryId=$snowflake_repositories \
-#     -DstagingDescription="Automated Release"
+mvn ${MVN_OPTIONS[@]} \
+    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-release \
+    -DserverId=$MVN_REPOSITORY_ID \
+    -DnexusUrl=https://oss.sonatype.org/ \
+    -DstagingRepositoryId=$snowflake_repositories \
+    -DstagingDescription="Automated Release"
 
 rm $OSSRH_DEPLOY_SETTINGS_XML

--- a/deploy.sh
+++ b/deploy.sh
@@ -78,42 +78,52 @@ MVN_OPTIONS+=(
   "--batch-mode"
 )
 
+echo "[INFO] mvn clean compile"
+mvn clean compile ${MVN_OPTIONS[@]}
+
+echo "[INFO] mvn dependency resolve"
+# mvn dependency:resolve dependency:resolve-plugins -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]} -Dmaven.wagon.http.pool=false
+mvn dependency:resolve dependency:resolve-plugins dependency:go-offline -DmanualInclude=org.apache.maven:maven-archiver:pom:2.5 ${MVN_OPTIONS[@]}
+
+echo "[INFO] mvn test"
+mvn test ${MVN_OPTIONS[@]}
+
 echo "[Info] Sign package and deploy to staging area"
 project_version=$($THIS_DIR/scripts/get_project_info_from_pom.py $THIS_DIR/pom.xml version)
 $THIS_DIR/scripts/update_project_version.py public_pom.xml $project_version > generated_public_pom.xml
 
-mvn deploy ${MVN_OPTIONS[@]} -Dossrh-deploy -Dmaven.wagon.http.pool=false -X -e
+mvn deploy ${MVN_OPTIONS[@]} -Dossrh-deploy -Dhttp.keepAlive=false
 
-echo "[INFO] Close and Release"
-snowflake_repositories=$(mvn ${MVN_OPTIONS[@]} \
-    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-list \
-    -DserverId=$MVN_REPOSITORY_ID \
-    -DnexusUrl=https://oss.sonatype.org/ | grep netsnowflake | awk '{print $2}')
-IFS=" "
-if (( $(echo $snowflake_repositories | wc -l)!=1 )); then
-    echo "[ERROR] Not single netsnowflake repository is staged. Login https://oss.sonatype.org/ and make sure no netsnowflake remains there."
-    exit 1
-fi
-if ! mvn ${MVN_OPTIONS[@]} \
-    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-close \
-    -DserverId=$MVN_REPOSITORY_ID \
-    -DnexusUrl=https://oss.sonatype.org/ \
-    -DstagingRepositoryId=$snowflake_repositories \
-    -DstagingDescription="Automated Close"; then
-    echo "[ERROR] Failed to close. Fix the errors and try this script again"
-    mvn ${MVN_OPTIONS[@]} \
-        nexus-staging:rc-drop \
-        -DserverId=$MVN_REPOSITORY_ID \
-        -DnexusUrl=https://oss.sonatype.org/ \
-        -DstagingRepositoryId=$snowflake_repositories \
-        -DstagingDescription="Failed to close. Dropping..."
-fi
+# echo "[INFO] Close and Release"
+# snowflake_repositories=$(mvn ${MVN_OPTIONS[@]} \
+#     org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-list \
+#     -DserverId=$MVN_REPOSITORY_ID \
+#     -DnexusUrl=https://oss.sonatype.org/ | grep netsnowflake | awk '{print $2}')
+# IFS=" "
+# if (( $(echo $snowflake_repositories | wc -l)!=1 )); then
+#     echo "[ERROR] Not single netsnowflake repository is staged. Login https://oss.sonatype.org/ and make sure no netsnowflake remains there."
+#     exit 1
+# fi
+# if ! mvn ${MVN_OPTIONS[@]} \
+#     org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-close \
+#     -DserverId=$MVN_REPOSITORY_ID \
+#     -DnexusUrl=https://oss.sonatype.org/ \
+#     -DstagingRepositoryId=$snowflake_repositories \
+#     -DstagingDescription="Automated Close"; then
+#     echo "[ERROR] Failed to close. Fix the errors and try this script again"
+#     mvn ${MVN_OPTIONS[@]} \
+#         nexus-staging:rc-drop \
+#         -DserverId=$MVN_REPOSITORY_ID \
+#         -DnexusUrl=https://oss.sonatype.org/ \
+#         -DstagingRepositoryId=$snowflake_repositories \
+#         -DstagingDescription="Failed to close. Dropping..."
+# fi
 
-mvn ${MVN_OPTIONS[@]} \
-    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-release \
-    -DserverId=$MVN_REPOSITORY_ID \
-    -DnexusUrl=https://oss.sonatype.org/ \
-    -DstagingRepositoryId=$snowflake_repositories \
-    -DstagingDescription="Automated Release"
+# mvn ${MVN_OPTIONS[@]} \
+#     org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-release \
+#     -DserverId=$MVN_REPOSITORY_ID \
+#     -DnexusUrl=https://oss.sonatype.org/ \
+#     -DstagingRepositoryId=$snowflake_repositories \
+#     -DstagingDescription="Automated Release"
 
 rm $OSSRH_DEPLOY_SETTINGS_XML


### PR DESCRIPTION
There has been a connection error during the release of snowflake-ingest-java. The last 3 releases, including unshaded, had this issue. 
Last time, shaded version was released skipping tests to unblock the release. The error is something like this:
```
00:11:41.344 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:2.4:jar (default-jar) on project snowflake-ingest-sdk: Execution default-jar of goal org.apache.maven.plugins:maven-jar-plugin:2.4:jar failed: Plugin org.apache.maven.plugins:maven-jar-plugin:2.4 or one of its dependencies could not be resolved: Failed to collect dependencies at org.apache.maven.plugins:maven-jar-plugin:jar:2.4 -> org.apache.maven:maven-archiver:jar:2.5: Failed to read artifact descriptor for org.apache.maven:maven-archiver:jar:2.5: Could not transfer artifact org.apache.maven:maven-archiver:pom:2.5 from/to central (https://artifactory.int.snowflakecomputing.com/artifactory/development-maven-virtual): Connection reset -> [Help 1]
```
This PR split the release in the next stages:

- do a clean compile
- resolve dependencies
  - this also include the `maven-archiver:pom:2.5` that is the one it fails to download on deploy
- test
- deploy
  - use parameter -Dhttp.keepAlive=false

Using this got the releases deployed to staging:
https://ci-dev-122.int.snowflakecomputing.com/job/MavenPushSnowpipeJavaSDK/75/
![image](https://github.com/user-attachments/assets/b769c350-4062-40c3-b87b-edcf0b1ad330)
