### PR TITLE
SNOW-1983454: Download required dependencies before release for unshaded version

### DIFF
--- a/unshaded_deploy.sh
+++ b/unshaded_deploy.sh
@@ -81,7 +81,7 @@ mvn clean compile ${MVN_OPTIONS[@]}
 
 echo "[INFO] mvn dependency resolve
 # mvn dependency:resolve dependency:resolve-plugins -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]} -Dmaven.wagon.http.pool=false
-mvn dependency:resolve dependency:resolve-plugins dependency:go-offline -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]} -Dmaven.wagon.http.pool=false
+mvn dependency:resolve dependency:resolve-plugins dependency:go-offline -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]}
 
 echo "[INFO] mvn test
 mvn test ${MVN_OPTIONS[@]}
@@ -93,7 +93,7 @@ echo "[Info] Project version: $project_version"
 $THIS_DIR/scripts/update_project_version.py pom.xml ${project_version} > generated_public_pom.xml
 
 echo "[INFO] mvn deploy
-mvn deploy ${MVN_OPTIONS[@]} -Dnot-shadeDep -Dossrh-deploy 
+mvn deploy ${MVN_OPTIONS[@]} -Dnot-shadeDep -Dossrh-deploy -Dmaven.wagon.http.pool=false
 
 # echo "[INFO] Close and Release"
 # snowflake_repositories=$(mvn ${MVN_OPTIONS[@]} \

--- a/unshaded_deploy.sh
+++ b/unshaded_deploy.sh
@@ -76,8 +76,13 @@ MVN_OPTIONS+=(
   "--settings" "$OSSRH_DEPLOY_SETTINGS_XML"
   "--batch-mode"
 )
+echo "[INFO] mvn clean compile
 mvn clean compile ${MVN_OPTIONS[@]}
+
+echo "[INFO] mvn dependency resolve
 mvn dependency:resolve dependency:resolve-plugins ${MVN_OPTIONS[@]}
+
+echo "[INFO] mvn verify
 mvn verify ${MVN_OPTIONS[@]}
 # -DmanualInclude="jakarta.xml.bind:jakarta.xml.bind-api"
 
@@ -86,6 +91,7 @@ project_version=$($THIS_DIR/scripts/get_project_info_from_pom.py $THIS_DIR/pom.x
 echo "[Info] Project version: $project_version"
 $THIS_DIR/scripts/update_project_version.py pom.xml ${project_version} > generated_public_pom.xml
 
+echo "[INFO] mvn deploy
 mvn deploy ${MVN_OPTIONS[@]} -Dnot-shadeDep -Dossrh-deploy 
 
 # echo "[INFO] Close and Release"

--- a/unshaded_deploy.sh
+++ b/unshaded_deploy.sh
@@ -80,7 +80,7 @@ echo "[INFO] mvn clean compile
 mvn clean compile ${MVN_OPTIONS[@]}
 
 echo "[INFO] mvn dependency resolve
-mvn dependency:resolve dependency:resolve-plugins -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]}
+mvn dependency:resolve dependency:resolve-plugins -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]} -Dmaven.wagon.http.pool=false
 
 echo "[INFO] mvn verify
 mvn verify ${MVN_OPTIONS[@]}

--- a/unshaded_deploy.sh
+++ b/unshaded_deploy.sh
@@ -80,7 +80,7 @@ echo "[INFO] mvn clean compile
 mvn clean compile ${MVN_OPTIONS[@]}
 
 echo "[INFO] mvn dependency resolve
-mvn dependency:resolve dependency:resolve-plugins ${MVN_OPTIONS[@]}
+mvn dependency:resolve dependency:resolve-plugins -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]}
 
 echo "[INFO] mvn verify
 mvn verify ${MVN_OPTIONS[@]}

--- a/unshaded_deploy.sh
+++ b/unshaded_deploy.sh
@@ -80,52 +80,49 @@ echo "[INFO] mvn clean compile"
 mvn clean compile ${MVN_OPTIONS[@]}
 
 echo "[INFO] mvn dependency resolve"
-# mvn dependency:resolve dependency:resolve-plugins -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]} -Dmaven.wagon.http.pool=false
 mvn dependency:resolve dependency:resolve-plugins dependency:go-offline -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]}
 
 echo "[INFO] mvn test"
 mvn test ${MVN_OPTIONS[@]}
-# -DmanualInclude="jakarta.xml.bind:jakarta.xml.bind-api"
 
 echo "[Info] Sign unshaded package and deploy to staging area"
 project_version=$($THIS_DIR/scripts/get_project_info_from_pom.py $THIS_DIR/pom.xml version)
 echo "[Info] Project version: $project_version"
 $THIS_DIR/scripts/update_project_version.py pom.xml ${project_version} > generated_public_pom.xml
 
-echo "[INFO] mvn deploy keepalive=false"
 mvn deploy ${MVN_OPTIONS[@]} -Dnot-shadeDep -Dossrh-deploy -Dhttp.keepAlive=false
 
-# echo "[INFO] Close and Release"
-# snowflake_repositories=$(mvn ${MVN_OPTIONS[@]} \
-#     org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-list \
-#     -DserverId=$MVN_REPOSITORY_ID  -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true \
-#     -DnexusUrl=https://oss.sonatype.org/ | grep netsnowflake | awk '{print $2}')
-# IFS=" "
-# if (( $(echo $snowflake_repositories | wc -l)!=1 )); then
-#     echo "[ERROR] Not single netsnowflake repository is staged. Login https://oss.sonatype.org/ and make sure no netsnowflake remains there."
-#     exit 1
-# fi
-# if ! mvn ${MVN_OPTIONS[@]} \
-#     org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-close \
-#     -DserverId=$MVN_REPOSITORY_ID \
-#     -DnexusUrl=https://oss.sonatype.org/ \
-#     -DstagingRepositoryId=$snowflake_repositories \
-#     -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true\
-#     -DstagingDescription="Automated Close"; then
-#     echo "[ERROR] Failed to close. Fix the errors and try this script again"
-#     mvn ${MVN_OPTIONS[@]} \
-#         nexus-staging:rc-drop \
-#         -DserverId=$MVN_REPOSITORY_ID \
-#         -DnexusUrl=https://oss.sonatype.org/ \
-#         -DstagingRepositoryId=$snowflake_repositories -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true\
-#         -DstagingDescription="Failed to close. Dropping..."
-# fi
+echo "[INFO] Close and Release"
+snowflake_repositories=$(mvn ${MVN_OPTIONS[@]} \
+    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-list \
+    -DserverId=$MVN_REPOSITORY_ID  -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true \
+    -DnexusUrl=https://oss.sonatype.org/ | grep netsnowflake | awk '{print $2}')
+IFS=" "
+if (( $(echo $snowflake_repositories | wc -l)!=1 )); then
+    echo "[ERROR] Not single netsnowflake repository is staged. Login https://oss.sonatype.org/ and make sure no netsnowflake remains there."
+    exit 1
+fi
+if ! mvn ${MVN_OPTIONS[@]} \
+    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-close \
+    -DserverId=$MVN_REPOSITORY_ID \
+    -DnexusUrl=https://oss.sonatype.org/ \
+    -DstagingRepositoryId=$snowflake_repositories \
+    -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true\
+    -DstagingDescription="Automated Close"; then
+    echo "[ERROR] Failed to close. Fix the errors and try this script again"
+    mvn ${MVN_OPTIONS[@]} \
+        nexus-staging:rc-drop \
+        -DserverId=$MVN_REPOSITORY_ID \
+        -DnexusUrl=https://oss.sonatype.org/ \
+        -DstagingRepositoryId=$snowflake_repositories -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true\
+        -DstagingDescription="Failed to close. Dropping..."
+fi
 
-# mvn ${MVN_OPTIONS[@]} \
-#     org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-release \
-#     -DserverId=$MVN_REPOSITORY_ID \
-#     -DnexusUrl=https://oss.sonatype.org/ \
-#     -DstagingRepositoryId=$snowflake_repositories -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true\
-#     -DstagingDescription="Automated Release"
+mvn ${MVN_OPTIONS[@]} \
+    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-release \
+    -DserverId=$MVN_REPOSITORY_ID \
+    -DnexusUrl=https://oss.sonatype.org/ \
+    -DstagingRepositoryId=$snowflake_repositories -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true\
+    -DstagingDescription="Automated Release"
 
 rm $OSSRH_DEPLOY_SETTINGS_XML

--- a/unshaded_deploy.sh
+++ b/unshaded_deploy.sh
@@ -76,14 +76,14 @@ MVN_OPTIONS+=(
   "--settings" "$OSSRH_DEPLOY_SETTINGS_XML"
   "--batch-mode"
 )
-echo "[INFO] mvn clean compile
+echo "[INFO] mvn clean compile"
 mvn clean compile ${MVN_OPTIONS[@]}
 
-echo "[INFO] mvn dependency resolve
+echo "[INFO] mvn dependency resolve"
 # mvn dependency:resolve dependency:resolve-plugins -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]} -Dmaven.wagon.http.pool=false
 mvn dependency:resolve dependency:resolve-plugins dependency:go-offline -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]}
 
-echo "[INFO] mvn test
+echo "[INFO] mvn test"
 mvn test ${MVN_OPTIONS[@]}
 # -DmanualInclude="jakarta.xml.bind:jakarta.xml.bind-api"
 
@@ -92,8 +92,8 @@ project_version=$($THIS_DIR/scripts/get_project_info_from_pom.py $THIS_DIR/pom.x
 echo "[Info] Project version: $project_version"
 $THIS_DIR/scripts/update_project_version.py pom.xml ${project_version} > generated_public_pom.xml
 
-echo "[INFO] mvn deploy
-mvn deploy ${MVN_OPTIONS[@]} -Dnot-shadeDep -Dossrh-deploy -Dmaven.wagon.http.pool=false
+echo "[INFO] mvn deploy keepalive=false"
+mvn deploy ${MVN_OPTIONS[@]} -Dnot-shadeDep -Dossrh-deploy -Dhttp.keepAlive=false
 
 # echo "[INFO] Close and Release"
 # snowflake_repositories=$(mvn ${MVN_OPTIONS[@]} \

--- a/unshaded_deploy.sh
+++ b/unshaded_deploy.sh
@@ -76,9 +76,9 @@ MVN_OPTIONS+=(
   "--settings" "$OSSRH_DEPLOY_SETTINGS_XML"
   "--batch-mode"
 )
-# mvn clean compile ${MVN_OPTIONS[@]}
-# mvn dependency:resolve dependency:resolve-plugins ${MVN_OPTIONS[@]}
-# mvn verify ${MVN_OPTIONS[@]}
+mvn clean compile ${MVN_OPTIONS[@]}
+mvn dependency:resolve dependency:resolve-plugins ${MVN_OPTIONS[@]}
+mvn verify ${MVN_OPTIONS[@]}
 # -DmanualInclude="jakarta.xml.bind:jakarta.xml.bind-api"
 
 echo "[Info] Sign unshaded package and deploy to staging area"

--- a/unshaded_deploy.sh
+++ b/unshaded_deploy.sh
@@ -30,6 +30,35 @@ cat > $OSSRH_DEPLOY_SETTINGS_XML << SETTINGS.XML
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <profiles>
+    <profile>
+      <id>internal-maven</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <name>Internal Maven Repository</name>
+          <url>https://artifactory.int.snowflakecomputing.com/artifactory/development-maven-virtual</url>
+        </repository>
+        <repository>
+          <id>deployment</id>
+          <name>Internal Releases</name>
+          <url>https://nexus.int.snowflakecomputing.com/repository/Releases/</url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <name>Internal Maven Repository</name>
+          <url>https://artifactory.int.snowflakecomputing.com/artifactory/development-maven-virtual</url>
+        </pluginRepository>
+        <pluginRepository>
+          <id>deployment</id>
+          <name>Internal Releases</name>
+          <url>https://nexus.int.snowflakecomputing.com/repository/Releases/</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
   <servers>
     <server>
       <id>$MVN_REPOSITORY_ID</id>
@@ -37,6 +66,9 @@ cat > $OSSRH_DEPLOY_SETTINGS_XML << SETTINGS.XML
       <password>$SONATYPE_PWD</password>
     </server>
   </servers>
+  <activeProfiles>
+    <activeProfile>internal-maven</activeProfile>
+  </activeProfiles>
 </settings>
 SETTINGS.XML
 
@@ -44,6 +76,10 @@ MVN_OPTIONS+=(
   "--settings" "$OSSRH_DEPLOY_SETTINGS_XML"
   "--batch-mode"
 )
+# mvn clean compile ${MVN_OPTIONS[@]}
+# mvn dependency:resolve dependency:resolve-plugins ${MVN_OPTIONS[@]}
+# mvn verify ${MVN_OPTIONS[@]}
+# -DmanualInclude="jakarta.xml.bind:jakarta.xml.bind-api"
 
 echo "[Info] Sign unshaded package and deploy to staging area"
 project_version=$($THIS_DIR/scripts/get_project_info_from_pom.py $THIS_DIR/pom.xml version)
@@ -52,37 +88,37 @@ $THIS_DIR/scripts/update_project_version.py pom.xml ${project_version} > generat
 
 mvn deploy ${MVN_OPTIONS[@]} -Dnot-shadeDep -Dossrh-deploy 
 
-echo "[INFO] Close and Release"
-snowflake_repositories=$(mvn ${MVN_OPTIONS[@]} \
-    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-list \
-    -DserverId=$MVN_REPOSITORY_ID  -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true \
-    -DnexusUrl=https://oss.sonatype.org/ | grep netsnowflake | awk '{print $2}')
-IFS=" "
-if (( $(echo $snowflake_repositories | wc -l)!=1 )); then
-    echo "[ERROR] Not single netsnowflake repository is staged. Login https://oss.sonatype.org/ and make sure no netsnowflake remains there."
-    exit 1
-fi
-if ! mvn ${MVN_OPTIONS[@]} \
-    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-close \
-    -DserverId=$MVN_REPOSITORY_ID \
-    -DnexusUrl=https://oss.sonatype.org/ \
-    -DstagingRepositoryId=$snowflake_repositories \
-    -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true\
-    -DstagingDescription="Automated Close"; then
-    echo "[ERROR] Failed to close. Fix the errors and try this script again"
-    mvn ${MVN_OPTIONS[@]} \
-        nexus-staging:rc-drop \
-        -DserverId=$MVN_REPOSITORY_ID \
-        -DnexusUrl=https://oss.sonatype.org/ \
-        -DstagingRepositoryId=$snowflake_repositories -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true\
-        -DstagingDescription="Failed to close. Dropping..."
-fi
+# echo "[INFO] Close and Release"
+# snowflake_repositories=$(mvn ${MVN_OPTIONS[@]} \
+#     org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-list \
+#     -DserverId=$MVN_REPOSITORY_ID  -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true \
+#     -DnexusUrl=https://oss.sonatype.org/ | grep netsnowflake | awk '{print $2}')
+# IFS=" "
+# if (( $(echo $snowflake_repositories | wc -l)!=1 )); then
+#     echo "[ERROR] Not single netsnowflake repository is staged. Login https://oss.sonatype.org/ and make sure no netsnowflake remains there."
+#     exit 1
+# fi
+# if ! mvn ${MVN_OPTIONS[@]} \
+#     org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-close \
+#     -DserverId=$MVN_REPOSITORY_ID \
+#     -DnexusUrl=https://oss.sonatype.org/ \
+#     -DstagingRepositoryId=$snowflake_repositories \
+#     -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true\
+#     -DstagingDescription="Automated Close"; then
+#     echo "[ERROR] Failed to close. Fix the errors and try this script again"
+#     mvn ${MVN_OPTIONS[@]} \
+#         nexus-staging:rc-drop \
+#         -DserverId=$MVN_REPOSITORY_ID \
+#         -DnexusUrl=https://oss.sonatype.org/ \
+#         -DstagingRepositoryId=$snowflake_repositories -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true\
+#         -DstagingDescription="Failed to close. Dropping..."
+# fi
 
-mvn ${MVN_OPTIONS[@]} \
-    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-release \
-    -DserverId=$MVN_REPOSITORY_ID \
-    -DnexusUrl=https://oss.sonatype.org/ \
-    -DstagingRepositoryId=$snowflake_repositories -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true\
-    -DstagingDescription="Automated Release"
+# mvn ${MVN_OPTIONS[@]} \
+#     org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:rc-release \
+#     -DserverId=$MVN_REPOSITORY_ID \
+#     -DnexusUrl=https://oss.sonatype.org/ \
+#     -DstagingRepositoryId=$snowflake_repositories -Dnot-shadeDep  versions:set -DnewVersion=$project_version-unshaded -Dmaven.javadoc.skip=true -Dmaven.source.skip=true\
+#     -DstagingDescription="Automated Release"
 
 rm $OSSRH_DEPLOY_SETTINGS_XML

--- a/unshaded_deploy.sh
+++ b/unshaded_deploy.sh
@@ -80,10 +80,11 @@ echo "[INFO] mvn clean compile
 mvn clean compile ${MVN_OPTIONS[@]}
 
 echo "[INFO] mvn dependency resolve
-mvn dependency:resolve dependency:resolve-plugins -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]} -Dmaven.wagon.http.pool=false
+# mvn dependency:resolve dependency:resolve-plugins -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]} -Dmaven.wagon.http.pool=false
+mvn dependency:resolve dependency:resolve-plugins dependency:go-offline -DmanualInclude=org.codehaus.plexus:plexus-utils:jar:3.0.20 ${MVN_OPTIONS[@]} -Dmaven.wagon.http.pool=false
 
-echo "[INFO] mvn verify
-mvn verify ${MVN_OPTIONS[@]}
+echo "[INFO] mvn test
+mvn test ${MVN_OPTIONS[@]}
 # -DmanualInclude="jakarta.xml.bind:jakarta.xml.bind-api"
 
 echo "[Info] Sign unshaded package and deploy to staging area"


### PR DESCRIPTION
There has been a connection error during the release of snowflake-ingest-java. The last 3 releases, including unshaded, had this issue.
Unshaded version was released using this code and confirmed on shaded version 3.1.2.

```
00:10:29.184 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:2.4:jar (default-jar) on project snowflake-ingest-sdk: Execution default-jar of goal org.apache.maven.plugins:maven-jar-plugin:2.4:jar failed: Plugin org.apache.maven.plugins:maven-jar-plugin:2.4 or one of its dependencies could not be resolved: Failed to collect dependencies at org.apache.maven.plugins:maven-jar-plugin:jar:2.4 -> org.apache.maven:maven-archiver:jar:2.5: Failed to read artifact descriptor for org.apache.maven:maven-archiver:jar:2.5: Could not transfer artifact org.apache.maven:maven-archiver:pom:2.5 from/to central (https://repo.maven.apache.org/maven2): Connection reset -> [Help 1]
```
This PR split the release in the next stages:

- do a clean compile
- resolve dependencies
  - this also include the `org.codehaus.plexus:plexus-utils:jar:3.0.20` that is the one it fails to download on deploy
- test
- deploy
  - use parameter -Dhttp.keepAlive=false

This configuration completed release to staging here: 
https://ci-dev-122.int.snowflakecomputing.com/job/MavenPushSnowpipeJavaSDKUnshaded/66/
![image](https://github.com/user-attachments/assets/fae4f0f9-e123-4946-a3c2-f6200452135d)
![image](https://github.com/user-attachments/assets/93eed674-a1fc-4765-81b8-2dbd621afe86)

