### PR TITLE
NO-SNOW Fix merge gate

### DIFF
--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -81,7 +81,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -115,7 +115,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}

--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
-
+          cache-dependency-path: '**/pom.xml'
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}
@@ -58,6 +58,7 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
+          cache-dependency-path: '**/pom.xml'
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }} on Windows Powershell
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}
@@ -85,7 +86,7 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
-
+          cache-dependency-path: '**/pom.xml'
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}
@@ -119,6 +120,7 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
+          cache-dependency-path: '**/pom.xml'
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }} on Windows Powershell
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}
@@ -151,6 +153,7 @@ jobs:
             11
             8
           cache: maven
+          cache-dependency-path: '**/pom.xml'
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}

--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -19,10 +19,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
+          cache: maven
 
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
         env:
@@ -52,7 +53,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -79,7 +80,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -113,7 +114,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}

--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -151,10 +151,6 @@ jobs:
             11
             8
           cache: maven
-      - name: Install python2
-        uses: actions/setup-python@v2
-        with:
-          python-version: '2.x'
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}

--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
-          cache: maven
 
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
         env:

--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -151,6 +151,10 @@ jobs:
             11
             8
           cache: maven
+      - name: Install python2
+        uses: actions/setup-python@v2
+        with:
+          python-version: '2.x'
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}

--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build & Test - JDK ${{ matrix.java }}, Cloud ${{ matrix.snowflake_cloud }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
       matrix:
@@ -23,6 +23,7 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
+          cache: maven
 
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
         env:
@@ -69,7 +70,7 @@ jobs:
           mvn -DghActionsIT -Dnot-shadeDep -D"failsafe.excludedGroups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
   build-iceberg:
     name: Build & Test Streaming Iceberg - JDK ${{ matrix.java }}, Cloud ${{ matrix.snowflake_cloud }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
       matrix:
@@ -130,7 +131,7 @@ jobs:
           mvn -DghActionsIT -Dnot-shadeDep -"Dfailsafe.groups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
   build-e2e-jar-test:
     name: e2e-jar-test cloud=${{ matrix.snowflake_cloud }} test_type=${{ matrix.test_type }} java=${{ matrix.java_path_env_var }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/update_project_version.py
+++ b/scripts/update_project_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Update project version

--- a/scripts/update_project_version.py
+++ b/scripts/update_project_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Update project version
@@ -23,25 +23,11 @@ def remove_namespace(doc, namespace):
     """
     ns = u'{%s}' % namespace
     nsl = len(ns)
-    for elem in doc.getiterator():
+    for elem in doc.iter():
         if type(elem.tag) is str and elem.tag.startswith(ns):
             elem.tag = elem.tag[nsl:]
 
-class PCParser(ET.XMLTreeBuilder):
-    """
-    A parser including the comments
-    """
-    def __init__(self):
-        ET.XMLTreeBuilder.__init__(self)
-        # assumes ElementTree 1.2.X
-        self._parser.CommentHandler = self.handle_comment
-
-    def handle_comment(self, data):
-        self._target.start(ET.Comment, {})
-        self._target.data(unescape(data.strip())) # strip spaces and unescape
-        self._target.end(ET.Comment)
-
-tree = ET.parse(pom_file, parser=PCParser())
+tree = ET.parse(pom_file)
 root = tree.getroot()
 for e1 in root:
     if type(e1.tag) is str and e1.tag.endswith('version'):
@@ -51,4 +37,4 @@ for e1 in root:
 
 remove_namespace(root, u'http://maven.apache.org/POM/4.0.0')
 
-tree.write(sys.stdout)
+tree.write(sys.stdout, encoding='unicode', xml_declaration=True)

--- a/scripts/update_project_version.py
+++ b/scripts/update_project_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 # Update project version


### PR DESCRIPTION
Our Github action merge gate keeps failing starting from yesterday due to several errors, this PR fix it.

* Upgrade to `ubuntu-24.04` as the old `ubuntu-20.04` is not supported anymore from yesterday. https://github.com/actions/runner-images/issues/11101
* Upgrade `upgdate_project_version.py` to run in python3. The python2 is not preinstalled in ubuntu 24.04, and cannot be installed via `setup-python` due to python2's deprecation. https://github.com/actions/setup-python/issues/672. Note that this change makes the original comments in `public_pom.xml` unavailable but this doesn't affect the testing results. 
* Upgrade `setup-java@v2` to `setup-java@v4` and specify `cache-dependency-path` as there seems to be some problem with maven caching service on `setup-java@v2` using `action/cache@v3` which is already deprecated https://github.com/actions/toolkit/discussions/1890. See the following error message for reference.
```
Resolved Java 8.0.442+6 from tool-cache
Setting Java 8.0.442+6 as the default

Java configuration:
  Distribution: temurin
  Version: 8.0.442+6
  Path: C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\8.0.442-6\x64

Creating settings.xml with server-id: github
Writing to C:\Users\runneradmin\.m2\settings.xml
Error: Cache service responded with 422
```