### PR TITLE
[SNOW-2134338] Add unit tests for http client retry strategy

### DIFF
--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -6,6 +6,7 @@ package net.snowflake.ingest.utils;
 
 import static net.snowflake.ingest.utils.Utils.isNullOrEmpty;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.security.Security;
 import java.time.Duration;
 import java.time.Instant;
@@ -16,8 +17,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
-
-import com.google.common.annotations.VisibleForTesting;
 import net.snowflake.client.core.SFSessionProperty;
 import net.snowflake.ingest.streaming.internal.StreamingIngestUtils;
 import org.apache.http.HttpHost;
@@ -66,8 +65,7 @@ public class HttpUtil {
    * value of {@link HttpUtil.TOTAL_RETRY_DURATION} when exponential backoff of up to 4 seconds per
    * retry is used.
    */
-  @VisibleForTesting
-  static final int MAX_RETRIES = 10;
+  @VisibleForTesting static final int MAX_RETRIES = 10;
 
   private static volatile CloseableHttpClient httpClient;
 

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -16,6 +16,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
+
+import com.google.common.annotations.VisibleForTesting;
 import net.snowflake.client.core.SFSessionProperty;
 import net.snowflake.ingest.streaming.internal.StreamingIngestUtils;
 import org.apache.http.HttpHost;
@@ -224,7 +226,8 @@ public class HttpUtil {
     }
   }
 
-  private static ServiceUnavailableRetryStrategy getServiceUnavailableRetryStrategy() {
+  @VisibleForTesting
+  static ServiceUnavailableRetryStrategy getServiceUnavailableRetryStrategy() {
     return new ServiceUnavailableRetryStrategy() {
       final int REQUEST_TIMEOUT = 408;
       final int TOO_MANY_REQUESTS = 429;

--- a/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
+++ b/src/main/java/net/snowflake/ingest/utils/HttpUtil.java
@@ -66,7 +66,8 @@ public class HttpUtil {
    * value of {@link HttpUtil.TOTAL_RETRY_DURATION} when exponential backoff of up to 4 seconds per
    * retry is used.
    */
-  private static final int MAX_RETRIES = 10;
+  @VisibleForTesting
+  static final int MAX_RETRIES = 10;
 
   private static volatile CloseableHttpClient httpClient;
 

--- a/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtilsTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtilsTest.java
@@ -69,7 +69,6 @@ public class StreamingIngestUtilsTest {
   public void testRetries() throws Exception {
     ChannelsStatusResponse response = new ChannelsStatusResponse();
     response.setStatusCode(RESPONSE_ERR_GENERAL_EXCEPTION_RETRY_REQUEST);
-    //    response.setStatusCode(7L);
 
     response.setMessage("honk");
     response.setChannels(new ArrayList<>());

--- a/src/test/java/net/snowflake/ingest/utils/HttpUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/utils/HttpUtilTest.java
@@ -1,5 +1,6 @@
 package net.snowflake.ingest.utils;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
@@ -9,9 +10,12 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import javax.net.ssl.SSLException;
 import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
 import org.apache.http.NoHttpResponseException;
 import org.apache.http.RequestLine;
+import org.apache.http.StatusLine;
 import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.ServiceUnavailableRetryStrategy;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -45,5 +49,43 @@ public class HttpUtilTest {
         httpRequestRetryHandler.retryRequest(
             new SSLException("Test exception"), 11, httpContextMock));
     assertFalse(httpRequestRetryHandler.retryRequest(new IOException(), 1, httpContextMock));
+  }
+
+  @Test
+  public void testServiceUnavailableRetryStrategy() {
+    ServiceUnavailableRetryStrategy retryStrategy = HttpUtil.getServiceUnavailableRetryStrategy();
+
+    HttpClientContext context = Mockito.mock(HttpClientContext.class);
+    HttpResponse response = Mockito.mock(HttpResponse.class);
+    HttpRequest request = Mockito.mock(HttpRequest.class);
+    RequestLine requestLine = Mockito.mock(RequestLine.class);
+    StatusLine statusLine = Mockito.mock(StatusLine.class);
+
+    doReturn(request).when(context).getRequest();
+    doReturn(requestLine).when(request).getRequestLine();
+    doReturn(statusLine).when(response).getStatusLine();
+
+    // Expect retry
+    doReturn(408).when(statusLine).getStatusCode();
+    assertTrue("Expected retry on 408 Request Timeout", retryStrategy.retryRequest(response, 1, context));
+
+    doReturn(429).when(statusLine).getStatusCode();
+    assertTrue("Expected retry on 429 Too Many Requests", retryStrategy.retryRequest(response, 1, context));
+
+    doReturn(500).when(statusLine).getStatusCode();
+    assertTrue("Expected retry on 500 Internal Server Error", retryStrategy.retryRequest(response, 1, context));
+
+    doReturn(503).when(statusLine).getStatusCode();
+    assertTrue("Expected retry on 503 Service Unavailable", retryStrategy.retryRequest(response, 1, context));
+
+    // Expect no retry
+    doReturn(200).when(statusLine).getStatusCode();
+    assertFalse("Expected no retry on 200 Success", retryStrategy.retryRequest(response, 1, context));
+
+    doReturn(400).when(statusLine).getStatusCode();
+    assertFalse("Expected no retry on 400 Bad Request", retryStrategy.retryRequest(response, 1, context));
+
+    doReturn(404).when(statusLine).getStatusCode();
+    assertFalse("Expected no retry on 404 Not Found", retryStrategy.retryRequest(response, 1, context));
   }
 }

--- a/src/test/java/net/snowflake/ingest/utils/HttpUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/utils/HttpUtilTest.java
@@ -33,22 +33,26 @@ public class HttpUtilTest {
     doReturn(requestLine).when(httpRequest).getRequestLine();
     doReturn("/api/v1/status").when(requestLine).getUri();
 
-    assertTrue(
-        httpRequestRetryHandler.retryRequest(
-            new NoHttpResponseException("Test exception"), 1, httpContextMock));
-    assertTrue(
-        httpRequestRetryHandler.retryRequest(
-            new SSLException("Test exception"), 1, httpContextMock));
-    assertTrue(
-        httpRequestRetryHandler.retryRequest(
-            new SocketException("Test exception"), 1, httpContextMock));
-    assertTrue(
-        httpRequestRetryHandler.retryRequest(
-            new UnknownHostException("Test exception"), 1, httpContextMock));
+    final String message = "Please retry";
+    IOException[] retryExceptions = {
+        new NoHttpResponseException(message),
+        new SSLException(message),
+        new SocketException(message),
+        new UnknownHostException(message)
+    };
+
+    for (IOException exception : retryExceptions) {
+      assertTrue(
+          httpRequestRetryHandler.retryRequest(exception, 1, httpContextMock));
+    }
+
+    // Verify generic IOException is not retried
+    assertFalse(httpRequestRetryHandler.retryRequest(new IOException(), 1, httpContextMock));
+
+    // Verify retry is disabled when retry count exceeds the limit
     assertFalse(
         httpRequestRetryHandler.retryRequest(
-            new SSLException("Test exception"), 11, httpContextMock));
-    assertFalse(httpRequestRetryHandler.retryRequest(new IOException(), 1, httpContextMock));
+            new SSLException(message), HttpUtil.MAX_RETRIES + 1, httpContextMock));
   }
 
   @Test
@@ -65,27 +69,16 @@ public class HttpUtilTest {
     doReturn(requestLine).when(request).getRequestLine();
     doReturn(statusLine).when(response).getStatusLine();
 
-    // Expect retry
-    doReturn(408).when(statusLine).getStatusCode();
-    assertTrue("Expected retry on 408 Request Timeout", retryStrategy.retryRequest(response, 1, context));
+    int[] retryStatusCodes = {408, 429, 500, 503};
+    for (int statusCode : retryStatusCodes) {
+      doReturn(statusCode).when(statusLine).getStatusCode();
+      assertTrue("Expected retry on " + statusCode, retryStrategy.retryRequest(response, 1, context));
+    }
 
-    doReturn(429).when(statusLine).getStatusCode();
-    assertTrue("Expected retry on 429 Too Many Requests", retryStrategy.retryRequest(response, 1, context));
-
-    doReturn(500).when(statusLine).getStatusCode();
-    assertTrue("Expected retry on 500 Internal Server Error", retryStrategy.retryRequest(response, 1, context));
-
-    doReturn(503).when(statusLine).getStatusCode();
-    assertTrue("Expected retry on 503 Service Unavailable", retryStrategy.retryRequest(response, 1, context));
-
-    // Expect no retry
-    doReturn(200).when(statusLine).getStatusCode();
-    assertFalse("Expected no retry on 200 Success", retryStrategy.retryRequest(response, 1, context));
-
-    doReturn(400).when(statusLine).getStatusCode();
-    assertFalse("Expected no retry on 400 Bad Request", retryStrategy.retryRequest(response, 1, context));
-
-    doReturn(404).when(statusLine).getStatusCode();
-    assertFalse("Expected no retry on 404 Not Found", retryStrategy.retryRequest(response, 1, context));
+    int[] noRetryStatusCodes = {200, 400, 404};
+    for (int statusCode : noRetryStatusCodes) {
+      doReturn(statusCode).when(statusLine).getStatusCode();
+      assertFalse("Expected no retry on " + statusCode, retryStrategy.retryRequest(response, 1, context));
+    }
   }
 }

--- a/src/test/java/net/snowflake/ingest/utils/HttpUtilTest.java
+++ b/src/test/java/net/snowflake/ingest/utils/HttpUtilTest.java
@@ -1,6 +1,5 @@
 package net.snowflake.ingest.utils;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
@@ -35,15 +34,14 @@ public class HttpUtilTest {
 
     final String message = "Please retry";
     IOException[] retryExceptions = {
-        new NoHttpResponseException(message),
-        new SSLException(message),
-        new SocketException(message),
-        new UnknownHostException(message)
+      new NoHttpResponseException(message),
+      new SSLException(message),
+      new SocketException(message),
+      new UnknownHostException(message)
     };
 
     for (IOException exception : retryExceptions) {
-      assertTrue(
-          httpRequestRetryHandler.retryRequest(exception, 1, httpContextMock));
+      assertTrue(httpRequestRetryHandler.retryRequest(exception, 1, httpContextMock));
     }
 
     // Verify generic IOException is not retried
@@ -72,13 +70,15 @@ public class HttpUtilTest {
     int[] retryStatusCodes = {408, 429, 500, 503};
     for (int statusCode : retryStatusCodes) {
       doReturn(statusCode).when(statusLine).getStatusCode();
-      assertTrue("Expected retry on " + statusCode, retryStrategy.retryRequest(response, 1, context));
+      assertTrue(
+          "Expected retry on " + statusCode, retryStrategy.retryRequest(response, 1, context));
     }
 
     int[] noRetryStatusCodes = {200, 400, 404};
     for (int statusCode : noRetryStatusCodes) {
       doReturn(statusCode).when(statusLine).getStatusCode();
-      assertFalse("Expected no retry on " + statusCode, retryStrategy.retryRequest(response, 1, context));
+      assertFalse(
+          "Expected no retry on " + statusCode, retryStrategy.retryRequest(response, 1, context));
     }
   }
 }


### PR DESCRIPTION
## Context

Specifically for channelsOpen API, we see the following flow:
1. API handler calls [executeWithRetries()](https://github.com/snowflakedb/snowflake-ingest-java/blob/1cd64137219da10e001b61aa32d509a9f445704c/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeServiceClient.java#L236), which makes the HTTP call and extracts the response
2. HTTP client uses [getServiceUnavailableRetryStrategy()](https://github.com/snowflakedb/snowflake-ingest-java/blob/1cd64137219da10e001b61aa32d509a9f445704c/src/main/java/net/snowflake/ingest/utils/HttpUtil.java#L227-L280) to determine when to retry server errors

The confusion is that step 1 contains [logic to retry internal code `GENERAL_EXCEPTION_RETRY_REQUEST`](https://github.com/snowflakedb/snowflake-ingest-java/blob/1cd64137219da10e001b61aa32d509a9f445704c/src/main/java/net/snowflake/ingest/streaming/internal/StreamingIngestUtils.java#L137-L144). For this code to be reached, the HTTP client has to receive a `200 OK`.  Any non-200 response that isn't handled by the HTTP client will throw an `IngestResponseException`. In other words, for this code to retry a `GENERAL_EXCEPTION_RETRY_REQUEST`, it must receive a `200 OK` with `GENERAL_EXCEPTION_RETRY_REQUEST` internal error code.

However, our server does not do this. Bad responses are send with a [400, 429, or 503](https://github.com/snowflakedb/snowflake/blob/a294c3141c80c5560615d06dd9ad6ea245265e71/GlobalServices/src/main/java/com/snowflake/resources/streaming/StreamingResource.java#L1822-L1832) error code. Specifically for our `channelOpens` case, throttling will always return `429` (legacy `503` with parameter disabled). This error code is retried by the HTTP client retry strategy and this PR verifies this behavior.