### PR TITLE
SNOW-2174149: Keep retrying on QUEUE_FULL instead of invalidating channels

### DIFF
--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -74,7 +74,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
-
+          cache-dependency-path: '**/pom.xml'
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }} on Windows Powershell
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}
@@ -83,11 +83,8 @@ jobs:
           ./scripts/decrypt_secret_windows.ps1 -SnowflakeDeployment '${{ matrix.snowflake_cloud }}'
 
       - name: Unit & Integration Test (Windows)
-        env:
-          MAVEN_OPTS: "-Dmdep.skip=true"
         continue-on-error: false
         run: |
-          # Skipped dependency analysis via MAVEN_OPTS to avoid command-line parsing issues on Windows
           mvn -DghActionsIT -Dnot-shadeDep -D"failsafe.groups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
 
   # Job for building and testing Iceberg functionality on Ubuntu
@@ -159,11 +156,8 @@ jobs:
           ./scripts/decrypt_secret_windows.ps1 -SnowflakeDeployment '${{ matrix.snowflake_cloud }}'
 
       - name: Unit & Integration Test (Windows)
-        env:
-          MAVEN_OPTS: "-Dmdep.skip=true"
         continue-on-error: false
         run: |
-          # Skipped dependency analysis via MAVEN_OPTS to avoid command-line parsing issues on Windows
           mvn -DghActionsIT -Dnot-shadeDep -D"failsafe.excludedGroups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
 
   # Job for end-to-end testing with different JAR types and Java versions

--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Unit & Integration Test (Windows)
         continue-on-error: false
         run: |
-          mvn -DghActionsIT -Dnot-shadeDep -D"failsafe.excludedGroups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
+          mvn -DghActionsIT -Dnot-shadeDep -Dmdep.skip=true -D"failsafe.excludedGroups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
 
   # Job for building and testing Iceberg functionality on Ubuntu
   build-iceberg:
@@ -159,7 +159,7 @@ jobs:
         continue-on-error: false
         run: |
           # Corrected the mvn command by removing the erroneous hyphen before -D
-          mvn -DghActionsIT -Dnot-shadeDep -D"failsafe.groups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
+          mvn -DghActionsIT -Dnot-shadeDep -Dmdep.skip=true -D"failsafe.groups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
 
   # Job for end-to-end testing with different JAR types and Java versions
   build-e2e-jar-test:

--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Unit & Integration Test (Windows)
         continue-on-error: false
         run: |
-          mvn -DghActionsIT -Dnot-shadeDep -D"failsafe.groups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
+          mvn -DghActionsIT -Dnot-shadeDep -D"failsafe.excludedGroups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
 
   # Job for building and testing Iceberg functionality on Ubuntu
   build-iceberg:
@@ -158,7 +158,7 @@ jobs:
       - name: Unit & Integration Test (Windows)
         continue-on-error: false
         run: |
-          mvn -DghActionsIT -Dnot-shadeDep -D"failsafe.excludedGroups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
+          mvn -DghActionsIT -Dnot-shadeDep -"Dfailsafe.groups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
 
   # Job for end-to-end testing with different JAR types and Java versions
   build-e2e-jar-test:

--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -83,9 +83,12 @@ jobs:
           ./scripts/decrypt_secret_windows.ps1 -SnowflakeDeployment '${{ matrix.snowflake_cloud }}'
 
       - name: Unit & Integration Test (Windows)
+        env:
+          MAVEN_OPTS: "-Dmdep.skip=true"
         continue-on-error: false
         run: |
-          mvn -DghActionsIT -Dnot-shadeDep -Dmdep.skip=true -D"failsafe.excludedGroups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
+          # Skipped dependency analysis via MAVEN_OPTS to avoid command-line parsing issues on Windows
+          mvn -DghActionsIT -Dnot-shadeDep -D"failsafe.groups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
 
   # Job for building and testing Iceberg functionality on Ubuntu
   build-iceberg:
@@ -156,10 +159,12 @@ jobs:
           ./scripts/decrypt_secret_windows.ps1 -SnowflakeDeployment '${{ matrix.snowflake_cloud }}'
 
       - name: Unit & Integration Test (Windows)
+        env:
+          MAVEN_OPTS: "-Dmdep.skip=true"
         continue-on-error: false
         run: |
-          # Corrected the mvn command by removing the erroneous hyphen before -D
-          mvn -DghActionsIT -Dnot-shadeDep -Dmdep.skip=true -D"failsafe.groups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
+          # Skipped dependency analysis via MAVEN_OPTS to avoid command-line parsing issues on Windows
+          mvn -DghActionsIT -Dnot-shadeDep -D"failsafe.excludedGroups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
 
   # Job for end-to-end testing with different JAR types and Java versions
   build-e2e-jar-test:

--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -60,7 +60,6 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
-          cache-dependency-path: '**/pom.xml'
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }} on Windows Powershell
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}
@@ -142,7 +141,7 @@ jobs:
       fail-fast: false
       matrix:
         snowflake_cloud: [ 'AWS', 'AZURE', 'GCP' ]
-        test_type: [ 'shaded', 'unshaded', 'fips']
+        test_type: [ 'shaded', 'unshaded', 'fips' ]
         java_path_env_var: [ "JAVA_HOME_8_X64", "JAVA_HOME_11_X64", "JAVA_HOME_17_X64", "JAVA_HOME_21_X64" ]
     steps:
       - name: Checkout Code

--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -1,30 +1,40 @@
+# Name of the GitHub Actions workflow
 name: Snowpipe Java SDK
 
+# Controls when the workflow will run
 on:
   push:
     branches: [ master ]
   pull_request:
-    branches: '**'
+    branches: [ '**' ]
 
 jobs:
+  # Job for building and testing on Ubuntu
   build:
     name: Build & Test - JDK ${{ matrix.java }}, Cloud ${{ matrix.snowflake_cloud }}
-    runs-on: ubuntu-24.04
+    # Use a stable LTS version of Ubuntu runner
+    runs-on: ubuntu-22.04
     strategy:
-      fail-fast: false # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
+      # Don't cancel other jobs in the matrix if one fails
+      fail-fast: false
       matrix:
         java: [ 8 ]
         snowflake_cloud: [ 'AWS', 'AZURE', 'GCP' ]
     steps:
+      # Use the latest stable version of the checkout action (v4)
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      # Use the latest stable version of the setup-java action (v4)
       - name: Install Java ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-          cache: maven
+          # Enable caching of Maven dependencies to speed up builds
+          cache: 'maven'
           cache-dependency-path: '**/pom.xml'
+
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}
@@ -39,10 +49,13 @@ jobs:
         run: |
           ./scripts/run_gh_actions.sh -Dfailsafe.excludedGroups="net.snowflake.ingest.IcebergIT"
 
+      # Use the latest stable version of the codecov action (v4)
       - name: Code Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Job for building and testing on Windows
   build-windows:
     name: Build & Test - Windows, JDK ${{ matrix.java }}, Cloud ${{ matrix.snowflake_cloud }}
     runs-on: windows-2022
@@ -53,41 +66,48 @@ jobs:
         snowflake_cloud: [ 'AWS', 'AZURE', 'GCP' ]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
       - name: Install Java ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-          cache: maven
+          cache: 'maven'
+
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }} on Windows Powershell
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}
         shell: pwsh
         run: |
           ./scripts/decrypt_secret_windows.ps1 -SnowflakeDeployment '${{ matrix.snowflake_cloud }}'
+
       - name: Unit & Integration Test (Windows)
         continue-on-error: false
         run: |
           mvn -DghActionsIT -Dnot-shadeDep -D"failsafe.excludedGroups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
+
+  # Job for building and testing Iceberg functionality on Ubuntu
   build-iceberg:
     name: Build & Test Streaming Iceberg - JDK ${{ matrix.java }}, Cloud ${{ matrix.snowflake_cloud }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
-      fail-fast: false # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
+      fail-fast: false
       matrix:
         java: [ 8 ]
         snowflake_cloud: [ 'AWS', 'AZURE' ]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
       - name: Install Java ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-          cache: maven
+          cache: 'maven'
           cache-dependency-path: '**/pom.xml'
+
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}
@@ -103,9 +123,11 @@ jobs:
           ./scripts/run_gh_actions.sh -Dfailsafe.groups="net.snowflake.ingest.IcebergIT"
 
       - name: Code Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Job for building and testing Iceberg functionality on Windows
   build-iceberg-windows:
     name: Build & Test - Streaming Iceberg Windows, JDK ${{ matrix.java }}, Cloud ${{ matrix.snowflake_cloud }}
     runs-on: windows-2022
@@ -116,27 +138,33 @@ jobs:
         snowflake_cloud: [ 'AWS', 'AZURE' ]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
       - name: Install Java ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-          cache: maven
+          cache: 'maven'
           cache-dependency-path: '**/pom.xml'
+
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }} on Windows Powershell
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}
         shell: pwsh
         run: |
           ./scripts/decrypt_secret_windows.ps1 -SnowflakeDeployment '${{ matrix.snowflake_cloud }}'
+
       - name: Unit & Integration Test (Windows)
         continue-on-error: false
         run: |
-          mvn -DghActionsIT -Dnot-shadeDep -"Dfailsafe.groups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
+          # Corrected the mvn command by removing the erroneous hyphen before -D
+          mvn -DghActionsIT -Dnot-shadeDep -D"failsafe.groups"="net.snowflake.ingest.IcebergIT" verify --batch-mode
+
+  # Job for end-to-end testing with different JAR types and Java versions
   build-e2e-jar-test:
     name: e2e-jar-test cloud=${{ matrix.snowflake_cloud }} test_type=${{ matrix.test_type }} java=${{ matrix.java_path_env_var }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -145,22 +173,26 @@ jobs:
         java_path_env_var: [ "JAVA_HOME_8_X64", "JAVA_HOME_11_X64", "JAVA_HOME_17_X64", "JAVA_HOME_21_X64" ]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
       - name: Install Java
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: | # Install all LTS java versions, the last mentioned one here will be the default
+          distribution: 'temurin'
+          # Install all required LTS java versions
+          java-version: |
             21
             17
             11
             8
-          cache: maven
+          cache: 'maven'
           cache-dependency-path: '**/pom.xml'
+
       - name: Decrypt profile.json for Cloud ${{ matrix.snowflake_cloud }}
         env:
           DECRYPTION_PASSPHRASE: ${{ secrets.PROFILE_JSON_DECRYPT_PASSPHRASE }}
         run: ./scripts/decrypt_secret.sh ${{ matrix.snowflake_cloud }}
+
       - name: Run E2E JAR Test
         env:
           test_type: ${{ matrix.test_type }}

--- a/pom.xml
+++ b/pom.xml
@@ -1046,7 +1046,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
@@ -1197,8 +1197,8 @@
               <ignoreNonCompile>true</ignoreNonCompile>
               <ignoredDependencies>
                 <!-- We defined these as direct dependencies (as opposed to just declaring it in dependencyManagement)
-                                                                                                                                                                                                                                                to workaround https://issues.apache.org/jira/browse/MNG-7982. Now the dependency analyzer complains that
-                                                                                                                                                                                                                                                the dependency is unused, so we ignore it here-->
+                                                                                                                                                                                                                                                                to workaround https://issues.apache.org/jira/browse/MNG-7982. Now the dependency analyzer complains that
+                                                                                                                                                                                                                                                                the dependency is unused, so we ignore it here-->
                 <ignoredDependency>org.apache.commons:commons-compress</ignoredDependency>
                 <ignoredDependency>org.apache.commons:commons-configuration2</ignoredDependency>
                 <ignoredDependency>io.grpc:grpc-netty</ignoredDependency>
@@ -1295,9 +1295,9 @@
         <configuration>
           <errorRemedy>failFast</errorRemedy>
           <!--
-                                                                                                                                                                                               The list of allowed licenses. If you see the build failing due to "There are some forbidden licenses used, please
-                                                                                                                                                                                              check your dependencies", verify the conditions of the license and add the reference to it here.
-                                                                                                                                                                                            -->
+                                                                                                                                                                                                         The list of allowed licenses. If you see the build failing due to "There are some forbidden licenses used, please
+                                                                                                                                                                                                        check your dependencies", verify the conditions of the license and add the reference to it here.
+                                                                                                                                                                                                      -->
           <includedLicenses>
             <includedLicense>Apache License 2.0</includedLicense>
             <includedLicense>BSD 2-Clause License</includedLicense>
@@ -1318,10 +1318,10 @@
                             |Apache License, Version 2.0
                             |Apache License, version 2.0
                             |Apache 2.0
-              |Apache License V2.0
-              |Apache 2</licenseMerge>
+                            |Apache License V2.0
+                            |Apache 2</licenseMerge>
             <licenseMerge>BSD 2-Clause License
-              |The BSD License |BSD</licenseMerge>
+                            |The BSD License |BSD</licenseMerge>
             <licenseMerge>The MIT License|MIT License|MIT license</licenseMerge>
             <licenseMerge>3-Clause BSD License|BSD-3-Clause</licenseMerge>
             <licenseMerge>The Go License|Go License</licenseMerge>
@@ -1704,9 +1704,9 @@
             </executions>
           </plugin>
           <!--
-                                                                                                                                                                                                        Plugin executes license processing Python script, which copies third party license files into the directory
-                                                                                                                                                                                                        target/generated-licenses-info/META-INF/third-party-licenses, which is then included in the shaded JAR.
-                                                                                                                                                                                                        -->
+                                                                                                                                                                                                                  Plugin executes license processing Python script, which copies third party license files into the directory
+                                                                                                                                                                                                                  target/generated-licenses-info/META-INF/third-party-licenses, which is then included in the shaded JAR.
+                                                                                                                                                                                                                  -->
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1046,7 +1046,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
@@ -1197,8 +1197,8 @@
               <ignoreNonCompile>true</ignoreNonCompile>
               <ignoredDependencies>
                 <!-- We defined these as direct dependencies (as opposed to just declaring it in dependencyManagement)
-                                                                                                                                                                                                                                                                to workaround https://issues.apache.org/jira/browse/MNG-7982. Now the dependency analyzer complains that
-                                                                                                                                                                                                                                                                the dependency is unused, so we ignore it here-->
+                                                                                                                                                                                                                                                                                to workaround https://issues.apache.org/jira/browse/MNG-7982. Now the dependency analyzer complains that
+                                                                                                                                                                                                                                                                                the dependency is unused, so we ignore it here-->
                 <ignoredDependency>org.apache.commons:commons-compress</ignoredDependency>
                 <ignoredDependency>org.apache.commons:commons-configuration2</ignoredDependency>
                 <ignoredDependency>io.grpc:grpc-netty</ignoredDependency>
@@ -1295,9 +1295,9 @@
         <configuration>
           <errorRemedy>failFast</errorRemedy>
           <!--
-                                                                                                                                                                                                         The list of allowed licenses. If you see the build failing due to "There are some forbidden licenses used, please
-                                                                                                                                                                                                        check your dependencies", verify the conditions of the license and add the reference to it here.
-                                                                                                                                                                                                      -->
+                                                                                                                                                                                                                   The list of allowed licenses. If you see the build failing due to "There are some forbidden licenses used, please
+                                                                                                                                                                                                                  check your dependencies", verify the conditions of the license and add the reference to it here.
+                                                                                                                                                                                                                -->
           <includedLicenses>
             <includedLicense>Apache License 2.0</includedLicense>
             <includedLicense>BSD 2-Clause License</includedLicense>
@@ -1704,9 +1704,9 @@
             </executions>
           </plugin>
           <!--
-                                                                                                                                                                                                                  Plugin executes license processing Python script, which copies third party license files into the directory
-                                                                                                                                                                                                                  target/generated-licenses-info/META-INF/third-party-licenses, which is then included in the shaded JAR.
-                                                                                                                                                                                                                  -->
+                                                                                                                                                                                                                            Plugin executes license processing Python script, which copies third party license files into the directory
+                                                                                                                                                                                                                            target/generated-licenses-info/META-INF/third-party-licenses, which is then included in the shaded JAR.
+                                                                                                                                                                                                                            -->
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -762,12 +762,26 @@ class FlushService<T> {
     boolean throttleOnQueuedTasks = buildAndUpload.getQueue().size() > numProcessors;
     if (throttleOnQueuedTasks) {
       logger.logWarn(
-          "Throttled due too many queue flush tasks (probably because of slow uploading speed),"
+          "Throttled due to too many queue flush tasks (probably because of slow uploading speed),"
               + " client={}, buildUploadWorkers stats={}",
           this.owningClient.getName(),
           this.buildUploadWorkers.toString());
     }
     return throttleOnQueuedTasks;
+  }
+
+  /** Throttle if the number of queued registration blobs is bigger than the max allowed */
+  boolean throttleDueToQueuedRegistrationRequests() {
+    int queueSize = registerService.getBlobsList().size();
+    boolean throttleOnQueueSize =
+        queueSize > this.owningClient.getParameterProvider().getMaxRegistrationQueueSize();
+    if (throttleOnQueueSize) {
+      logger.logWarn(
+          "Throttled due to too many queued registration blobs, client={}, size={}",
+          this.owningClient.getName(),
+          queueSize);
+    }
+    return throttleOnQueueSize;
   }
 
   /** Get whether we're running under test mode */

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -11,6 +11,7 @@ import static net.snowflake.ingest.utils.Constants.THREAD_SHUTDOWN_TIMEOUT_IN_SE
 import static net.snowflake.ingest.utils.Utils.getStackTrace;
 
 import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.security.InvalidAlgorithmParameterException;
@@ -787,5 +788,11 @@ class FlushService<T> {
   /** Get whether we're running under test mode */
   boolean isTestMode() {
     return this.isTestMode;
+  }
+
+  /** Get the register service, used for TEST only */
+  @VisibleForTesting
+  RegisterService<T> getRegisterService() {
+    return this.registerService;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -771,18 +771,18 @@ class FlushService<T> {
     return throttleOnQueuedTasks;
   }
 
-  /** Throttle if the number of queued registration blobs is bigger than the max allowed */
-  boolean throttleDueToQueuedRegistrationRequests() {
-    int queueSize = registerService.getBlobsList().size();
-    boolean throttleOnQueueSize =
+  /** Check if the number of queued registration blobs is bigger than the max allowed */
+  boolean isMaxRegistrationQueueSizeExceeded() {
+    int queueSize = registerService.getBlobsListSize();
+    boolean isQueueSizeExceeded =
         queueSize > this.owningClient.getParameterProvider().getMaxRegistrationQueueSize();
-    if (throttleOnQueueSize) {
+    if (isQueueSizeExceeded) {
       logger.logWarn(
-          "Throttled due to too many queued registration blobs, client={}, size={}",
+          "The number of queued registration blobs exceeds the max allowed threshold, client={}, size={}",
           this.owningClient.getName(),
           queueSize);
     }
-    return throttleOnQueueSize;
+    return isQueueSizeExceeded;
   }
 
   /** Get whether we're running under test mode */

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -778,7 +778,8 @@ class FlushService<T> {
         queueSize > this.owningClient.getParameterProvider().getMaxRegistrationQueueSize();
     if (isQueueSizeExceeded) {
       logger.logWarn(
-          "The number of queued registration blobs exceeds the max allowed threshold, client={}, size={}",
+          "The number of queued registration blobs exceeds the max allowed threshold, client={},"
+              + " size={}",
           this.owningClient.getName(),
           queueSize);
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
@@ -215,7 +215,7 @@ class RegisterService<T> {
   }
 
   /**
-   * Get the blobsList, this is for TEST ONLY, no lock protection
+   * Get the blobsList, used for tests or get estimated size, no lock protection
    *
    * @return the blobsList
    */

--- a/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/RegisterService.java
@@ -215,11 +215,11 @@ class RegisterService<T> {
   }
 
   /**
-   * Get the blobsList, used for tests or get estimated size, no lock protection
+   * Get the size of the blobsList, no lock protection so it could be an estimated size
    *
-   * @return the blobsList
+   * @return the size of the blobsList
    */
-  List<Pair<FlushService.BlobData<T>, CompletableFuture<BlobMetadata>>> getBlobsList() {
-    return this.blobsList;
+  int getBlobsListSize() {
+    return this.blobsList.size();
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -456,12 +456,12 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
    */
   void throttleInsertIfNeeded(MemoryInfoProvider memoryInfoProvider) {
     int retry = 0;
+    // Insert will be throttled if we run into low memory or the queued flush tasks in flush service
+    // exceeds the threshold or the queued registration requests exceeds the threshold.
     while (hasLowRuntimeMemory(memoryInfoProvider)
         || (this.owningClient.getFlushService() != null
             && (this.owningClient.getFlushService().throttleDueToQueuedFlushTasks()
-                || this.owningClient
-                    .getFlushService()
-                    .throttleDueToQueuedRegistrationRequests()))) {
+                || this.owningClient.getFlushService().isMaxRegistrationQueueSizeExceeded()))) {
       try {
         Thread.sleep(insertThrottleIntervalInMs);
         retry++;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -645,10 +645,13 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
                                         // If the chunk queue is full, we wait and retry the chunks
                                         if ((channelStatus.getStatusCode()
                                                     == RESPONSE_ERR_ENQUEUE_TABLE_CHUNK_QUEUE_FULL
-                                                || channelStatus.getStatusCode()
-                                                    == RESPONSE_ERR_GENERAL_EXCEPTION_RETRY_REQUEST)
-                                            && executionCount
-                                                < MAX_STREAMING_INGEST_API_CHANNEL_RETRY) {
+                                                && executionCount
+                                                    < parameterProvider
+                                                        .getMaxChannelWriteRetryCountOnQueueFull())
+                                            || (channelStatus.getStatusCode()
+                                                    == RESPONSE_ERR_GENERAL_EXCEPTION_RETRY_REQUEST
+                                                && executionCount
+                                                    < MAX_STREAMING_INGEST_API_CHANNEL_RETRY)) {
                                           queueFullChunks.add(chunkStatus);
                                         } else {
                                           String errorMessage =
@@ -828,16 +831,6 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
   /** Get whether we're running under test mode */
   boolean isTestMode() {
     return this.isTestMode;
-  }
-
-  /** Get the http client */
-  CloseableHttpClient getHttpClient() {
-    return this.httpClient;
-  }
-
-  /** Get the request builder */
-  RequestBuilder getRequestBuilder() {
-    return this.requestBuilder;
   }
 
   /** Get the channel cache */

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -643,15 +643,18 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
                                     channelStatus -> {
                                       if (channelStatus.getStatusCode() != RESPONSE_SUCCESS) {
                                         // If the chunk queue is full, we wait and retry the chunks
-                                        if ((channelStatus.getStatusCode()
+                                        boolean retryQueueFull =
+                                            channelStatus.getStatusCode()
                                                     == RESPONSE_ERR_ENQUEUE_TABLE_CHUNK_QUEUE_FULL
                                                 && executionCount
                                                     < parameterProvider
-                                                        .getMaxChannelWriteRetryCountOnQueueFull())
-                                            || (channelStatus.getStatusCode()
+                                                        .getMaxChannelWriteRetryCountOnQueueFull();
+                                        boolean retryGenericRetryableException =
+                                            channelStatus.getStatusCode()
                                                     == RESPONSE_ERR_GENERAL_EXCEPTION_RETRY_REQUEST
                                                 && executionCount
-                                                    < MAX_STREAMING_INGEST_API_CHANNEL_RETRY)) {
+                                                    < MAX_STREAMING_INGEST_API_CHANNEL_RETRY;
+                                        if (retryQueueFull || retryGenericRetryableException) {
                                           queueFullChunks.add(chunkStatus);
                                         } else {
                                           String errorMessage =

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -44,7 +44,6 @@ public class Constants {
   public static final long RESPONSE_ERR_ENQUEUE_TABLE_CHUNK_QUEUE_FULL =
       7L; // Don't change, should match server side
   public static final int BLOB_UPLOAD_TIMEOUT_IN_SEC = 20;
-  public static final int INSERT_THROTTLE_MAX_RETRY_COUNT = 60;
   public static final long MAX_BLOB_SIZE_IN_BYTES = 1024 * 1024 * 1024;
   public static final int BLOB_TAG_SIZE_IN_BYTES = 4;
   public static final int BLOB_VERSION_SIZE_IN_BYTES = 1;

--- a/src/main/java/net/snowflake/ingest/utils/Constants.java
+++ b/src/main/java/net/snowflake/ingest/utils/Constants.java
@@ -69,6 +69,8 @@ public class Constants {
   public static final int MAX_OAUTH_REFRESH_TOKEN_RETRY = 3;
   public static final int BINARY_COLUMN_MAX_SIZE = 8 * 1024 * 1024;
   public static final int VARCHAR_COLUMN_MAX_SIZE = 16 * 1024 * 1024;
+  public static final int INSERT_THROTTLE_MAX_RETRY_COUNT =
+      900; // 15 minutes with default retry interval
 
   // Channel level constants
   public static final String CHANNEL_STATUS_ENDPOINT = "/v1/streaming/channels/status/";

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -67,9 +67,10 @@ public class ParameterProvider {
   public static final long MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT = -1L;
   public static final long MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT = 64 * 1024 * 1024;
   public static final long MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 256 * 1024 * 1024;
-  public static final int MAX_CHANNEL_WRITE_RETRY_COUNT_ON_QUEUE_FULL_DEFAULT = 75;
+  public static final int MAX_CHANNEL_WRITE_RETRY_COUNT_ON_QUEUE_FULL_DEFAULT =
+      150; // 10 minutes assuming default retry interval of 4s
   public static final int MAX_REGISTRATION_QUEUE_SIZE_DEFAULT =
-      300; // 5 minutes of no progress assuming 1s flush interval
+      600; // 10 minutes of no progress assuming 1s flush interval
 
   // Lag related parameters
   public static final long MAX_CLIENT_LAG_DEFAULT = 1000; // 1 second

--- a/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
+++ b/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java
@@ -49,6 +49,11 @@ public class ParameterProvider {
 
   public static final String ENABLE_ICEBERG_STREAMING = "ENABLE_ICEBERG_STREAMING".toLowerCase();
 
+  public static final String MAX_CHANNEL_WRITE_RETRY_COUNT_ON_QUEUE_FULL =
+      "MAX_CHANNEL_WRITE_RETRY_COUNT_ON_QUEUE_FULL".toLowerCase();
+  public static final String MAX_REGISTRATION_QUEUE_SIZE =
+      "MAX_REGISTRATION_QUEUE_SIZE".toLowerCase();
+
   // Default values
   public static final long BUFFER_FLUSH_CHECK_INTERVAL_IN_MILLIS_DEFAULT = 100;
   public static final long INSERT_THROTTLE_INTERVAL_IN_MILLIS_DEFAULT = 1000;
@@ -62,6 +67,9 @@ public class ParameterProvider {
   public static final long MAX_MEMORY_LIMIT_IN_BYTES_DEFAULT = -1L;
   public static final long MAX_CHANNEL_SIZE_IN_BYTES_DEFAULT = 64 * 1024 * 1024;
   public static final long MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 256 * 1024 * 1024;
+  public static final int MAX_CHANNEL_WRITE_RETRY_COUNT_ON_QUEUE_FULL_DEFAULT = 75;
+  public static final int MAX_REGISTRATION_QUEUE_SIZE_DEFAULT =
+      300; // 5 minutes of no progress assuming 1s flush interval
 
   // Lag related parameters
   public static final long MAX_CLIENT_LAG_DEFAULT = 1000; // 1 second
@@ -270,6 +278,20 @@ public class ParameterProvider {
         props,
         false /* enforceDefault */);
 
+    this.checkAndUpdate(
+        MAX_CHANNEL_WRITE_RETRY_COUNT_ON_QUEUE_FULL,
+        MAX_CHANNEL_WRITE_RETRY_COUNT_ON_QUEUE_FULL_DEFAULT,
+        parameterOverrides,
+        props,
+        false /* enforceDefault */);
+
+    this.checkAndUpdate(
+        MAX_REGISTRATION_QUEUE_SIZE,
+        MAX_REGISTRATION_QUEUE_SIZE_DEFAULT,
+        parameterOverrides,
+        props,
+        false /* enforceDefault */);
+
     if (getMaxChunksInBlob() > getMaxChunksInRegistrationRequest()) {
       throw new IllegalArgumentException(
           String.format(
@@ -450,6 +472,33 @@ public class ParameterProvider {
     Object val =
         this.parameterMap.getOrDefault(
             BLOB_UPLOAD_MAX_RETRY_COUNT, BLOB_UPLOAD_MAX_RETRY_COUNT_DEFAULT);
+    if (val instanceof String) {
+      return Integer.parseInt(val.toString());
+    }
+    return (int) val;
+  }
+
+  /**
+   * @return The max number of retries for channel write API before giving up
+   */
+  public int getMaxChannelWriteRetryCountOnQueueFull() {
+    Object val =
+        this.parameterMap.getOrDefault(
+            MAX_CHANNEL_WRITE_RETRY_COUNT_ON_QUEUE_FULL,
+            MAX_CHANNEL_WRITE_RETRY_COUNT_ON_QUEUE_FULL_DEFAULT);
+    if (val instanceof String) {
+      return Integer.parseInt(val.toString());
+    }
+    return (int) val;
+  }
+
+  /**
+   * @return The max size of the registration queue in number of chunks before throttling
+   */
+  public int getMaxRegistrationQueueSize() {
+    Object val =
+        this.parameterMap.getOrDefault(
+            MAX_REGISTRATION_QUEUE_SIZE, MAX_REGISTRATION_QUEUE_SIZE_DEFAULT);
     if (val instanceof String) {
       return Integer.parseInt(val.toString());
     }

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -1320,28 +1320,28 @@ public class FlushServiceTest {
   }
 
   @Test
-  public void testThrottleDueToQueuedRegistrationRequestsBelowThreshold() {
+  public void testisMaxRegistrationQueueSizeExceeded() {
+    int threshold = 10;
     TestContext<List<List<Object>>> testContext = testContextFactory.create();
     testContext.setParameterOverride(
-        Collections.singletonMap(ParameterProvider.MAX_REGISTRATION_QUEUE_SIZE, 10));
+        Collections.singletonMap(ParameterProvider.MAX_REGISTRATION_QUEUE_SIZE, threshold));
     FlushService fs = testContext.flushService;
     Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blob =
         new Pair<>(
             new FlushService.BlobData<>("test", null),
             CompletableFuture.completedFuture(new BlobMetadata("path", "md5", null, null)));
 
-    int threshold = 10;
     for (int i = 0; i < threshold; i++) {
       fs.getRegisterService().addBlobs(Collections.singletonList(blob));
     }
     Assert.assertFalse(
         "Throttling should not occur when queued requests are below the threshold",
-        fs.throttleDueToQueuedRegistrationRequests());
+        fs.isMaxRegistrationQueueSizeExceeded());
 
     fs.getRegisterService().addBlobs(Collections.singletonList(blob));
     Assert.assertTrue(
-        "Throttling should not occur when queued requests are below the threshold",
-        fs.throttleDueToQueuedRegistrationRequests());
+        "Throttling should occur when queued requests are above the threshold",
+        fs.isMaxRegistrationQueueSizeExceeded());
   }
 
   private Timer setupTimer(long expectedLatencyMs) {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/FlushServiceTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +53,7 @@ import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.utils.Constants;
 import net.snowflake.ingest.utils.Cryptor;
 import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.ParameterProvider;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.parquet.column.ParquetProperties;
@@ -1315,6 +1317,31 @@ public class FlushServiceTest {
     byte[] decryptedData = Cryptor.decrypt(encryptedData, encryptionKey, diversifier, 0);
 
     Assert.assertArrayEquals(data, decryptedData);
+  }
+
+  @Test
+  public void testThrottleDueToQueuedRegistrationRequestsBelowThreshold() {
+    TestContext<List<List<Object>>> testContext = testContextFactory.create();
+    testContext.setParameterOverride(
+        Collections.singletonMap(ParameterProvider.MAX_REGISTRATION_QUEUE_SIZE, 10));
+    FlushService fs = testContext.flushService;
+    Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blob =
+        new Pair<>(
+            new FlushService.BlobData<>("test", null),
+            CompletableFuture.completedFuture(new BlobMetadata("path", "md5", null, null)));
+
+    int threshold = 10;
+    for (int i = 0; i < threshold; i++) {
+      fs.getRegisterService().addBlobs(Collections.singletonList(blob));
+    }
+    Assert.assertFalse(
+        "Throttling should not occur when queued requests are below the threshold",
+        fs.throttleDueToQueuedRegistrationRequests());
+
+    fs.getRegisterService().addBlobs(Collections.singletonList(blob));
+    Assert.assertTrue(
+        "Throttling should not occur when queued requests are below the threshold",
+        fs.throttleDueToQueuedRegistrationRequests());
   }
 
   private Timer setupTimer(long expectedLatencyMs) {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/ParameterProviderTest.java
@@ -42,6 +42,8 @@ public class ParameterProviderTest {
     parameterMap.put(ParameterProvider.MAX_MEMORY_LIMIT_IN_BYTES, 1000L);
     parameterMap.put(ParameterProvider.MAX_CHANNEL_SIZE_IN_BYTES, 1000000L);
     parameterMap.put(ParameterProvider.BDEC_PARQUET_COMPRESSION_ALGORITHM, "gzip");
+    parameterMap.put(ParameterProvider.MAX_CHANNEL_WRITE_RETRY_COUNT_ON_QUEUE_FULL, 10);
+    parameterMap.put(ParameterProvider.MAX_REGISTRATION_QUEUE_SIZE, 10);
     return parameterMap;
   }
 
@@ -64,6 +66,8 @@ public class ParameterProviderTest {
     Assert.assertEquals(
         Constants.BdecParquetCompression.GZIP,
         parameterProvider.getBdecParquetCompressionAlgorithm());
+    Assert.assertEquals(10, parameterProvider.getMaxChannelWriteRetryCountOnQueueFull());
+    Assert.assertEquals(10, parameterProvider.getMaxRegistrationQueueSize());
   }
 
   @Test
@@ -170,6 +174,12 @@ public class ParameterProviderTest {
     Assert.assertEquals(
         ParameterProvider.MAX_CHUNKS_IN_REGISTRATION_REQUEST_DEFAULT,
         parameterProvider.getMaxChunksInRegistrationRequest());
+    Assert.assertEquals(
+        ParameterProvider.MAX_CHANNEL_WRITE_RETRY_COUNT_ON_QUEUE_FULL_DEFAULT,
+        parameterProvider.getMaxChannelWriteRetryCountOnQueueFull());
+    Assert.assertEquals(
+        ParameterProvider.MAX_REGISTRATION_QUEUE_SIZE_DEFAULT,
+        parameterProvider.getMaxRegistrationQueueSize());
   }
 
   @Test

--- a/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/RegisterServiceTest.java
@@ -66,10 +66,10 @@ public class RegisterServiceTest {
             new FlushService.BlobData<>("test", null),
             CompletableFuture.completedFuture(new BlobMetadata("path", "md5", null, null)));
     rs.addBlobs(Collections.singletonList(blobFuture));
-    Assert.assertEquals(1, rs.getBlobsList().size());
+    Assert.assertEquals(1, rs.getBlobsListSize());
     Assert.assertEquals(false, blobFuture.getValue().get().getSpansMixedTables());
     List<FlushService.BlobData<StubChunkData>> errorBlobs = rs.registerBlobs(null);
-    Assert.assertEquals(0, rs.getBlobsList().size());
+    Assert.assertEquals(0, rs.getBlobsListSize());
     Assert.assertEquals(0, errorBlobs.size());
   }
 
@@ -95,10 +95,10 @@ public class RegisterServiceTest {
     Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blobFuture2 =
         new Pair<>(new FlushService.BlobData<StubChunkData>("fail", new ArrayList<>()), future);
     rs.addBlobs(Arrays.asList(blobFuture1, blobFuture2));
-    Assert.assertEquals(2, rs.getBlobsList().size());
+    Assert.assertEquals(2, rs.getBlobsListSize());
     try {
       List<FlushService.BlobData<StubChunkData>> errorBlobs = rs.registerBlobs(null);
-      Assert.assertEquals(0, rs.getBlobsList().size());
+      Assert.assertEquals(0, rs.getBlobsListSize());
       Assert.assertEquals(1, errorBlobs.size());
       Assert.assertEquals("fail", errorBlobs.get(0).getPath());
     } catch (Exception e) {
@@ -129,10 +129,10 @@ public class RegisterServiceTest {
     Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blobFuture2 =
         new Pair<>(new FlushService.BlobData<StubChunkData>("fail", new ArrayList<>()), future);
     rs.addBlobs(Arrays.asList(blobFuture1, blobFuture2));
-    Assert.assertEquals(2, rs.getBlobsList().size());
+    Assert.assertEquals(2, rs.getBlobsListSize());
     try {
       List<FlushService.BlobData<StubChunkData>> errorBlobs = rs.registerBlobs(null);
-      Assert.assertEquals(0, rs.getBlobsList().size());
+      Assert.assertEquals(0, rs.getBlobsListSize());
       Assert.assertEquals(1, errorBlobs.size());
       Assert.assertEquals("fail", errorBlobs.get(0).getPath());
     } catch (Exception e) {
@@ -149,10 +149,10 @@ public class RegisterServiceTest {
     Pair<FlushService.BlobData<StubChunkData>, CompletableFuture<BlobMetadata>> blobFuture =
         new Pair<>(new FlushService.BlobData<>("fail", new ArrayList<>()), future);
     rs.addBlobs(Collections.singletonList(blobFuture));
-    Assert.assertEquals(1, rs.getBlobsList().size());
+    Assert.assertEquals(1, rs.getBlobsListSize());
     try {
       List<FlushService.BlobData<StubChunkData>> errorBlobs = rs.registerBlobs(null);
-      Assert.assertEquals(0, rs.getBlobsList().size());
+      Assert.assertEquals(0, rs.getBlobsListSize());
       Assert.assertEquals(1, errorBlobs.size());
       Assert.assertEquals("fail", errorBlobs.get(0).getPath());
     } catch (Exception e) {

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientTest.java
@@ -11,7 +11,7 @@ import static net.snowflake.ingest.utils.Constants.DROP_CHANNEL_ENDPOINT;
 import static net.snowflake.ingest.utils.Constants.MAX_STREAMING_INGEST_API_CHANNEL_RETRY;
 import static net.snowflake.ingest.utils.Constants.PRIVATE_KEY;
 import static net.snowflake.ingest.utils.Constants.REGISTER_BLOB_ENDPOINT;
-import static net.snowflake.ingest.utils.Constants.RESPONSE_ERR_ENQUEUE_TABLE_CHUNK_QUEUE_FULL;
+import static net.snowflake.ingest.utils.Constants.RESPONSE_ERR_GENERAL_EXCEPTION_RETRY_REQUEST;
 import static net.snowflake.ingest.utils.Constants.RESPONSE_SUCCESS;
 import static net.snowflake.ingest.utils.Constants.ROLE;
 import static net.snowflake.ingest.utils.Constants.USER;
@@ -661,12 +661,12 @@ public class SnowflakeStreamingIngestClientTest {
 
     List<ChannelRegisterStatus> channelRegisterStatuses = new ArrayList<>();
     ChannelRegisterStatus status1 = new ChannelRegisterStatus();
-    status1.setStatusCode(RESPONSE_ERR_ENQUEUE_TABLE_CHUNK_QUEUE_FULL);
+    status1.setStatusCode(RESPONSE_ERR_GENERAL_EXCEPTION_RETRY_REQUEST);
     status1.setChannelName(channelMetadata1.getChannelName());
     status1.setChannelSequencer(channelMetadata1.getClientSequencer());
 
     ChannelRegisterStatus status2 = new ChannelRegisterStatus();
-    status2.setStatusCode(RESPONSE_ERR_ENQUEUE_TABLE_CHUNK_QUEUE_FULL);
+    status2.setStatusCode(RESPONSE_ERR_GENERAL_EXCEPTION_RETRY_REQUEST);
     status2.setChannelName(channelMetadata2.getChannelName());
     status2.setChannelSequencer(channelMetadata2.getClientSequencer());
 


### PR DESCRIPTION
We have seen the issue in the O11y case when the chunk queue is full, channel write starts return QUEUE_FULL error, and it causes the channel to be invalidated. Channel invalidation results in a new set of channel reopen, which makes the issue even worse. 

With this PR:
- We will keep retrying on QUEUE_FULL up to roughly 5mins instead of just a few seconds before invalidating the channel.
- Add a limit on the registration queue and throttle insertRows once it reaches a certain size
- Both parameters are configurable in case there is any regressions.