### PR TITLE
FLOW-4820 Openflow x SPCS x GCP support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <hadoop.version>3.4.1</hadoop.version>
     <iceberg.version>1.6.1</iceberg.version>
     <jacoco.skip.instrument>true</jacoco.skip.instrument>
-    <jacoco.version>0.8.5</jacoco.version>
+    <jacoco.version>0.8.13</jacoco.version>
     <license.processing.dependencyJarsDir>${project.build.directory}/dependency-jars</license.processing.dependencyJarsDir>
     <license.processing.dependencyListFile>${project.build.directory}/dependency-list.txt</license.processing.dependencyListFile>
     <license.processing.resourcesRoot>${project.build.directory}/generated-licenses-info</license.processing.resourcesRoot>
@@ -78,7 +78,7 @@
     <shadeBase>net.snowflake.ingest.internal</shadeBase>
     <slf4j.version>1.7.36</slf4j.version>
     <snappy.version>1.1.10.5</snappy.version>
-    <snowjdbc.version>3.24.2</snowjdbc.version>
+    <snowjdbc.version>3.25.1</snowjdbc.version>
     <threetenbp.version>1.7.0</threetenbp.version>
     <version.plugin.buildhelper>3.6.1</version.plugin.buildhelper>
     <version.plugin.publishing>0.8.0</version.plugin.publishing>
@@ -1108,6 +1108,8 @@
               <exclude>**/*SnowflakeStreamingIngestExample*</exclude>
               <exclude>**/*SnowflakeIngestBasicExample*</exclude>
               <exclude>**/*IngestExampleHelper*</exclude>
+              <exclude>net/snowflake/client/**</exclude>
+              <exclude>com/snowflake/client/**</exclude>
             </excludes>
           </configuration>
           <executions>
@@ -1860,6 +1862,13 @@
             <version>${jacoco.version}</version>
             <configuration>
               <skip>${jacoco.skip.instrument}</skip>
+              <excludes>
+                <exclude>**/*SnowflakeStreamingIngestExample*</exclude>
+                <exclude>**/*SnowflakeIngestBasicExample*</exclude>
+                <exclude>**/*IngestExampleHelper*</exclude>
+                <exclude>net/snowflake/client/**</exclude>
+                <exclude>com/snowflake/client/**</exclude>
+              </excludes>
             </configuration>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1104,12 +1104,14 @@
           <version>${jacoco.version}</version>
           <configuration>
             <skip>${jacoco.skip.instrument}</skip>
+            <includes>
+              <include>net/snowflake/ingest/**</include>
+              <include>org/apache/**</include>
+            </includes>
             <excludes>
               <exclude>**/*SnowflakeStreamingIngestExample*</exclude>
               <exclude>**/*SnowflakeIngestBasicExample*</exclude>
               <exclude>**/*IngestExampleHelper*</exclude>
-              <exclude>net/snowflake/client/**</exclude>
-              <exclude>com/snowflake/client/**</exclude>
             </excludes>
           </configuration>
           <executions>
@@ -1862,13 +1864,6 @@
             <version>${jacoco.version}</version>
             <configuration>
               <skip>${jacoco.skip.instrument}</skip>
-              <excludes>
-                <exclude>**/*SnowflakeStreamingIngestExample*</exclude>
-                <exclude>**/*SnowflakeIngestBasicExample*</exclude>
-                <exclude>**/*IngestExampleHelper*</exclude>
-                <exclude>net/snowflake/client/**</exclude>
-                <exclude>com/snowflake/client/**</exclude>
-              </excludes>
             </configuration>
             <executions>
               <execution>

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileLocationInfo.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileLocationInfo.java
@@ -55,6 +55,10 @@ public class FileLocationInfo {
   @JsonProperty("volumeHash")
   private String volumeHash;
 
+  /** Whether to use virtual URL for the stage, required for GCS stage in SCPS */
+  @JsonProperty("useVirtualUrl")
+  private boolean useVirtualUrl;
+
   String getLocationType() {
     return locationType;
   }
@@ -141,5 +145,13 @@ public class FileLocationInfo {
 
   void setVolumeHash(String volumeHash) {
     this.volumeHash = volumeHash;
+  }
+
+  boolean getUseVirtualUrl() {
+    return this.useVirtualUrl;
+  }
+
+  void setUseVirtualUrl(boolean useVirtualUrl) {
+    this.useVirtualUrl = useVirtualUrl;
   }
 }


### PR DESCRIPTION
### TL;DR

Upgraded Snowflake JDBC driver to version 3.25.1 and added GCS virtual URL support for SCPS.

### What changed?

- Updated the Snowflake JDBC driver version from 3.24.2 to 3.25.1 in pom.xml
- Added a new `useVirtualUrl` boolean field to pass to JDBC file transfer agent.
- Updated Jacoco to make it compatible with JDBC driver.
- Only include project code for coverage analysis.