### PR TITLE
NO-SNOW Fix v4.2.0 unshaded pom.xml

### DIFF
--- a/unshaded_deploy.sh
+++ b/unshaded_deploy.sh
@@ -93,7 +93,7 @@ mvn test ${MVN_OPTIONS[@]} -Dnot-shadeDep
 
 echo "[Info] Deploy to Central Publisher Portal"
 project_version=$($THIS_DIR/scripts/get_project_info_from_pom.py $THIS_DIR/pom.xml version)
-$THIS_DIR/scripts/update_project_version.py public_pom.xml $project_version > generated_public_pom.xml
+$THIS_DIR/scripts/update_project_version.py pom.xml $project_version > generated_public_pom.xml
 
 # Allow disabling auto-publish via environment variable
 AUTO_PUBLISH=${AUTO_PUBLISH:-true}

--- a/unshaded_snapshot_deploy.sh
+++ b/unshaded_snapshot_deploy.sh
@@ -52,7 +52,7 @@ MVN_OPTIONS+=(
 
 echo "[INFO] Deploy to snapshot repository"
 project_version=$($THIS_DIR/scripts/get_project_info_from_pom.py $THIS_DIR/pom.xml version)
-$THIS_DIR/scripts/update_project_version.py public_pom.xml $project_version-unshaded > generated_public_pom.xml
+$THIS_DIR/scripts/update_project_version.py pom.xml $project_version > generated_public_pom.xml
 
 # Allow disabling auto-publish via environment variable
 AUTO_PUBLISH=${AUTO_PUBLISH:-true}


### PR DESCRIPTION
### TL;DR

Updated deployment scripts to use the main pom.xml instead of public_pom.xml for version updates.

### What changed?

Modified both `unshaded_deploy.sh` and `unshaded_snapshot_deploy.sh` to use the main `pom.xml` file as input for the `update_project_version.py` script instead of `public_pom.xml`. Also removed the `-unshaded` suffix from the version in the snapshot deployment script.