### PR TITLE
SNOW-2302576 Honor the encryption option set on the external volume

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileLocationInfo.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileLocationInfo.java
@@ -65,7 +65,8 @@ public class FileLocationInfo {
   @JsonProperty("encryptionKmsKeyId")
   private String encryptionKmsKeyId;
 
-  String getLocationType() {
+  @VisibleForTesting
+  public String getLocationType() {
     return locationType;
   }
 
@@ -161,7 +162,8 @@ public class FileLocationInfo {
     this.useVirtualUrl = useVirtualUrl;
   }
 
-  String getVolumeEncryptionMode() {
+  @VisibleForTesting
+  public String getVolumeEncryptionMode() {
     return this.volumeEncryptionMode;
   }
 
@@ -169,7 +171,8 @@ public class FileLocationInfo {
     this.volumeEncryptionMode = volumeEncryptionMode;
   }
 
-  String getEncryptionKmsKeyId() {
+  @VisibleForTesting
+  public String getEncryptionKmsKeyId() {
     return this.encryptionKmsKeyId;
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileLocationInfo.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileLocationInfo.java
@@ -60,7 +60,7 @@ public class FileLocationInfo {
   private boolean useVirtualUrl;
 
   @JsonProperty("volumeEncryptionMode")
-  private String volumeEncryptionMode;
+  private VolumeEncryptionMode volumeEncryptionMode;
 
   @JsonProperty("encryptionKmsKeyId")
   private String encryptionKmsKeyId;
@@ -163,11 +163,11 @@ public class FileLocationInfo {
   }
 
   @VisibleForTesting
-  public String getVolumeEncryptionMode() {
+  public VolumeEncryptionMode getVolumeEncryptionMode() {
     return this.volumeEncryptionMode;
   }
 
-  void setVolumeEncryptionMode(String volumeEncryptionMode) {
+  void setVolumeEncryptionMode(VolumeEncryptionMode volumeEncryptionMode) {
     this.volumeEncryptionMode = volumeEncryptionMode;
   }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/FileLocationInfo.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FileLocationInfo.java
@@ -59,6 +59,12 @@ public class FileLocationInfo {
   @JsonProperty("useVirtualUrl")
   private boolean useVirtualUrl;
 
+  @JsonProperty("volumeEncryptionMode")
+  private String volumeEncryptionMode;
+
+  @JsonProperty("encryptionKmsKeyId")
+  private String encryptionKmsKeyId;
+
   String getLocationType() {
     return locationType;
   }
@@ -153,5 +159,21 @@ public class FileLocationInfo {
 
   void setUseVirtualUrl(boolean useVirtualUrl) {
     this.useVirtualUrl = useVirtualUrl;
+  }
+
+  String getVolumeEncryptionMode() {
+    return this.volumeEncryptionMode;
+  }
+
+  void setVolumeEncryptionMode(String volumeEncryptionMode) {
+    this.volumeEncryptionMode = volumeEncryptionMode;
+  }
+
+  String getEncryptionKmsKeyId() {
+    return this.encryptionKmsKeyId;
+  }
+
+  void setEncryptionKmsKeyId(String encryptionKmsKeyId) {
+    this.encryptionKmsKeyId = encryptionKmsKeyId;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/InternalStage.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/InternalStage.java
@@ -190,7 +190,7 @@ public class InternalStage implements IStorage {
         InputStream inStream = new ByteArrayInputStream(data);
 
         if (this.useIcebergFileTransferAgent) {
-          String volumeEncryptionMode =
+          VolumeEncryptionMode volumeEncryptionMode =
               this.fileLocationInfo != null
                   ? this.fileLocationInfo.getVolumeEncryptionMode()
                   : null;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/InternalStageManager.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/InternalStageManager.java
@@ -92,6 +92,7 @@ class InternalStageManager implements IStorageManager {
                 NO_TABLE_REF,
                 false /* useIcebergFileTransferAgent */,
                 (SnowflakeFileTransferMetadataWithAge) null,
+                null /* fileLocationInfo */,
                 DEFAULT_MAX_UPLOAD_RETRIES);
       }
     } catch (IngestResponseException | IOException e) {

--- a/src/main/java/net/snowflake/ingest/streaming/internal/VolumeEncryptionMode.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/VolumeEncryptionMode.java
@@ -1,0 +1,91 @@
+package net.snowflake.ingest.streaming.internal;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enum representing the different volume encryption modes supported by Snowflake. These modes
+ * determine how data is encrypted when stored in cloud storage.
+ */
+public enum VolumeEncryptionMode {
+  /** AWS S3 server-side encryption with S3-managed keys */
+  AWS_SSE_S3("AWS_SSE_S3"),
+
+  /** AWS S3 server-side encryption with AWS KMS-managed keys */
+  AWS_SSE_KMS("AWS_SSE_KMS"),
+
+  /** Google Cloud Storage server-side encryption with GCS KMS-managed keys */
+  GCS_SSE_KMS("GCS_SSE_KMS"),
+
+  /** No encryption (typically used for Azure as Snowflake doesn't support KMS encryption there) */
+  NONE("NONE");
+
+  private final String value;
+
+  VolumeEncryptionMode(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Gets the string value of the encryption mode. This is used for JSON serialization and external
+   * APIs.
+   *
+   * @return the string representation of the encryption mode
+   */
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Creates a VolumeEncryptionMode from a string value. Returns null for null input to maintain
+   * backward compatibility. This method is used by Jackson for JSON deserialization.
+   *
+   * @param value the string value
+   * @return the corresponding VolumeEncryptionMode, or null if input is null
+   * @throws IllegalArgumentException if the value is not recognized
+   */
+  @JsonCreator
+  public static VolumeEncryptionMode fromString(String value) {
+    if (value == null) {
+      return null;
+    }
+
+    for (VolumeEncryptionMode mode : values()) {
+      if (mode.value.equals(value)) {
+        return mode;
+      }
+    }
+
+    throw new IllegalArgumentException("Unknown volume encryption mode: " + value);
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+
+  /**
+   * Checks if this encryption mode requires a KMS key ID.
+   *
+   * @return true if this mode requires a KMS key ID, false otherwise
+   */
+  public boolean requiresKmsKeyId() {
+    return this == AWS_SSE_KMS || this == GCS_SSE_KMS;
+  }
+
+  /**
+   * Validates that the given KMS key ID is compatible with this encryption mode.
+   *
+   * @param encryptionKmsKeyId the KMS key ID to validate
+   * @throws IllegalArgumentException if the key ID is invalid for this mode
+   */
+  public void validateKmsKeyId(String encryptionKmsKeyId) {
+    if (requiresKmsKeyId()) {
+      if (encryptionKmsKeyId == null || encryptionKmsKeyId.trim().isEmpty()) {
+        throw new IllegalArgumentException(
+            "Encryption KMS key ID is required for volume encryption mode: " + this);
+      }
+    }
+  }
+}

--- a/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergFileTransferAgent.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergFileTransferAgent.java
@@ -59,7 +59,7 @@ public class IcebergFileTransferAgent {
   }
 
   /**
-   * Static API function to upload data without JDBC session.
+   * Static API function to upload data without JDBC session with encryption support.
    *
    * <p>NOTE: This function is developed based on getUploadFileCallable().
    *
@@ -71,7 +71,9 @@ public class IcebergFileTransferAgent {
       Properties proxyProperties,
       String streamingIngestClientName,
       String streamingIngestClientKey,
-      String fullFilePath)
+      String fullFilePath,
+      String volumeEncryptionMode,
+      String encryptionKmsKeyId)
       throws Exception {
     OCSPMode ocspMode = OCSPMode.FAIL_OPEN;
     int networkTimeoutInMilli = 0;
@@ -114,7 +116,9 @@ public class IcebergFileTransferAgent {
           destFileName,
           uploadSize);
 
-      IcebergStorageClient initialClient = storageFactory.createClient(stageInfo, 1);
+      IcebergStorageClient initialClient =
+          storageFactory.createClient(
+              stageInfo, 1 /* parallel */, volumeEncryptionMode, encryptionKmsKeyId);
 
       switch (stageInfo.getStageType()) {
         case S3:

--- a/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergFileTransferAgent.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergFileTransferAgent.java
@@ -18,6 +18,7 @@ import net.snowflake.client.jdbc.SnowflakeFileTransferMetadataV1;
 import net.snowflake.client.jdbc.SnowflakeUtil;
 import net.snowflake.client.jdbc.cloud.storage.StageInfo;
 import net.snowflake.client.jdbc.cloud.storage.StorageObjectMetadata;
+import net.snowflake.ingest.streaming.internal.VolumeEncryptionMode;
 import net.snowflake.ingest.utils.Logging;
 import org.apache.commons.io.IOUtils;
 
@@ -72,7 +73,7 @@ public class IcebergFileTransferAgent {
       String streamingIngestClientName,
       String streamingIngestClientKey,
       String fullFilePath,
-      String volumeEncryptionMode,
+      VolumeEncryptionMode volumeEncryptionMode,
       String encryptionKmsKeyId)
       throws Exception {
     OCSPMode ocspMode = OCSPMode.FAIL_OPEN;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergGCSClient.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergGCSClient.java
@@ -284,7 +284,9 @@ class IcebergGCSClient implements IcebergStorageClient {
             .setMetadata(metadata)
             .build();
 
-    this.volumeEncryptionMode.validateKmsKeyId(this.encryptionKmsKeyId);
+    if (this.volumeEncryptionMode != null) {
+      this.volumeEncryptionMode.validateKmsKeyId(this.encryptionKmsKeyId);
+    }
     try {
       // Use KMS encryption if specified, otherwise use default GCS encryption
       return VolumeEncryptionMode.GCS_SSE_KMS.equals(this.volumeEncryptionMode)

--- a/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergS3Client.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergS3Client.java
@@ -296,7 +296,9 @@ class IcebergS3Client implements IcebergStorageClient {
                 : new PutObjectRequest(remoteStorageLocation, destFileName, srcFile);
         putRequest.setMetadata(s3Meta);
 
-        this.volumeEncryptionMode.validateKmsKeyId(this.encryptionKmsKeyId);
+        if (this.volumeEncryptionMode != null) {
+          this.volumeEncryptionMode.validateKmsKeyId(this.encryptionKmsKeyId);
+        }
         if (VolumeEncryptionMode.AWS_SSE_KMS.equals(this.volumeEncryptionMode)) {
           putRequest.setSSEAwsKeyManagementParams(
               new SSEAwsKeyManagementParams(this.encryptionKmsKeyId));

--- a/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergS3Client.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergS3Client.java
@@ -67,8 +67,8 @@ class IcebergS3Client implements IcebergStorageClient {
   private static final String EXPIRED_AWS_TOKEN_ERROR_CODE = "ExpiredToken";
 
   // SSE algorithms, should match the values in the server side encryption mode
-  private static final String SSE_KMS = "SSE_KMS";
-  private static final String SSE_S3 = "SSE_S3";
+  private static final String AWS_SSE_KMS = "AWS_SSE_KMS";
+  private static final String AWS_SSE_S3 = "AWS_SSE_S3";
 
   private boolean isUseS3RegionalUrl = false;
   private ClientConfiguration clientConfig = null;
@@ -299,7 +299,7 @@ class IcebergS3Client implements IcebergStorageClient {
                 : new PutObjectRequest(remoteStorageLocation, destFileName, srcFile);
         putRequest.setMetadata(s3Meta);
 
-        if (SSE_KMS.equals(this.volumeEncryptionMode)) {
+        if (AWS_SSE_KMS.equals(this.volumeEncryptionMode)) {
           putRequest.setSSEAwsKeyManagementParams(
               new SSEAwsKeyManagementParams(this.encryptionKmsKeyId));
         }
@@ -412,19 +412,19 @@ class IcebergS3Client implements IcebergStorageClient {
     try {
       if (!isClientSideEncrypted) {
         // since we're not client-side encrypting, make sure we're server-side encrypting
-        if (this.volumeEncryptionMode == null || this.volumeEncryptionMode.equals(SSE_S3)) {
+        if (this.volumeEncryptionMode == null || this.volumeEncryptionMode.equals(AWS_SSE_S3)) {
           // Default to SSE-S3 encryption
           meta.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
-        } else if (this.volumeEncryptionMode.equals(SSE_KMS)) {
+        } else if (this.volumeEncryptionMode.equals(AWS_SSE_KMS)) {
           meta.setSSEAlgorithm(SSEAlgorithm.KMS.getAlgorithm());
         } else {
           throw new IllegalArgumentException(
               "Unexpected volume encryption mode: "
                   + this.volumeEncryptionMode
                   + ". Expected "
-                  + SSE_S3
+                  + AWS_SSE_S3
                   + " or "
-                  + SSE_KMS);
+                  + AWS_SSE_KMS);
         }
       }
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergStorageClientFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergStorageClientFactory.java
@@ -60,7 +60,8 @@ class IcebergStorageClientFactory {
             stage.getProxyProperties(),
             stage.getRegion(),
             stage.getEndPoint(),
-            stage.getIsClientSideEncrypted(),
+            stage.getIsClientSideEncrypted(), // Ignored - client-side encryption not supported for
+            // Iceberg
             useS3RegionalUrl,
             volumeEncryptionMode,
             encryptionKmsKeyId);
@@ -87,7 +88,8 @@ class IcebergStorageClientFactory {
    * @param parallel degree of parallelism
    * @param stageRegion the region where the stage is located
    * @param stageEndPoint the FIPS endpoint for the stage, if needed
-   * @param isClientSideEncrypted whether client-side encryption should be used
+   * @param isClientSideEncrypted whether client-side encryption should be used (not supported for
+   *     Iceberg tables)
    * @param useS3RegionalUrl
    * @param volumeEncryptionMode the volume encryption mode (e.g., "SSE_KMS", "SSE_S3")
    * @param encryptionKmsKeyId the KMS key ID for encryption when using SSE_KMS
@@ -137,7 +139,7 @@ class IcebergStorageClientFactory {
               proxyProperties,
               stageRegion,
               stageEndPoint,
-              isClientSideEncrypted,
+              isClientSideEncrypted, // Ignored - client-side encryption not supported for Iceberg
               useS3RegionalUrl,
               volumeEncryptionMode,
               encryptionKmsKeyId);

--- a/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergStorageClientFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergStorageClientFactory.java
@@ -7,6 +7,7 @@ import net.snowflake.client.core.HttpUtil;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
 import net.snowflake.client.jdbc.cloud.storage.StageInfo;
 import net.snowflake.client.jdbc.cloud.storage.StorageObjectMetadata;
+import net.snowflake.ingest.streaming.internal.VolumeEncryptionMode;
 import net.snowflake.ingest.utils.Logging;
 
 /**
@@ -47,7 +48,10 @@ class IcebergStorageClientFactory {
    * @throws SnowflakeSQLException if any error occurs
    */
   public IcebergStorageClient createClient(
-      StageInfo stage, int parallel, String volumeEncryptionMode, String encryptionKmsKeyId)
+      StageInfo stage,
+      int parallel,
+      VolumeEncryptionMode volumeEncryptionMode,
+      String encryptionKmsKeyId)
       throws SnowflakeSQLException {
     logger.logDebug("Creating storage client. Client type: {}", stage.getStageType().name());
 
@@ -104,7 +108,7 @@ class IcebergStorageClientFactory {
       String stageEndPoint,
       boolean isClientSideEncrypted,
       boolean useS3RegionalUrl,
-      String volumeEncryptionMode,
+      VolumeEncryptionMode volumeEncryptionMode,
       String encryptionKmsKeyId)
       throws SnowflakeSQLException {
     final int S3_TRANSFER_MAX_RETRIES = 3;
@@ -202,12 +206,12 @@ class IcebergStorageClientFactory {
    * Creates a IcebergGCSClient object which encapsulates the GCS Storage client
    *
    * @param stage Stage information
-   * @param volumeEncryptionMode the volume encryption mode (e.g., "GCS_SSE_KMS")
-   * @param encryptionKmsKeyId the KMS key ID for encryption when using GCS_SSE_KMS
+   * @param volumeEncryptionMode the volume encryption mode
+   * @param encryptionKmsKeyId the KMS key ID for encryption when using KMS modes
    * @return the IcebergGCSClient instance created
    */
   private IcebergStorageClient createGCSClient(
-      StageInfo stage, String volumeEncryptionMode, String encryptionKmsKeyId)
+      StageInfo stage, VolumeEncryptionMode volumeEncryptionMode, String encryptionKmsKeyId)
       throws SnowflakeSQLException {
     IcebergGCSClient gcsClient;
 

--- a/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergStorageClientFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergStorageClientFactory.java
@@ -69,7 +69,7 @@ class IcebergStorageClientFactory {
         return createAzureClient(stage);
 
       case GCS:
-        return createGCSClient(stage);
+        return createGCSClient(stage, volumeEncryptionMode, encryptionKmsKeyId);
 
       default:
         // We don't create a storage client for FS_LOCAL,
@@ -200,13 +200,19 @@ class IcebergStorageClientFactory {
    * Creates a IcebergGCSClient object which encapsulates the GCS Storage client
    *
    * @param stage Stage information
+   * @param volumeEncryptionMode the volume encryption mode (e.g., "GCS_SSE_KMS")
+   * @param encryptionKmsKeyId the KMS key ID for encryption when using GCS_SSE_KMS
    * @return the IcebergGCSClient instance created
    */
-  private IcebergStorageClient createGCSClient(StageInfo stage) throws SnowflakeSQLException {
+  private IcebergStorageClient createGCSClient(
+      StageInfo stage, String volumeEncryptionMode, String encryptionKmsKeyId)
+      throws SnowflakeSQLException {
     IcebergGCSClient gcsClient;
 
     try {
-      gcsClient = IcebergGCSClient.createSnowflakeGCSClient(stage);
+      gcsClient =
+          IcebergGCSClient.createSnowflakeGCSClient(
+              stage, volumeEncryptionMode, encryptionKmsKeyId);
     } catch (Exception ex) {
       logger.logDebug("Exception creating GCS Storage client", ex);
       throw ex;

--- a/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergStorageClientFactory.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/fileTransferAgent/IcebergStorageClientFactory.java
@@ -37,14 +37,17 @@ class IcebergStorageClientFactory {
   }
 
   /**
-   * Creates a storage client based on the value of stageLocationType
+   * Creates a storage client based on the value of stageLocationType with encryption parameters
    *
    * @param stage the stage properties
    * @param parallel the degree of parallelism to be used by the client
+   * @param volumeEncryptionMode the volume encryption mode (e.g., "SSE_KMS", "SSE_S3")
+   * @param encryptionKmsKeyId the KMS key ID for encryption when using SSE_KMS
    * @return a IcebergStorageClient interface to the instance created
    * @throws SnowflakeSQLException if any error occurs
    */
-  public IcebergStorageClient createClient(StageInfo stage, int parallel)
+  public IcebergStorageClient createClient(
+      StageInfo stage, int parallel, String volumeEncryptionMode, String encryptionKmsKeyId)
       throws SnowflakeSQLException {
     logger.logDebug("Creating storage client. Client type: {}", stage.getStageType().name());
 
@@ -58,7 +61,9 @@ class IcebergStorageClientFactory {
             stage.getRegion(),
             stage.getEndPoint(),
             stage.getIsClientSideEncrypted(),
-            useS3RegionalUrl);
+            useS3RegionalUrl,
+            volumeEncryptionMode,
+            encryptionKmsKeyId);
 
       case AZURE:
         return createAzureClient(stage);
@@ -84,6 +89,8 @@ class IcebergStorageClientFactory {
    * @param stageEndPoint the FIPS endpoint for the stage, if needed
    * @param isClientSideEncrypted whether client-side encryption should be used
    * @param useS3RegionalUrl
+   * @param volumeEncryptionMode the volume encryption mode (e.g., "SSE_KMS", "SSE_S3")
+   * @param encryptionKmsKeyId the KMS key ID for encryption when using SSE_KMS
    * @return the IcebergS3Client instance created
    * @throws SnowflakeSQLException failure to create the S3 client
    */
@@ -94,7 +101,9 @@ class IcebergStorageClientFactory {
       String stageRegion,
       String stageEndPoint,
       boolean isClientSideEncrypted,
-      boolean useS3RegionalUrl)
+      boolean useS3RegionalUrl,
+      String volumeEncryptionMode,
+      String encryptionKmsKeyId)
       throws SnowflakeSQLException {
     final int S3_TRANSFER_MAX_RETRIES = 3;
 
@@ -129,7 +138,9 @@ class IcebergStorageClientFactory {
               stageRegion,
               stageEndPoint,
               isClientSideEncrypted,
-              useS3RegionalUrl);
+              useS3RegionalUrl,
+              volumeEncryptionMode,
+              encryptionKmsKeyId);
     } catch (Exception ex) {
       logger.logDebug("Exception creating s3 client", ex);
       throw ex;

--- a/src/test/java/net/snowflake/ingest/streaming/internal/InternalStageTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/InternalStageTest.java
@@ -145,7 +145,8 @@ public class InternalStageTest {
             false /* useIcebergFileTransferAgent */,
             new SnowflakeFileTransferMetadataWithAge(
                 originalMetadata, Optional.of(System.currentTimeMillis()), "test/path"),
-            1);
+            null /* fileLocationInfo */,
+            1 /* maxUploadRetries */);
     PowerMockito.mockStatic(SnowflakeFileTransferAgent.class);
 
     final ArgumentCaptor<SnowflakeFileTransferConfig> captor =
@@ -192,7 +193,8 @@ public class InternalStageTest {
                 false /* useIcebergFileTransferAgent */,
                 new SnowflakeFileTransferMetadataWithAge(
                     fullFilePath, Optional.of(System.currentTimeMillis()), "test/path"),
-                1));
+                null /* fileLocationInfo */,
+                1 /* maxUploadRetries */));
     Mockito.doReturn(true).when(stage).isLocalFS();
 
     stage.put(
@@ -225,6 +227,7 @@ public class InternalStageTest {
             false /* useIcebergFileTransferAgent */,
             new SnowflakeFileTransferMetadataWithAge(
                 originalMetadata, Optional.of(System.currentTimeMillis()), "test/path"),
+            null /* fileLocationInfo */,
             maxUploadRetryCount);
     PowerMockito.mockStatic(SnowflakeFileTransferAgent.class);
     SnowflakeSQLException e =
@@ -287,7 +290,8 @@ public class InternalStageTest {
                 false /* useIcebergFileTransferAgent */,
                 new SnowflakeFileTransferMetadataWithAge(
                     originalMetadata, Optional.of(System.currentTimeMillis()), "test/path"),
-                1));
+                null /* fileLocationInfo */,
+                1 /* maxUploadRetries */));
     PowerMockito.mockStatic(SnowflakeFileTransferAgent.class);
     SnowflakeFileTransferMetadataV1 metaMock = Mockito.mock(SnowflakeFileTransferMetadataV1.class);
 
@@ -327,7 +331,8 @@ public class InternalStageTest {
             InternalStageManager.NO_TABLE_REF,
             false /* useIcebergFileTransferAgent */,
             (SnowflakeFileTransferMetadataWithAge) null,
-            1);
+            null /* fileLocationInfo */,
+            1 /* maxUploadRetries */);
 
     SnowflakeFileTransferMetadataWithAge metadataWithAge = stage.refreshSnowflakeMetadata(true);
 
@@ -425,7 +430,8 @@ public class InternalStageTest {
             InternalStageManager.NO_TABLE_REF,
             false /* useIcebergFileTransferAgent */,
             (SnowflakeFileTransferMetadataWithAge) null,
-            1);
+            null /* fileLocationInfo */,
+            1 /* maxUploadRetries */);
 
     SnowflakeFileTransferMetadataV1 metadata = stage.fetchSignedURL("path/fileName");
 
@@ -473,7 +479,8 @@ public class InternalStageTest {
             InternalStageManager.NO_TABLE_REF,
             false /* useIcebergFileTransferAgent */,
             (SnowflakeFileTransferMetadataWithAge) null,
-            1);
+            null /* fileLocationInfo */,
+            1 /* maxUploadRetries */);
 
     ThreadFactory buildUploadThreadFactory =
         new BasicThreadFactory.Builder().namingPattern("ingest-build-upload-thread-%d").build();
@@ -606,6 +613,7 @@ public class InternalStageTest {
             false /* useIcebergFileTransferAgent */,
             new SnowflakeFileTransferMetadataWithAge(
                 originalMetadata, Optional.of(System.currentTimeMillis()), "test/path"),
+            null /* fileLocationInfo */,
             maxUploadRetryCount);
     PowerMockito.mockStatic(SnowflakeFileTransferAgent.class);
     SnowflakeSQLException e =

--- a/src/test/java/net/snowflake/ingest/streaming/internal/VolumeEncryptionModeTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/VolumeEncryptionModeTest.java
@@ -1,0 +1,90 @@
+package net.snowflake.ingest.streaming.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+/** Unit tests for VolumeEncryptionMode validation */
+public class VolumeEncryptionModeTest {
+
+  @Test
+  public void testRequiresKmsKeyId() {
+    // KMS modes require key ID
+    assertThat(VolumeEncryptionMode.AWS_SSE_KMS.requiresKmsKeyId()).isTrue();
+    assertThat(VolumeEncryptionMode.GCS_SSE_KMS.requiresKmsKeyId()).isTrue();
+
+    // Non-KMS modes don't require key ID
+    assertThat(VolumeEncryptionMode.AWS_SSE_S3.requiresKmsKeyId()).isFalse();
+    assertThat(VolumeEncryptionMode.NONE.requiresKmsKeyId()).isFalse();
+  }
+
+  @Test
+  public void testValidateKmsKeyId_Success() {
+    // Valid key ID for KMS modes
+    VolumeEncryptionMode.AWS_SSE_KMS.validateKmsKeyId("valid-key-id");
+    VolumeEncryptionMode.GCS_SSE_KMS.validateKmsKeyId("valid-key-id");
+
+    // Non-KMS modes should accept null/empty key ID
+    VolumeEncryptionMode.AWS_SSE_S3.validateKmsKeyId(null);
+    VolumeEncryptionMode.AWS_SSE_S3.validateKmsKeyId("");
+    VolumeEncryptionMode.NONE.validateKmsKeyId(null);
+    VolumeEncryptionMode.NONE.validateKmsKeyId("");
+  }
+
+  @Test
+  public void testValidateKmsKeyId_FailsForKmsModeWithNullKey() {
+    assertThatThrownBy(() -> VolumeEncryptionMode.AWS_SSE_KMS.validateKmsKeyId(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Encryption KMS key ID is required for volume encryption mode: AWS_SSE_KMS");
+
+    assertThatThrownBy(() -> VolumeEncryptionMode.GCS_SSE_KMS.validateKmsKeyId(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Encryption KMS key ID is required for volume encryption mode: GCS_SSE_KMS");
+  }
+
+  @Test
+  public void testValidateKmsKeyId_FailsForKmsModeWithEmptyKey() {
+    assertThatThrownBy(() -> VolumeEncryptionMode.AWS_SSE_KMS.validateKmsKeyId(""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Encryption KMS key ID is required for volume encryption mode: AWS_SSE_KMS");
+
+    assertThatThrownBy(() -> VolumeEncryptionMode.AWS_SSE_KMS.validateKmsKeyId("   "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Encryption KMS key ID is required for volume encryption mode: AWS_SSE_KMS");
+  }
+
+  @Test
+  public void testFileLocationInfoValidation_KmsModeWithValidKey() {
+    FileLocationInfo info = new FileLocationInfo();
+
+    // Should work in any order now
+    info.setVolumeEncryptionMode(VolumeEncryptionMode.AWS_SSE_KMS);
+    info.setEncryptionKmsKeyId("valid-key");
+
+    assertThat(info.getVolumeEncryptionMode()).isEqualTo(VolumeEncryptionMode.AWS_SSE_KMS);
+    assertThat(info.getEncryptionKmsKeyId()).isEqualTo("valid-key");
+  }
+
+  @Test
+  public void testFileLocationInfoValidation_NoOrderingDependency() {
+    FileLocationInfo info1 = new FileLocationInfo();
+    FileLocationInfo info2 = new FileLocationInfo();
+
+    // Order 1: Set mode first, then key
+    info1.setVolumeEncryptionMode(VolumeEncryptionMode.AWS_SSE_KMS);
+    info1.setEncryptionKmsKeyId("valid-key");
+
+    // Order 2: Set key first, then mode
+    info2.setEncryptionKmsKeyId("valid-key");
+    info2.setVolumeEncryptionMode(VolumeEncryptionMode.AWS_SSE_KMS);
+
+    // Both should work and be equivalent
+    assertThat(info1.getVolumeEncryptionMode()).isEqualTo(info2.getVolumeEncryptionMode());
+    assertThat(info1.getEncryptionKmsKeyId()).isEqualTo(info2.getEncryptionKmsKeyId());
+  }
+}

--- a/src/test/java/net/snowflake/ingest/streaming/internal/it/IcebergKmsEncryptionIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/it/IcebergKmsEncryptionIT.java
@@ -22,6 +22,7 @@ import net.snowflake.ingest.streaming.internal.FileLocationInfo;
 import net.snowflake.ingest.streaming.internal.IStorageManager;
 import net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientInternal;
 import net.snowflake.ingest.streaming.internal.TableRef;
+import net.snowflake.ingest.streaming.internal.VolumeEncryptionMode;
 import net.snowflake.ingest.utils.Constants;
 import org.junit.After;
 import org.junit.Before;
@@ -134,18 +135,18 @@ public class IcebergKmsEncryptionIT {
     FileLocationInfo fileLocationInfo =
         storageManager.getRefreshedLocation(tableRef, Optional.empty());
 
-    String expectedVolumeEncryptionMode = null;
+    VolumeEncryptionMode expectedVolumeEncryptionMode = null;
     if (isKmsEncryption) {
       switch (fileLocationInfo.getLocationType()) {
         case "S3":
-          expectedVolumeEncryptionMode = "AWS_SSE_KMS";
+          expectedVolumeEncryptionMode = VolumeEncryptionMode.AWS_SSE_KMS;
           break;
         case "GCS":
-          expectedVolumeEncryptionMode = "GCS_SSE_KMS";
+          expectedVolumeEncryptionMode = VolumeEncryptionMode.GCS_SSE_KMS;
           break;
         case "AZURE":
           expectedVolumeEncryptionMode =
-              "NONE"; // Snoflake doesn't support kms encryption for Azure
+              VolumeEncryptionMode.NONE; // Snowflake doesn't support kms encryption for Azure
           break;
         default:
           throw new IllegalArgumentException(

--- a/src/test/java/net/snowflake/ingest/streaming/internal/it/IcebergKmsEncryptionIT.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/it/IcebergKmsEncryptionIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2025 Snowflake Computing Inc. All rights reserved.
+ */
+
+package net.snowflake.ingest.streaming.internal.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import net.snowflake.ingest.IcebergIT;
+import net.snowflake.ingest.TestUtils;
+import net.snowflake.ingest.streaming.OpenChannelRequest;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import net.snowflake.ingest.streaming.internal.FileLocationInfo;
+import net.snowflake.ingest.streaming.internal.IStorageManager;
+import net.snowflake.ingest.streaming.internal.SnowflakeStreamingIngestClientInternal;
+import net.snowflake.ingest.streaming.internal.TableRef;
+import net.snowflake.ingest.utils.Constants;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration test for KMS encryption with Iceberg streaming ingest.
+ *
+ * <p>This test validates: 1. Data can be ingested successfully with KMS encryption 2. Data is
+ * correctly committed to Snowflake 3. Files are encrypted with KMS on S3 (when KMS key is
+ * configured)
+ */
+@Category(IcebergIT.class)
+public class IcebergKmsEncryptionIT {
+  private static final Logger logger = LoggerFactory.getLogger(IcebergKmsEncryptionIT.class);
+
+  private String database;
+  private String schema;
+  private Connection conn;
+  private SnowflakeStreamingIngestClient client;
+
+  @Before
+  public void before() throws Exception {
+    database = String.format("SDK_ICEBERG_KMS_ENCRYPTION_IT_DB_%d", System.nanoTime());
+    schema = "PUBLIC";
+    conn = TestUtils.getConnection(true);
+    client =
+        TestUtils.setUp(
+            conn, database, schema, true, "ZSTD", Constants.IcebergSerializationPolicy.COMPATIBLE);
+  }
+
+  @After
+  public void after() throws Exception {
+    if (client != null) {
+      client.close();
+    }
+    if (conn != null) {
+      conn.createStatement().execute(String.format("drop database if exists %s;", database));
+      conn.close();
+    }
+  }
+
+  @Test
+  public void testKmsEncryptionDataIngestion() throws Exception {
+    String tableName = "test_kms_encryption_table";
+
+    // Create Iceberg table with external volume
+    String createTableSql =
+        String.format(
+            "create or replace iceberg table %s(id int) "
+                + "catalog = 'SNOWFLAKE' "
+                + "external_volume = 'streaming_ingest_kms' "
+                + "base_location = 'SDK_IT/%s/%s';",
+            tableName, database, tableName);
+
+    conn.createStatement().execute(createTableSql);
+    conn.createStatement()
+        .execute(
+            String.format(
+                "alter iceberg table %s set ENABLE_FIX_2302576_ICEBERG_VOLUME_KMS_ENCRYPTION ="
+                    + " false",
+                tableName));
+    verifyS3Encryption(tableName, false);
+
+    OpenChannelRequest request =
+        OpenChannelRequest.builder("test_kms_channel")
+            .setDBName(database)
+            .setSchemaName(schema)
+            .setTableName(tableName)
+            .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
+            .build();
+
+    SnowflakeStreamingIngestChannel channel = client.openChannel(request);
+
+    List<Map<String, Object>> rows = new ArrayList<>();
+    for (int i = 1; i <= 10; i++) {
+      Map<String, Object> row = ImmutableMap.of("id", i);
+      rows.add(row);
+    }
+
+    TestUtils.verifyInsertValidationResponse(channel.insertRows(rows, "offset_kms"));
+    TestUtils.waitForOffset(channel, "offset_kms");
+
+    String selectSql = String.format("select * from %s order by id", tableName);
+
+    ResultSet rs = conn.createStatement().executeQuery(selectSql);
+
+    for (int i = 1; i <= 10; i++) {
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getInt(1)).isEqualTo(i);
+    }
+    assertThat(rs.next()).isFalse();
+
+    logger.info("Verifying S3 encryption");
+
+    conn.createStatement()
+        .execute(
+            String.format(
+                "alter iceberg table %s set ENABLE_FIX_2302576_ICEBERG_VOLUME_KMS_ENCRYPTION ="
+                    + " false",
+                tableName));
+    verifyS3Encryption(tableName, false);
+
+    channel.close();
+  }
+
+  private void verifyS3Encryption(String tableName, boolean isKmsEncryption) {
+    SnowflakeStreamingIngestClientInternal<?> internalClient =
+        (SnowflakeStreamingIngestClientInternal<?>) client;
+    IStorageManager storageManager = internalClient.getStorageManager();
+
+    TableRef tableRef = new TableRef(database, schema, tableName);
+    FileLocationInfo fileLocationInfo =
+        storageManager.getRefreshedLocation(tableRef, Optional.empty());
+
+    String expectedVolumeEncryptionMode = null;
+    if (isKmsEncryption) {
+      switch (fileLocationInfo.getLocationType()) {
+        case "S3":
+          expectedVolumeEncryptionMode = "AWS_SSE_KMS";
+          break;
+        case "GCS":
+          expectedVolumeEncryptionMode = "GCS_SSE_KMS";
+          break;
+        case "AZURE":
+          expectedVolumeEncryptionMode =
+              "NONE"; // Snoflake doesn't support kms encryption for Azure
+          break;
+        default:
+          throw new IllegalArgumentException(
+              "Unexpected location type: " + fileLocationInfo.getLocationType());
+      }
+      assertThat(fileLocationInfo.getEncryptionKmsKeyId()).isNotNull();
+    } else {
+      assertThat(fileLocationInfo.getEncryptionKmsKeyId()).isNull();
+    }
+
+    assertThat(fileLocationInfo.getVolumeEncryptionMode()).isEqualTo(expectedVolumeEncryptionMode);
+  }
+}


### PR DESCRIPTION
### Content
Support server side KMS encryption when uploading the file to external volume on AWS and GCP.

### Background
An encryption option can be specified on an external volume on top of a storage bucket. However, SSV1 Iceberg ingestion does not honor the option value because AES_256_SERVER_SIDE_ENCRYPTION (SSE_S3) is hardcoded in the SDK code. 