### PR TITLE
[NO-SNOW] Exclude vulnerable transitive deps from snowflake-jdbc-thin

### DIFF
--- a/e2e-jar-test/pom.xml
+++ b/e2e-jar-test/pom.xml
@@ -53,6 +53,24 @@
         <groupId>net.snowflake</groupId>
         <artifactId>snowflake-jdbc-thin</artifactId>
         <version>3.25.1</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>net.snowflake.snowflake-ingest-java-e2e-jar-test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2024-2025 Snowflake Computing Inc. All rights reserved.
+  ~ Copyright (c) 2024-2026 Snowflake Computing Inc. All rights reserved.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -186,12 +186,20 @@
             <artifactId>grpc-context</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
           </exclusion>
           <exclusion>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.jsoup</groupId>
@@ -1025,6 +1033,12 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Summary
Exclude vulnerable transitive dependencies pulled in by `snowflake-jdbc-thin` (test scope) and add `hamcrest-core` as an explicit test dependency.

### Security fixes
Exclude from `snowflake-jdbc-thin` in both main `pom.xml` and `e2e-jar-test/pom.xml`:

| Dependency | Issue | Severity |
|---|---|---|
| `io.grpc:grpc-netty-shaded` | CVE-2025-55163 (Resource allocation without limits) | CVSS 8.7 High |
| `org.apache.commons:commons-lang3` | CVE-2025-48924 (Uncontrolled recursion) | CVSS 8.8 High |
| `javax.servlet:javax.servlet-api` | Dual license CDDL-1.1/GPL-2.0 | High |
| `javax.annotation:javax.annotation-api` | Dual license CDDL-1.1/GPL-2.0 | High |

The ingest SDK already declares safe versions of `grpc` (1.77.0) and `commons-lang3` (3.18.0) directly. `javax.servlet-api` and `javax.annotation-api` were already excluded in the main pom but not in the e2e-jar-test pom.

### Test dependency
- Add `org.hamcrest:hamcrest-core:1.3` as explicit test dependency (used by ported JDBC tests in #1147)

## Test plan
- [x] `mvn compiler:compile` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)