### PR TITLE
[NO-SNOW] Route Maven deploy scripts through Artifactory mirror

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -31,35 +31,14 @@ cat > $CENTRAL_DEPLOY_SETTINGS_XML << SETTINGS.XML
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <profiles>
-    <profile>
-      <id>internal-maven</id>
-      <repositories>
-        <repository>
-          <id>central</id>
-          <n>Internal Maven Repository</n>
-          <url>https://artifactory.int.snowflakecomputing.com/artifactory/development-maven-virtual</url>
-        </repository>
-        <repository>
-          <id>deployment</id>
-          <n>Internal Releases</n>
-          <url>https://nexus.int.snowflakecomputing.com/repository/Releases/</url>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>central</id>
-          <n>Internal Maven Repository</n>
-          <url>https://artifactory.int.snowflakecomputing.com/artifactory/development-maven-virtual</url>
-        </pluginRepository>
-        <pluginRepository>
-          <id>deployment</id>
-          <n>Internal Releases</n>
-          <url>https://nexus.int.snowflakecomputing.com/repository/Releases/</url>
-        </pluginRepository>
-      </pluginRepositories>
-    </profile>
-  </profiles>
+  <mirrors>
+    <mirror>
+      <id>snowflake-artifactory</id>
+      <name>Snowflake Internal Artifactory</name>
+      <url>https://artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/artifactory/development-maven-virtual</url>
+      <mirrorOf>*,!ossrh,!snapshot</mirrorOf>
+    </mirror>
+  </mirrors>
   <servers>
     <server>
       <id>$MVN_REPOSITORY_ID</id>
@@ -67,9 +46,6 @@ cat > $CENTRAL_DEPLOY_SETTINGS_XML << SETTINGS.XML
       <password>$SONATYPE_PWD</password>
     </server>
   </servers>
-  <activeProfiles>
-    <activeProfile>internal-maven</activeProfile>
-  </activeProfiles>
 </settings>
 SETTINGS.XML
 

--- a/snapshot_deploy.sh
+++ b/snapshot_deploy.sh
@@ -35,6 +35,14 @@ cat > $CENTRAL_DEPLOY_SETTINGS_XML << SETTINGS.XML
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>snowflake-artifactory</id>
+      <name>Snowflake Internal Artifactory</name>
+      <url>https://artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/artifactory/development-maven-virtual</url>
+      <mirrorOf>*,!ossrh,!snapshot</mirrorOf>
+    </mirror>
+  </mirrors>
   <servers>
     <server>
       <id>$MVN_REPOSITORY_ID</id>

--- a/unshaded_deploy.sh
+++ b/unshaded_deploy.sh
@@ -35,35 +35,14 @@ cat > $CENTRAL_DEPLOY_SETTINGS_XML << SETTINGS.XML
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <profiles>
-    <profile>
-      <id>internal-maven</id>
-      <repositories>
-        <repository>
-          <id>central</id>
-          <n>Internal Maven Repository</n>
-          <url>https://artifactory.int.snowflakecomputing.com/artifactory/development-maven-virtual</url>
-        </repository>
-        <repository>
-          <id>deployment</id>
-          <n>Internal Releases</n>
-          <url>https://nexus.int.snowflakecomputing.com/repository/Releases/</url>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>central</id>
-          <n>Internal Maven Repository</n>
-          <url>https://artifactory.int.snowflakecomputing.com/artifactory/development-maven-virtual</url>
-        </pluginRepository>
-        <pluginRepository>
-          <id>deployment</id>
-          <n>Internal Releases</n>
-          <url>https://nexus.int.snowflakecomputing.com/repository/Releases/</url>
-        </pluginRepository>
-      </pluginRepositories>
-    </profile>
-  </profiles>
+  <mirrors>
+    <mirror>
+      <id>snowflake-artifactory</id>
+      <name>Snowflake Internal Artifactory</name>
+      <url>https://artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/artifactory/development-maven-virtual</url>
+      <mirrorOf>*,!ossrh,!snapshot</mirrorOf>
+    </mirror>
+  </mirrors>
   <servers>
     <server>
       <id>$MVN_REPOSITORY_ID</id>
@@ -71,9 +50,6 @@ cat > $CENTRAL_DEPLOY_SETTINGS_XML << SETTINGS.XML
       <password>$SONATYPE_PWD</password>
     </server>
   </servers>
-  <activeProfiles>
-    <activeProfile>internal-maven</activeProfile>
-  </activeProfiles>
 </settings>
 SETTINGS.XML
 

--- a/unshaded_snapshot_deploy.sh
+++ b/unshaded_snapshot_deploy.sh
@@ -35,6 +35,14 @@ cat > $CENTRAL_DEPLOY_SETTINGS_XML << SETTINGS.XML
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>snowflake-artifactory</id>
+      <name>Snowflake Internal Artifactory</name>
+      <url>https://artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/artifactory/development-maven-virtual</url>
+      <mirrorOf>*,!ossrh,!snapshot</mirrorOf>
+    </mirror>
+  </mirrors>
   <servers>
     <server>
       <id>$MVN_REPOSITORY_ID</id>


### PR DESCRIPTION
## Summary
- Replace `<repository id="central">` override with a `<mirror mirrorOf="*,!ossrh,!snapshot">` block in the settings.xml generated by `deploy.sh`, `snapshot_deploy.sh`, `unshaded_deploy.sh`, and `unshaded_snapshot_deploy.sh`.
- Point the mirror at `https://artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/artifactory/development-maven-virtual` (Snowflake's internal Artifactory, globally-trusted cert per [onboarding wiki](https://snowflakecomputing.atlassian.net/wiki/spaces/EN/pages/4325410552/Artifactory+How+To+Onboard+to+Artifactory+3rd+party+artifacts)).
- Drops a pre-existing `<n>` typo (should have been `<name>`) that was producing `[WARNING] Unrecognised tag: 'n'` at build time.

## Why

Releasing 4.4.3-unshaded failed with:

```
Failed to read artifact descriptor for com.google.cloud.opentelemetry:exporter-metrics:jar:0.31.0:
Could not transfer artifact com.google.cloud:first-party-dependencies:pom:3.18.0 from/to central
(https://repo.maven.apache.org/maven2), status: 429
```

The existing `<repository id="central">` redefinition only catches repos declared in the effective POM. Maven resolves **transitive parent-POM** lookups (like `first-party-dependencies:3.18.0`, a parent of `exporter-metrics`) using the parent's declared repositories, bypassing the override and hitting public Maven Central directly — where we got rate-limited.

A `<mirror>` intercepts at the HTTP transport layer, so every outbound request (including transitive parent/BOM resolution) is rewritten to Artifactory. `ossrh` and `snapshot` are excluded from `mirrorOf` defensively — they're `<server>` ids (credentials for `central-publishing-maven-plugin`), not repository ids, so mirrors wouldn't match them anyway, but the exclusion makes publishing-intent explicit.

## Test plan
- [x] Verified fix on `alhuang-release-4.4.3-unshaded`: release pipeline re-ran successfully; `first-party-dependencies:3.18.0` now resolves via Artifactory, no `repo.maven.apache.org` URLs in logs.
- [ ] Reviewer: sanity-check generated settings.xml from each script by manually running `bash deploy.sh` / `bash snapshot_deploy.sh` / `bash unshaded_deploy.sh` / `bash unshaded_snapshot_deploy.sh` through the heredoc step (or inspect the script source). The `<mirror>` block should contain the Artifactory URL and `mirrorOf=*,!ossrh,!snapshot`.
- [ ] Verify `central-publishing-maven-plugin` upload path unaffected (it uploads via its own configured URL using server-id auth, not via a mapped repository id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)