### PR TITLE
Release 2.1.0-parquet1171: Upgrade Parquet to 1.17.1

### DIFF
--- a/e2e-jar-test/pom.xml
+++ b/e2e-jar-test/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>net.snowflake</groupId>
                 <artifactId>snowflake-ingest-sdk</artifactId>
-                <version>2.1.0</version>
+                <version>2.1.0-parquet1171</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <!-- Arifact name and version information -->
   <groupId>net.snowflake</groupId>
   <artifactId>snowflake-ingest-sdk</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.0-parquet1171</version>
   <packaging>jar</packaging>
   <name>Snowflake Ingest SDK</name>
   <description>Snowflake Ingest SDK</description>
@@ -53,18 +53,18 @@
     <license.processing.dependencyListFile>${project.build.directory}/dependency-list.txt</license.processing.dependencyListFile>
     <license.processing.resourcesRoot>${project.build.directory}/generated-licenses-info</license.processing.resourcesRoot>
     <license.processing.targetDir>${license.processing.resourcesRoot}/META-INF/third-party-licenses</license.processing.targetDir>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <net.minidev.version>2.4.9</net.minidev.version>
     <netty.version>4.1.94.Final</netty.version>
     <nimbusds.version>9.31</nimbusds.version>
     <objenesis.version>3.1</objenesis.version>
-    <parquet.version>1.13.1</parquet.version>
+    <parquet.version>1.17.1</parquet.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <protobuf.version>3.19.6</protobuf.version>
     <shadeBase>net.snowflake.ingest.internal</shadeBase>
     <slf4j.version>1.7.36</slf4j.version>
-    <snappy.version>1.1.10.4</snappy.version>
+    <snappy.version>1.1.10.7</snappy.version>
     <snowjdbc.version>3.14.5</snowjdbc.version>
     <yetus.version>0.13.0</yetus.version>
   </properties>
@@ -474,7 +474,7 @@
     <dependency>
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>
-      <version>1.5.0-1</version>
+      <version>1.5.7-3</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -675,11 +675,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
+        <version>3.13.0</version>
         <inherited>true</inherited>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -110,7 +110,7 @@ public class RequestBuilder {
   // Don't change!
   public static final String CLIENT_NAME = "SnowpipeJavaSDK";
 
-  public static final String DEFAULT_VERSION = "2.1.0";
+  public static final String DEFAULT_VERSION = "2.1.0-parquet1171";
 
   public static final String JAVA_USER_AGENT = "JAVA";
 


### PR DESCRIPTION
## Summary

- Upgrade `parquet.version` 1.13.1 → 1.17.1
- Java compiler source/target 8 → 11 (Parquet 1.17 requires Java 11)
- `maven-compiler-plugin` 2.5.1 → 3.13.0
- `snappy-java` 1.1.10.4 → 1.1.10.7 (RequireUpperBoundDeps)
- `zstd-jni` 1.5.0-1 → 1.5.7-3
- Version bumped to `2.1.0-parquet1171`

## Motivation

GS consumes `snowflake-ingest-sdk:2.1.0-unshaded` which was compiled against Parquet 1.13.1. At Parquet 1.14.0, `InternalParquetRecordWriter`'s constructor signature changed (`BytesCompressor` → `BytesInputCompressor`), causing a `NoSuchMethodError` at runtime under 1.17.1. Rebuilding the SDK against 1.17.1 fixes this. No source changes needed.

## Test plan

- [ ] Build unshaded jar: `mvn clean install -Dnot-shadeDep -DskipTests -Dlicense.skipAddThirdParty=true`
- [ ] Verify constructor descriptor flipped to `BytesInputCompressor` via `javap`
- [ ] Run GS integration tests against new artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)