### PR TITLE
Upgrade v2.1.0 Parquet to 1.17.1 + associated dependencies

### DIFF
--- a/e2e-jar-test/pom.xml
+++ b/e2e-jar-test/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>net.snowflake</groupId>
                 <artifactId>snowflake-ingest-sdk</artifactId>
-                <version>2.1.0</version>
+                <version>2.1.0-parquet1171</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -777,6 +777,13 @@
           <excludes>
             <exclude>**/TestSimpleIngestLocal.java</exclude>
           </excludes>
+          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED
+            --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+            --add-opens java.base/java.util=ALL-UNNAMED
+            --add-opens java.base/java.io=ALL-UNNAMED
+            --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens java.base/java.nio.file=ALL-UNNAMED
+            --add-opens java.base/sun.nio.fs=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <!-- Arifact name and version information -->
   <groupId>net.snowflake</groupId>
   <artifactId>snowflake-ingest-sdk</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.0-parquet1171</version>
   <packaging>jar</packaging>
   <name>Snowflake Ingest SDK</name>
   <description>Snowflake Ingest SDK</description>
@@ -53,18 +53,18 @@
     <license.processing.dependencyListFile>${project.build.directory}/dependency-list.txt</license.processing.dependencyListFile>
     <license.processing.resourcesRoot>${project.build.directory}/generated-licenses-info</license.processing.resourcesRoot>
     <license.processing.targetDir>${license.processing.resourcesRoot}/META-INF/third-party-licenses</license.processing.targetDir>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <net.minidev.version>2.4.9</net.minidev.version>
     <netty.version>4.1.94.Final</netty.version>
     <nimbusds.version>9.31</nimbusds.version>
     <objenesis.version>3.1</objenesis.version>
-    <parquet.version>1.13.1</parquet.version>
+    <parquet.version>1.17.1</parquet.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <protobuf.version>3.19.6</protobuf.version>
     <shadeBase>net.snowflake.ingest.internal</shadeBase>
     <slf4j.version>1.7.36</slf4j.version>
-    <snappy.version>1.1.10.4</snappy.version>
+    <snappy.version>1.1.10.7</snappy.version>
     <snowjdbc.version>3.14.5</snowjdbc.version>
     <yetus.version>0.13.0</yetus.version>
   </properties>
@@ -474,7 +474,7 @@
     <dependency>
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>
-      <version>1.5.0-1</version>
+      <version>1.5.7-3</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -675,11 +675,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
+        <version>3.13.0</version>
         <inherited>true</inherited>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
       <plugin>

--- a/scripts/process_licenses.py
+++ b/scripts/process_licenses.py
@@ -61,6 +61,7 @@ ADDITIONAL_LICENSES_MAP = {
     "org.bouncycastle:bcpkix-jdk18on": BOUNCY_CASTLE_LICENSE,
     "org.bouncycastle:bcutil-jdk18on": BOUNCY_CASTLE_LICENSE,
     "org.bouncycastle:bcprov-jdk18on": BOUNCY_CASTLE_LICENSE,
+    "org.locationtech.jts:jts-core": EDL_10_LICENSE,
 }
 
 

--- a/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
+++ b/src/main/java/net/snowflake/ingest/connection/RequestBuilder.java
@@ -110,7 +110,7 @@ public class RequestBuilder {
   // Don't change!
   public static final String CLIENT_NAME = "SnowpipeJavaSDK";
 
-  public static final String DEFAULT_VERSION = "2.1.0";
+  public static final String DEFAULT_VERSION = "2.1.0-parquet1171";
 
   public static final String JAVA_USER_AGENT = "JAVA";
 


### PR DESCRIPTION
## Changes

- **Parquet**: 1.13.1 → 1.17.1 — direct deps on `parquet-column`, `parquet-common`, `parquet-hadoop`
- **Java**: source/target 1.8 → 11 (required by Parquet 1.17)
- **maven-compiler-plugin**: 2.5.1 → 3.13.0
- **snappy-java**: 1.1.10.4 → 1.1.10.7 (RequireUpperBoundDeps)
- **zstd-jni**: 1.5.0-1 → 1.5.7-3
- **Surefire**: added `--add-opens` JVM args for Java 11 module system compatibility in tests
- **process_licenses.py**: added `org.locationtech.jts:jts-core` (EDL 1.0) to license map
- **Version**: 2.1.0 → 2.1.0-parquet1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)